### PR TITLE
Fix inconsistent sound muffling of door sounds between multiplayer and singleplayer

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Map/Hull.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Map/Hull.cs
@@ -1141,14 +1141,9 @@ namespace Barotrauma
                 float distanceMultiplier = 1;
                 if (g.ConnectedDoor != null && !g.ConnectedDoor.IsBroken)
                 {
-                    bool isClosed = g.ConnectedDoor.IsClosed;
-                    bool isMostlyClosed = g.ConnectedDoor.OpenState < 0.1f;
-                    bool isOpening = g.ConnectedDoor.PredictedState.HasValue && g.ConnectedDoor.PredictedState.Value;
-
-                    // Multipayer: Door is closed  OR  door is closing and is mostly closed.
-                    if (GameMain.IsMultiplayer && (isClosed && !isOpening || !isOpening && isMostlyClosed) ||
-                        // Singleplayer: Door is closed/closing and is mostly closed.
-                        !GameMain.IsMultiplayer && isClosed && isMostlyClosed)
+                    bool isMultiplayerDoorChangingState = g.ConnectedDoor.PredictedState.HasValue;
+                    // Gap blocked if the door is closed or is curently closing and 90% closed.
+                    if ((!isMultiplayerDoorChangingState && g.ConnectedDoor.IsClosed || isMultiplayerDoorChangingState && !g.ConnectedDoor.PredictedState.Value) && g.ConnectedDoor.OpenState < 0.1f)
                     {
                         if (distanceMultiplierFromDoors <= 0) { continue; }
                         distanceMultiplier *= distanceMultiplierFromDoors;

--- a/Barotrauma/BarotraumaShared/SharedSource/Map/Hull.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Map/Hull.cs
@@ -1141,14 +1141,17 @@ namespace Barotrauma
                 float distanceMultiplier = 1;
                 if (g.ConnectedDoor != null && !g.ConnectedDoor.IsBroken)
                 {
-                    //gap blocked if the door is not open or the predicted state is not open
-                    if ((g.ConnectedDoor.IsClosed && !g.ConnectedDoor.IsBroken) || (g.ConnectedDoor.PredictedState.HasValue && !g.ConnectedDoor.PredictedState.Value))
+                    bool isClosed = g.ConnectedDoor.IsClosed;
+                    bool isMostlyClosed = g.ConnectedDoor.OpenState < 0.1f;
+                    bool isOpening = g.ConnectedDoor.PredictedState.HasValue && g.ConnectedDoor.PredictedState.Value;
+
+                    // Multipayer: Door is closed  OR  door is closing and is mostly closed.
+                    if (GameMain.IsMultiplayer && (isClosed && !isOpening || !isOpening && isMostlyClosed) ||
+                        // Singleplayer: Door is closed/closing and is mostly closed.
+                        !GameMain.IsMultiplayer && isClosed && isMostlyClosed)
                     {
-                        if (g.ConnectedDoor.OpenState < 0.1f)
-                        {
-                            if (distanceMultiplierFromDoors <= 0) { continue; }
-                            distanceMultiplier *= distanceMultiplierFromDoors;
-                        }
+                        if (distanceMultiplierFromDoors <= 0) { continue; }
+                        distanceMultiplier *= distanceMultiplierFromDoors;
                     }
                 }
                 else if (g.Open <= 0.0f)


### PR DESCRIPTION
This bug relates to the conditions used to check if a door is open or closed in the GetApproximateHullDistance method and how those conditions resolve differently depending on whether the game is multiplayer or singleplayer. Most noticeably, this affects the muffling of door sounds when opened on their non-inclusive side (the side opposite the hull containing the door). First reported in issue #2476, this bug has been around for a long time and applies to every door in multiplayer.

Basically, if you're in a different hull to the door's hull when you open it in multiplayer, the game thinks there is no path to the opening sound and muffles it. This fix changes a condition that opens up that path.

For anyone reading who isn't familiar with this part of the codebase, I'll try to give a basic breakdown of what the door values in the conditions represent (to my understanding) because it wasn't immediately clear to me how it worked either:
The float `OpenState` is the ratio of the door being open/closed, 1.0 being fully open and 0.0 being closed.

The bool `IsClosed` represents the state of the door. In singleplayer, it updates the instant a door begins changing state (opening/closing). Whereas in multiplayer, it only updates once the door has finished changing state, which isn't helpful in this context because we need to account for stuff in between (otherwise, sounds could remain muffled until the door has fully finished opening).

There's the obvious question, "Why not just use the OpenState to determine if the door is open or closed?"
One reason is that when a player clicks on a door to open it, the OpenState at that moment is 0, which would cause the opening sound to be muffled.

A solution to this is the bool `PredictedState`, which only exists in multiplayer and when the state of a door is changing (otherwise it's null). It acts as the instant flag that `IsClosed` is for singleplayer.

With these rules in mind, I'll describe the current release method (simplified) to see why the bug occurs:
```cs
if ((IsClosed) || (PredictedState.HasValue && !PredictedState.Value))
{
    if (g.ConnectedDoor.OpenState < 0.1f)
    {
        // no path
    }
}                   
```
Here are the relevant states a door can be in when checking for a path to the opposite side. The current release method correctly evaluates all but one use case. 
(The following section almost definitely over-describes the issue, but I hope it might better illustrate the problem for some people and save on potential testing time).
**1. Door is open**
Singleplayer: `IsClosed` is false, but `PredictedState` has no value. Path is open.
Multiplayer : `IsClosed` is false, but `PredictedState` has no value. Path is open.

**2. Door is closed**
Singleplayer: `IsClosed` is true, and `OpenState` is less than 0.1. Path is closed.
Multiplayer : `IsClosed` is true, and `OpenState` is less than 0.1. Path is closed.

**3. Door starts closing**
Singleplayer: `IsClosed` is true, and `OpenState` is greater than 0.1. Path is open.
Multiplayer : `IsClosed` is false, but `!PredictedState.Value` resolves to true. `OpenState` is greater than 0.1. Path is open.

**4. Door starts opening**
Singleplayer: `IsClosed` is false, but `PredictedState` has no value. Path is open.
**Multiplayer : `IsClosed` is true, and `OpenState` is less than 0.1. Path is closed.**

When testing the same use cases on the newly proposed method, we always get the correct result regardless of being in singleplayer or multiplayer:
```cs
if ((!PredictedState.HasValue && IsClosed || PredictedState.HasValue && !PredictedState.Value) && OpenState < 0.1f)
{
    // no path
}
```
**1. Door is open**
Singleplayer: `PredictedState` has no value, but IsClosed is false. Path is open.
Multiplayer : `PredictedState` has no value, but IsClosed is false. Path is open.

**2. Door is closed**
Singleplayer: `PredictedState` has no value, and IsClosed is true. Path is closed.
Multiplayer : `PredictedState` has no value, and IsClosed is true. Path is closed.

**3. Door starts closing**
Singleplayer: `PredictedState` has no value, and IsClosed is true, but `OpenState` is greater than 0.1. Path is open.
Multiplayer : `!PredictedState.Value` evaluates to true, but but `OpenState` is greater than 0.1. Path is open.

**4. Door starts opening**
Singleplayer: `PredictedState` has no value, but IsClosed is false. Path is open.
Multiplayer :  `!PredictedState.Value` evaluates to false. Path is open.

Due to the frequency that this method is called, the proposed solution was written in a similar way to the original to prioritise performance by using inline short-circuit evaluations and a local variable to store `ConnectedDoor.PredictedState.HasValue`, which is accessed twice.

I have built and tested this change on both singleplayer and multiplayer for Windows, and it's working as described above. Let me know if there's anything I missed or need to improve on. Thank you!