### PR TITLE
GreaterComponent support for multiple signals within a timeframe

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/GreaterComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/GreaterComponent.cs
@@ -5,7 +5,8 @@ namespace Barotrauma.Items.Components
 {
     class GreaterComponent : EqualsComponent
     {
-        private float val1, val2;
+        private float val1 = float.NegativeInfinity;
+        private float val2 = float.PositiveInfinity;
 
         public GreaterComponent(Item item, ContentXElement element)
             : base(item, element)
@@ -25,6 +26,8 @@ namespace Barotrauma.Items.Components
             if (sendOutput)
             {
                 string signalOut = val1 > val2 ? output : falseOutput;
+                val1 = float.NegativeInfinity;
+                val2 = float.PositiveInfinity;
                 if (string.IsNullOrEmpty(signalOut)) return;
 
                 item.SendSignal(signalOut, "signal_out");
@@ -33,15 +36,18 @@ namespace Barotrauma.Items.Components
 
         public override void ReceiveSignal(Signal signal, Connection connection)
         {           
-            //base.ReceiveSignal(signal, connection);
             switch (connection.Name)
             {
                 case "signal_in1":
-                    float.TryParse(signal.value, NumberStyles.Float, CultureInfo.InvariantCulture, out val1);
+                    float signal1 = float.NegativeInfinity;
+                    float.TryParse(signal.value, NumberStyles.Float, CultureInfo.InvariantCulture, out signal1);
+                    val1 = signal1 > val1 ? signal1 : val1;
                     timeSinceReceived[0] = 0.0f;
                     break;
                 case "signal_in2":
-                    float.TryParse(signal.value, NumberStyles.Float, CultureInfo.InvariantCulture, out val2);
+                    float signal2 = float.PositiveInfinity;
+                    float.TryParse(signal.value, NumberStyles.Float, CultureInfo.InvariantCulture, out signal2);
+                    val2 = signal2 < val2 ? signal2 : val2;
                     timeSinceReceived[1] = 0.0f;
                     break;
                 case "set_output":


### PR DESCRIPTION
This change would allow us to make simple circuits that compare multiple signals to see if any of them is greater or less than one or many signals.

It is a 100% backwards compatible way of allowing players to use Min(a,b) and Max(a,b) when comparing values.

The description could be modified to better reflect this change, although this is not necessary since the change does not alter existing behavior.
_Original description:_
> Sends a signal if the value the signal_in1 input is larger than the signal_in2 input.

_New description_
> Sends a signal if signal_in1 receives a value that is larger than values sent to signal_in2 within the timeframe.


**Example**
the circuit which compares conditions to show if any of the devices need servicing.
**Before**, using makeshift min(a,b):
![image](https://user-images.githubusercontent.com/68995233/220315937-e9d32db3-9d7d-4a9e-a628-556edc2b04d0.png)


**After:**
![image](https://user-images.githubusercontent.com/68995233/220314595-c1f55d24-5f2a-4fd2-8edd-739373dab426.png)
