### PR TITLE
Improve textbox control navigation

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/GUI/GUITextBox.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GUI/GUITextBox.cs
@@ -410,7 +410,7 @@ namespace Barotrauma
             }
 
             bool isMouseOn = MouseRect.Contains(PlayerInput.MousePosition) && (GUI.MouseOn == null || (!(GUI.MouseOn is GUIButton) && GUI.IsMouseOn(this)));
-            if (isMouseOn || isSelecting)
+            if (isMouseOn || isSelecting || (State == ComponentState.Selected && PlayerInput.IsShiftDown()))
             {
                 State = ComponentState.Hover;
                 if (PlayerInput.PrimaryMouseButtonDown())
@@ -868,7 +868,7 @@ namespace Barotrauma
                     }
                     else
                     {
-                        CaretIndex = Text.LastIndexOf('\n', CaretIndex - 1) + 1;
+                        CaretIndex = Text.LastIndexOf('\n', Math.Max(0, CaretIndex - 1)) + 1;
                     }
 
                     caretTimer = 0;


### PR DESCRIPTION
Improving navigations withing all textbox controls.

Specifically:

- <kbd>Ctrl</kbd> + <kbd>Left</kbd> moves caret to beginning of current **word**
- <kbd>Ctrl</kbd> + <kbd>Right</kbd> moves caret to beginning of next **word**
- <kbd>Ctrl</kbd> + <kbd>Delete</kbd> removes characters starting from carret position to start of next **word**
- <kbd>Ctrl</kbd> + <kbd>Backspace</kbd>  removes characters starting from carret position to start of current **word**
- <kbd>Home</kbd> moves caret to start of current line
- <kbd>Ctrl</kbd> + <kbd>Home</kbd> moves caret to start of whole text
- <kbd>Ctrl</kbd> + <kbd>End</kbd> moves caret to the end of whole text
- <kbd>End</kbd> moves carent to end of current line
- Holding <kbd>Shift</kbd> enables selecting mode so selection can be made by keystrokes <kbd>Shift</kbd>+<kbd>Left/Right</kbd> and even by <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>Left/Right</kbd> according to rules defined above

**word** is defined as sequence of characters that is surrounded from both sides by one of following
- punctuation characters (`char.IsPunctuation()`)
- whitespace
- newline character(`\n`)
- start of string
- end of string