### PR TITLE
Better Semi-auto weapons, without changing existing key stuff.

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/PlayerInput.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/PlayerInput.cs
@@ -104,6 +104,32 @@ namespace Barotrauma
             return false;
         }
 
+        public bool IsPressed()
+        {
+            switch (MouseButton)
+            {
+                case MouseButton.None:
+                    if (Key == Keys.None) { return false; }
+                    return PlayerInput.KeyHit(Key);
+                case MouseButton.PrimaryMouse:
+                    return PlayerInput.PrimaryMouseButtonDown();
+                case MouseButton.SecondaryMouse:
+                    return PlayerInput.SecondaryMouseButtonDown();
+                case MouseButton.MiddleMouse:
+                    return PlayerInput.MidButtonClicked();
+                case MouseButton.MouseButton4:
+                    return PlayerInput.Mouse4ButtonClicked();
+                case MouseButton.MouseButton5:
+                    return PlayerInput.Mouse5ButtonClicked();
+                case MouseButton.MouseWheelUp:
+                    return PlayerInput.MouseWheelUpClicked();
+                case MouseButton.MouseWheelDown:
+                    return PlayerInput.MouseWheelDownClicked();
+            }
+
+            return false;
+        }
+
         public override bool Equals(object obj)
         {
             if (obj is KeyOrMouse keyOrMouse)

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
@@ -1569,6 +1569,48 @@ namespace Barotrauma
             return keys[(int)inputType].Hit;
         }
 
+        public bool IsKeyPressed(InputType inputType)
+        {
+#if SERVER
+            if (GameMain.Server != null && IsRemotePlayer)
+            {
+                switch (inputType)
+                {
+                    case InputType.Left:
+                        return dequeuedInput.HasFlag(InputNetFlags.Left) && !prevDequeuedInput.HasFlag(InputNetFlags.Left);
+                    case InputType.Right:
+                        return dequeuedInput.HasFlag(InputNetFlags.Right) && !prevDequeuedInput.HasFlag(InputNetFlags.Right);
+                    case InputType.Up:
+                        return dequeuedInput.HasFlag(InputNetFlags.Up) && !prevDequeuedInput.HasFlag(InputNetFlags.Up);
+                    case InputType.Down:
+                        return dequeuedInput.HasFlag(InputNetFlags.Down) && !prevDequeuedInput.HasFlag(InputNetFlags.Down);
+                    case InputType.Run:
+                        return dequeuedInput.HasFlag(InputNetFlags.Run) && prevDequeuedInput.HasFlag(InputNetFlags.Run);
+                    case InputType.Crouch:
+                        return dequeuedInput.HasFlag(InputNetFlags.Crouch) && !prevDequeuedInput.HasFlag(InputNetFlags.Crouch);
+                    case InputType.Select:
+                        return dequeuedInput.HasFlag(InputNetFlags.Select); //TODO: clean up the way this input is registered
+                    case InputType.Deselect:
+                        return dequeuedInput.HasFlag(InputNetFlags.Deselect);
+                    case InputType.Health:
+                        return dequeuedInput.HasFlag(InputNetFlags.Health);
+                    case InputType.Grab:
+                        return dequeuedInput.HasFlag(InputNetFlags.Grab);
+                    case InputType.Use:
+                        return dequeuedInput.HasFlag(InputNetFlags.Use) && !prevDequeuedInput.HasFlag(InputNetFlags.Use);
+                    case InputType.Shoot:
+                        return dequeuedInput.HasFlag(InputNetFlags.Shoot) && !prevDequeuedInput.HasFlag(InputNetFlags.Shoot);
+                    case InputType.Ragdoll:
+                        return dequeuedInput.HasFlag(InputNetFlags.Ragdoll) && !prevDequeuedInput.HasFlag(InputNetFlags.Ragdoll);
+                    default:
+                        return false;
+                }
+            }
+#endif
+
+            return keys[(int)inputType].Pressed;
+        }
+
         public bool IsKeyDown(InputType inputType)
         {
 #if SERVER
@@ -2230,7 +2272,7 @@ namespace Barotrauma
                         item.Use(deltaTime, user: this);
                     }
                 }
-                if (IsKeyDown(InputType.Shoot) && item.IsShootable)
+                if (item.GetComponent<RangedWeapon>()?.HoldTrigger ?? false || item.GetComponent<MeleeWeapon>() != null ? IsKeyDown(InputType.Shoot) : IsKeyPressed(InputType.Shoot) && item.IsShootable)
                 {
                     if (!item.RequireAimToUse || IsKeyDown(InputType.Aim))
                     {

--- a/Barotrauma/BarotraumaShared/SharedSource/PlayerInput.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/PlayerInput.cs
@@ -5,6 +5,7 @@ namespace Barotrauma
     class Key
     {
         private bool hit, hitQueue;
+        private bool pressed;
         private bool held, heldQueue;
 
 
@@ -42,6 +43,8 @@ namespace Barotrauma
             hit = binding.IsHit() && AllowOnGUI(inputType);
             if (hit) hitQueue = true;
 
+            pressed = binding.IsPressed() && AllowOnGUI(inputType);
+
             held = binding.IsDown() && AllowOnGUI(inputType);
             if (held) heldQueue = true;
         }
@@ -56,6 +59,18 @@ namespace Barotrauma
             set
             {
                 hit = value;
+            }
+        }
+
+        public bool Pressed
+        {
+            get
+            {
+                return pressed;
+            }
+            set
+            {
+                pressed = value;
             }
         }
 


### PR DESCRIPTION
Addresses https://github.com/Regalis11/Barotrauma/pull/11264#issuecomment-1782415160 by adding a new input method instead of modifying the existing one.
Unfortunately I don't believe I can reopen closed PRs here, so here is a new one instead! ;3


From #11264:
This commit makes use of the `holdtrigger` attribute of the `RangedWeapon` item component to force players to release their "Shoot" binding to be able to fire the weapon again if it is set to `true`.
