### PR TITLE
Quality of life: filter item interactions when pressing a particular key

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Characters/Character.cs
@@ -503,9 +503,8 @@ namespace Barotrauma
         /// </summary>
         /// <param name="character">The Character who is looking for the interactable item, only items that are close enough to this character are returned</param>
         /// <param name="simPosition">The item at the simPosition, with the lowest depth, is returned</param>
-        /// <param name="allowFindingNearestItem">If this is true and an item cannot be found at simPosition then a nearest item will be returned if possible</param>
-        /// <param name="hull">If a hull is specified, only items within that hull are returned</param>
-        public Item FindItemAtPosition(Vector2 simPosition, float aimAssistModifier = 0.0f, Item[] ignoredItems = null)
+        /// <param name="aimAssistModifier">Multiplier for the distance around the given point where items will be searched. Only applies when no item is selected yet</param>
+        public Item FindItemAtPosition(Vector2 simPosition, float aimAssistModifier = 0.0f, Func<Item, bool> filter = null)
         {
             if (Submarine != null)
             {
@@ -538,7 +537,9 @@ namespace Barotrauma
                 }
                 if (item.body != null && !item.body.Enabled) { continue; }
                 if (item.ParentInventory != null) { continue; }
-                if (ignoredItems != null && ignoredItems.Contains(item)) { continue; }
+                // At this point at least, it is very sane to avoid calculating everything for ALL items on the map
+                if ((item.WorldPosition - displayPosition).LengthSquared() > 1600.0f) { continue; }
+                if (filter != null && !filter(item)) { continue; }
                 if (item.Prefab.RequireCampaignInteract && item.CampaignInteractionType == CampaignMode.InteractionType.None) { continue; }
                 if (Screen.Selected is SubEditorScreen editor && editor.WiringMode && item.GetComponent<ConnectionPanel>() == null) { continue; }
 

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
@@ -2650,7 +2650,24 @@ namespace Barotrauma
                             aimAssist = 0.0f;
                         }
 
-                        var item = FindItemAtPosition(mouseSimPos, aimAssist);
+                        Func<Item, bool> filter = null;
+                        if(PlayerInput.KeyDown(InputType.FilterItemFocus))
+                        {
+                            bool FilterPickables(Item item)
+                            {
+                                if (item.GetComponent<Pickable>() is { } pickable)
+                                {
+                                    if(!pickable.IsAttached)
+                                    {
+                                        return item.AllowedSlots.Any(x => (x & InvSlotType.Any) != 0);
+                                    }
+                                }
+                                return false;
+                            }
+                            filter = FilterPickables;
+                        }
+
+                        var item = FindItemAtPosition(mouseSimPos, aimAssist, filter);
                         
                         focusedItem = CanInteract ? item : null;
                         if (focusedItem != null && focusedItem.CampaignInteractionType != CampaignMode.InteractionType.None)

--- a/Barotrauma/BarotraumaShared/SharedSource/InputType.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/InputType.cs
@@ -23,6 +23,7 @@ namespace Barotrauma
         PreviousFireMode,
         ActiveChat,
         ToggleChatMode,
-        ChatBox
+        ChatBox,
+        FilterItemFocus
     }
 }

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Door.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Door.cs
@@ -23,7 +23,9 @@ namespace Barotrauma.Items.Components
         private readonly Sprite doorSprite, weldedSprite, brokenSprite;
         private readonly bool scaleBrokenSprite, fadeBrokenSprite;
         private readonly bool autoOrientGap;
-        
+
+        public override bool IsAttached => true;
+
         private bool isJammed;
         public bool IsJammed
         {

--- a/Barotrauma/BarotraumaShared/SharedSource/Settings/GameSettings.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Settings/GameSettings.cs
@@ -307,7 +307,8 @@ namespace Barotrauma
                         { InputType.Use, Keys.E },
                         { InputType.Select, MouseButton.PrimaryMouse },
                         { InputType.Deselect, MouseButton.SecondaryMouse },
-                        { InputType.Shoot, MouseButton.PrimaryMouse }
+                        { InputType.Shoot, MouseButton.PrimaryMouse },
+                        { InputType.FilterItemFocus, Keys.LeftAlt },
                 }.ToImmutableDictionary();
 
                 public static KeyMapping GetDefault() => new KeyMapping


### PR DESCRIPTION
I created a simple quality-of-life improvement. I am not sure if this is the best way to do it, but I'd at least like to suggest something along these lines. I was originally intending to also allow switching what filter is applied during the mouse wheel, but I decided it might not be needed. I am keeping that door open though, by leaving the filter as a lambda instead of just passing a bool argument to `FindItemAtPosition`.

Other than the implementation itself, I have also overridden the `IsAttached` getter for doors. I am not sure why they implement `Pickable`, but decided it is safe to assume they are attached since they cannot be ever dropped as an item on the ground.

I did change the `FindItemAtPosition` signature as the original filtering by array was unused - the function has only one refference. I also added a performance change to it - if the item is way outside the search range, ignore it straight away.

This needs to be added to translations:

```
<inputtype.filteritemfocus>Select pickable items only</inputtype.filteritemfocus>
```