### PR TITLE
Add an ItemContainer property to draw items based on slot position.

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/ItemContainer.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/ItemContainer.cs
@@ -307,8 +307,6 @@ namespace Barotrauma.Items.Components
                 transformedItemPos += item.body.DrawPosition;
             }
 
-            Vector2 currentItemPos = transformedItemPos;
-
             SpriteEffects spriteEffects = SpriteEffects.None;
             if ((item.body != null && item.body.Dir == -1) || item.FlippedX) 
             { 
@@ -321,10 +319,12 @@ namespace Barotrauma.Items.Components
 
             bool isWiringMode = SubEditorScreen.TransparentWiringMode && SubEditorScreen.IsWiringMode();
 
-            int i = 0;
-            foreach (Item containedItem in Inventory.AllItems)
+            int total = 0;
+            for (int i = 0; i < Inventory.Capacity; i++)
             {
-                if (containedItem?.Sprite == null) { continue; }
+                Item containedItem = Inventory.GetItemAt(i);
+                if (containedItem is null) { continue; }
+                if (containedItem.Sprite == null) { continue; }
 
                 if (AutoInteractWithContained)
                 {
@@ -343,6 +343,20 @@ namespace Barotrauma.Items.Components
                 }
                 containedSpriteDepth = itemDepth + (containedSpriteDepth - (item.Sprite?.Depth ?? item.SpriteDepth)) / 10000.0f;
 
+                Vector2 currentItemPos = transformedItemPos;
+                int targetPosition = ItemsUseInventoryPlacement ? i : total;
+                if (Math.Abs(ItemInterval.X) > 0.001f && Math.Abs(ItemInterval.Y) > 0.001f)
+                {
+                    //interval set on both axes -> use a grid layout
+                    currentItemPos += transformedItemIntervalHorizontal * (targetPosition % ItemsPerRow);
+                    currentItemPos += transformedItemIntervalVertical * (targetPosition / ItemsPerRow);
+                }
+                else
+                {
+                    currentItemPos += transformedItemInterval * targetPosition;
+                }
+                total++;
+
                 containedItem.Sprite.Draw(
                     spriteBatch,
                     new Vector2(currentItemPos.X, -currentItemPos.Y),
@@ -357,22 +371,6 @@ namespace Barotrauma.Items.Components
                 {
                     if (ic.hideItems) continue;
                     ic.DrawContainedItems(spriteBatch, containedSpriteDepth);
-                }
-
-                i++;
-                if (Math.Abs(ItemInterval.X) > 0.001f && Math.Abs(ItemInterval.Y) > 0.001f)
-                {
-                    //interval set on both axes -> use a grid layout
-                    currentItemPos += transformedItemIntervalHorizontal;
-                    if (i % ItemsPerRow == 0)
-                    {
-                        currentItemPos = transformedItemPos;
-                        currentItemPos += transformedItemIntervalVertical * (i / ItemsPerRow);
-                    }
-                }
-                else
-                {
-                    currentItemPos += transformedItemInterval;
                 }
             }
         }

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/ItemContainer.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/ItemContainer.cs
@@ -99,6 +99,9 @@ namespace Barotrauma.Items.Components
         [Serialize(100, IsPropertySaveable.No, description: "How many items are placed in a row before starting a new row.")]
         public int ItemsPerRow { get; set; }
 
+        [Serialize(false, IsPropertySaveable.No, description: "Should items be drawn based on their position within the inventory?")]
+        public bool ItemsUseInventoryPlacement { get; set; }
+
         [Serialize(true, IsPropertySaveable.No, description: "Should the inventory of this item be visible when the item is selected.")]
         public bool DrawInventory
         {


### PR DESCRIPTION
Just a satisfying aesthetic change. Maybe some interesting applications for mods, but that's not really the point.

Crate shelf with `ItemsUseInventoryPlacement="true"` tag added in XML, so slot position is visibly reflected on the shelf.
![image](https://user-images.githubusercontent.com/734762/198490182-f4bee644-c3ac-47f9-aa47-4b613b586701.png)

Unit load device without tag, showing unchanged stacking behavior.
![image](https://user-images.githubusercontent.com/734762/198489334-d276e585-6e3e-4ba0-a5d5-16a26f98a09c.png)
