### PR TITLE
Add a simple disallowcargo tag for cargo containers.

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Map/Submarine.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Map/Submarine.cs
@@ -1239,6 +1239,7 @@ namespace Barotrauma
             {
                 if (!connectedSubs.Contains(item.Submarine)) { continue; }
                 if (!item.HasTag("cargocontainer")) { continue; }
+                if (item.HasTag("disallowcargo")) { continue; }
                 if (item.NonInteractable || item.HiddenInGame) { continue; }
                 var itemContainer = item.GetComponent<ItemContainer>();
                 if (itemContainer == null) { continue; }


### PR DESCRIPTION
Simple addition. Any item container tagged as a "cargocontainer" (such as the crate shelf or unit load device) may also be tagged with "disallowcargo" to exclude it from consideration for cargo missions.

I have seen several sub editors asking if this is possible, usually because they have a dedicated cargo hold on their ship and want shelves for manual player storage elsewhere.

Tested in the campaign and seems to function as expected, mission assignment and payout on completion all reflects the lower cargo capacity.

Only downside (in my opinion) is the discoverability of this addition is bad, but if the modding guides and wiki can be updated that should be okay.