### PR TITLE
support multiple subs for ending the round

### DIFF
--- a/Barotrauma/BarotraumaServer/ServerSource/Networking/GameServer.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Networking/GameServer.cs
@@ -415,16 +415,38 @@ namespace Barotrauma.Networking
                             !c.Character.IsDead && !c.Character.IsUnconscious &&
                             c.Character.Submarine != Level.Loaded.EndOutpost);
 
-                        //level finished if the sub is docked to the outpost
+                        //level finished if any player sub is docked to the outpost
                         //or very close and someone from the crew made it inside the outpost
-                        subAtLevelEnd =
-                            Submarine.MainSub.DockedTo.Contains(Level.Loaded.EndOutpost) ||
-                            (Submarine.MainSub.AtEndExit && charactersInsideOutpost > 0) ||
-                            (charactersInsideOutpost > charactersOutsideOutpost);
+                        if (charactersInsideOutpost > charactersOutsideOutpost)
+                        {
+                            subAtLevelEnd = true;
+                        }
+                        else
+                        {
+                            //all subs are checked you can have a drone/escape pod/etc dock to the outpost and end the round
+                            foreach (var sub in Submarine.Loaded)
+                            {
+                                if (sub.TeamID != Submarine.MainSub.TeamID)
+                                    continue;
+                                subAtLevelEnd =
+                                    sub.DockedTo.Contains(Level.Loaded.EndOutpost) ||
+                                    sub.AtEndExit && charactersInsideOutpost > 0);
+                                if (subAtLevelEnd)
+                                    break;
+                            }
+                        }
                     }
                     else
                     {
-                        subAtLevelEnd = Submarine.MainSub.AtEndExit;
+                        //check all player subs like above
+                        foreach (var sub in Submarine.Loaded)
+                        {
+                            if (sub.TeamID == Submarine.MainSub.TeamID && sub.AtEndExit)
+                            {
+                                subAtLevelEnd = true;
+                                break;
+                            }
+                        }
                     }
                 }
 


### PR DESCRIPTION
Currently if you play with multiple subs (I am working on a mod that does this) you can only use the main sub to dock to the outpost.
This PR lets you use any player-team sub to end the round, meaning:
- You can use drones or escape pods as a last ditch effort to save the round facing certain death in the sub
- If your "sub" is actually multiple subs glued together, any of those sub parts can dock to it (basis of my mod)

PvP is unaffected and I believe pirates use a different team id, so pirates spawning at natural formation end zone shouldn't do anything to the round.