### PR TITLE
Door sprite depth changes

### DIFF
--- a/doors.xml
+++ b/doors.xml
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Items>
   <Item name="" identifier="door" tags="door,weldable" scale="0.5" health="100" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyexplosions="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" allowrotatingineditor="false" allowedlinks="structure,item" ondamagedthreshold="2" linkable="true">
-    <Sprite texture="door.png" sourcerect="0,0,49,416" depth="0.51" origin="0.5,0.5" />
-    <DecorativeSprite texture="door.png" sourcerect="49,0,49,416" depth="0.89" origin="0.5,0.5"/>
+    <Sprite texture="Content/Items/Door/door.png" sourcerect="0,0,49,416" depth="0.51" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Items/Door/door.png" sourcerect="49,0,49,416" depth="0.61" origin="0.5,0.5"/>
     <Door canbeselected="true" canbepicked="true" pickkey="Action" msg="ItemMsgForceOpenCrowbar" PickingTime="7.5" shadowscale="0.7,1">
       <Upgrade gameversion="0.22.0.0" PickingTime="7.5" />
       <RequiredItem items="crowbar" type="Equipped" />
-      <Sprite texture="door.png" sourcerect="158,0,42,416" depth="0.05" origin="0.5,0.0" />
-      <WeldedSprite texture="door.png" sourcerect="203,0,65,377" depth="0.0" origin="0.5,0.5" />
-      <BrokenSprite texture="door.png" sourcerect="271,0,121,416" depth="0.509" origin="0.5,0.0" scale="true" />
+      <Sprite texture="Content/Items/Door/door.png" sourcerect="158,0,42,416" depth="0.05" origin="0.5,0.0" />
+      <WeldedSprite texture="Content/Items/Door/door.png" sourcerect="203,0,65,377" depth="0.0" origin="0.5,0.5" />
+      <BrokenSprite texture="Content/Items/Door/door.png" sourcerect="271,0,121,416" depth="0.509" origin="0.5,0.0" scale="true" />
       <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
       <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
       <sound file="Content/Items/Door/Door3.ogg" type="OnUse" range="500.0" />
@@ -40,14 +40,14 @@
     </ConnectionPanel>
   </Item>
   <Item name="" identifier="windoweddoor" tags="door,weldable" scale="0.5" health="100" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" allowrotatingineditor="false" allowedlinks="structure,item" ondamagedthreshold="2" linkable="true">
-    <Sprite texture="door.png" sourcerect="0,0,49,416" depth="0.51" origin="0.5,0.5" />
-    <DecorativeSprite texture="door.png" sourcerect="49,0,49,416" depth="0.89" origin="0.5,0.5"/>
+    <Sprite texture="Content/Items/Door/door.png" sourcerect="0,0,49,416" depth="0.51" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Items/Door/door.png" sourcerect="49,0,49,416" depth="0.61" origin="0.5,0.5"/>
     <Door window="0,-76,50,153" canbepicked="true" canbeselected="true" pickkey="Action" msg="ItemMsgForceOpenCrowbar" PickingTime="7.5" shadowscale="0.7,1">
       <Upgrade gameversion="0.22.0.0" PickingTime="7.5" />
       <RequiredItem items="crowbar" type="Equipped" />
-      <Sprite texture="door.png" sourcerect="106,0,50,416" depth="0.05" origin="0.5,0.0" />
-      <WeldedSprite texture="door.png" sourcerect="203,0,65,377" depth="0.0" origin="0.5,0.5" />
-      <BrokenSprite texture="door.png" sourcerect="392,0,120,416" depth="0.509" origin="0.5,0.0" scale="true" />
+      <Sprite texture="Content/Items/Door/door.png" sourcerect="106,0,50,416" depth="0.05" origin="0.5,0.0" />
+      <WeldedSprite texture="Content/Items/Door/door.png" sourcerect="203,0,65,377" depth="0.0" origin="0.5,0.5" />
+      <BrokenSprite texture="Content/Items/Door/door.png" sourcerect="392,0,120,416" depth="0.509" origin="0.5,0.0" scale="true" />
       <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
       <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
       <sound file="Content/Items/Door/Door3.ogg" type="OnUse" range="500.0" />
@@ -80,13 +80,13 @@
   </Item>
   <Item name="" identifier="hatch" allowedlinks="gap,hull,structure,item" linkable="true" tags="door,weldable" scale="0.5" health="100" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" ondamagedthreshold="2" allowrotatingineditor="false">
     <Upgrade gameversion="0.9.7.0" spritedepth="0.7"/>
-    <Sprite texture="hatch.png" sourcerect="0,0,256,98" depth="0.7" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Door/hatch.png" sourcerect="0,0,256,98" depth="0.7" origin="0.5,0.5" />
     <Door canbeselected="true" canbepicked="true" horizontal="true" pickkey="Action" msg="ItemMsgForceOpenCrowbar" PickingTime="7.5" shadowscale="1,0.8">
       <Upgrade gameversion="0.22.0.0" PickingTime="7.5" />
       <RequiredItem items="crowbar" type="Equipped" />
-      <Sprite texture="hatch.png" sourcerect="256,0,256,38" depth="0.05" origin="0.0,0.5" />
-      <WeldedSprite texture="hatch.png" sourcerect="0,100,227,75" depth="0.0" origin="0.5,0.5" />
-      <BrokenSprite texture="hatch.png" sourcerect="256,45,256,114" depth="0.509" origin="0.0,0.5" scale="true" />
+      <Sprite texture="Content/Items/Door/hatch.png" sourcerect="256,0,256,38" depth="0.05" origin="0.0,0.5" />
+      <WeldedSprite texture="Content/Items/Door/hatch.png" sourcerect="0,100,227,75" depth="0.0" origin="0.5,0.5" />
+      <BrokenSprite texture="Content/Items/Door/hatch.png" sourcerect="256,45,256,114" depth="0.509" origin="0.0,0.5" scale="true" />
       <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
       <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
       <sound file="Content/Items/Door/Door3.ogg" type="OnUse" range="500.0" />
@@ -118,17 +118,17 @@
     </ConnectionPanel>
   </Item>
   <Item name="" identifier="doorwbuttons" tags="door,weldable" scale="0.5" health="100" requirebodyinsidetrigger="false" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" allowrotatingineditor="false" allowedlinks="structure,item" ondamagedthreshold="2" linkable="true">
-    <Sprite texture="door.png" sourcerect="0,0,49,416" depth="0.51" origin="0.5,0.5" />
-    <DecorativeSprite texture="door.png" sourcerect="49,0,49,416" depth="0.89" origin="0.5,0.5"/>
-    <DecorativeSprite texture="Content/Items/Button/button.png" sourcerect="28,70,34,51" depth="0.75" origin="1.65,0.76" />
-    <DecorativeSprite texture="Content/Items/Button/button.png" sourcerect="28,70,34,51" depth="0.75" origin="-0.65,0.76" />
+    <Sprite texture="Content/Items/Door/door.png" sourcerect="0,0,49,416" depth="0.51" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Items/Door/door.png" sourcerect="49,0,49,416" depth="0.61" origin="0.5,0.5"/>
+    <DecorativeSprite texture="Content/Items/Button/button.png" sourcerect="28,70,34,51" depth="0.62" origin="1.65,0.76" />
+    <DecorativeSprite texture="Content/Items/Button/button.png" sourcerect="28,70,34,51" depth="0.62" origin="-0.65,0.76" />
     <Door canbeselected="true" canbepicked="true" pickkey="Action" msg="ItemMsgForceOpenCrowbar" PickingTime="7.5" shadowscale="0.7,1" hasintegratedbuttons="true">
       <Upgrade gameversion="0.22.0.0" PickingTime="7.5" />
       <RequiredItem items="crowbar" type="Equipped" optional="true"/>
       <Requireditem items="idcard" type="Picked" optional="true"/>
-      <Sprite texture="door.png" sourcerect="158,0,42,416" depth="0.05" origin="0.5,0.0" />
-      <WeldedSprite texture="door.png" sourcerect="203,0,65,377" depth="0.0" origin="0.5,0.5" />
-      <BrokenSprite texture="door.png" sourcerect="271,0,121,416" depth="0.509" origin="0.5,0.0" scale="true" />
+      <Sprite texture="Content/Items/Door/door.png" sourcerect="158,0,42,416" depth="0.05" origin="0.5,0.0" />
+      <WeldedSprite texture="Content/Items/Door/door.png" sourcerect="203,0,65,377" depth="0.0" origin="0.5,0.5" />
+      <BrokenSprite texture="Content/Items/Door/door.png" sourcerect="271,0,121,416" depth="0.509" origin="0.5,0.0" scale="true" />
       <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
       <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
       <sound file="Content/Items/Door/Door3.ogg" type="OnUse" range="500.0" />
@@ -161,17 +161,17 @@
     </ConnectionPanel>
   </Item>
   <Item name="" identifier="windoweddoorwbuttons" tags="door,weldable" scale="0.5" health="100" requirebodyinsidetrigger="false" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" allowrotatingineditor="false" allowedlinks="structure,item" ondamagedthreshold="2" linkable="true">
-    <Sprite texture="door.png" sourcerect="0,0,49,416" depth="0.51" origin="0.5,0.5" />
-    <DecorativeSprite texture="door.png" sourcerect="49,0,49,416" depth="0.89" origin="0.5,0.5"/>
-    <DecorativeSprite texture="Content/Items/Button/button.png" sourcerect="28,70,34,51" depth="0.75" origin="1.65,0.76" />
-    <DecorativeSprite texture="Content/Items/Button/button.png" sourcerect="28,70,34,51" depth="0.75" origin="-0.65,0.76" />
+    <Sprite texture="Content/Items/Door/door.png" sourcerect="0,0,49,416" depth="0.51" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Items/Door/door.png" sourcerect="49,0,49,416" depth="0.61" origin="0.5,0.5"/>
+    <DecorativeSprite texture="Content/Items/Button/button.png" sourcerect="28,70,34,51" depth="0.62" origin="1.65,0.76" />
+    <DecorativeSprite texture="Content/Items/Button/button.png" sourcerect="28,70,34,51" depth="0.62" origin="-0.65,0.76" />
     <Door window="0,-76,50,153" canbepicked="true" canbeselected="true" pickkey="Action" msg="ItemMsgForceOpenCrowbar" PickingTime="7.5" shadowscale="0.7,1" hasintegratedbuttons="true">
       <Upgrade gameversion="0.22.0.0" PickingTime="7.5" />
       <RequiredItem items="crowbar" type="Equipped" optional="true"/>
       <Requireditem items="idcard" type="Picked" optional="true"/>
-      <Sprite texture="door.png" sourcerect="106,0,50,416" depth="0.05" origin="0.5,0.0" />
-      <WeldedSprite texture="door.png" sourcerect="203,0,65,377" depth="0.0" origin="0.5,0.5" />
-      <BrokenSprite texture="door.png" sourcerect="392,0,120,416" depth="0.509" origin="0.5,0.0" scale="true" />
+      <Sprite texture="Content/Items/Door/door.png" sourcerect="106,0,50,416" depth="0.05" origin="0.5,0.0" />
+      <WeldedSprite texture="Content/Items/Door/door.png" sourcerect="203,0,65,377" depth="0.0" origin="0.5,0.5" />
+      <BrokenSprite texture="Content/Items/Door/door.png" sourcerect="392,0,120,416" depth="0.509" origin="0.5,0.0" scale="true" />
       <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
       <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
       <sound file="Content/Items/Door/Door3.ogg" type="OnUse" range="500.0" />
@@ -205,15 +205,15 @@
   </Item>
   <Item name="" identifier="hatchwbuttons" allowedlinks="gap,hull,structure,item" linkable="true" tags="door,weldable" scale="0.5" health="100" requirebodyinsidetrigger="false" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" ondamagedthreshold="2" allowrotatingineditor="false">
     <Upgrade gameversion="0.9.7.0" spritedepth="0.7"/>
-    <Sprite texture="hatch.png" sourcerect="0,0,256,98" depth="0.7" origin="0.5,0.5" />
-    <DecorativeSprite texture="hatch.png" sourcerect="0,234,256,193" depth="0.89" origin="0.5,0.5"/>
+    <Sprite texture="Content/Items/Door/hatch.png" sourcerect="0,0,256,98" depth="0.7" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Items/Door/hatch.png" sourcerect="0,234,256,193" depth="0.89" origin="0.5,0.5"/>
     <Door canbeselected="true" canbepicked="true" horizontal="true" pickkey="Action" msg="ItemMsgOpen" PickingTime="7.5" shadowscale="1,0.8" hasintegratedbuttons="true">
       <Upgrade gameversion="0.22.0.0" PickingTime="7.5" />
       <RequiredItem items="crowbar" type="Equipped" optional="true"/>
       <Requireditem items="idcard" type="Picked" optional="true"/>
-      <Sprite texture="hatch.png" sourcerect="256,0,256,38" depth="0.05" origin="0.0,0.5" />
-      <WeldedSprite texture="hatch.png" sourcerect="0,100,227,75" depth="0.0" origin="0.5,0.5" />
-      <BrokenSprite texture="hatch.png" sourcerect="256,45,256,114" depth="0.509" origin="0.0,0.5" scale="true" />
+      <Sprite texture="Content/Items/Door/hatch.png" sourcerect="256,0,256,38" depth="0.05" origin="0.0,0.5" />
+      <WeldedSprite texture="Content/Items/Door/hatch.png" sourcerect="0,100,227,75" depth="0.0" origin="0.5,0.5" />
+      <BrokenSprite texture="Content/Items/Door/hatch.png" sourcerect="256,45,256,114" depth="0.509" origin="0.0,0.5" scale="true" />
       <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
       <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
       <sound file="Content/Items/Door/Door3.ogg" type="OnUse" range="500.0" />
@@ -332,13 +332,13 @@
         <RequiredItem items="wrench" type="equipped" />
       </Repairable>
     </Upgrade>
-    <Sprite texture="door.png" sourcerect="37,430,64,64" depth="0.01" origin="0.5,0.5" />
-    <DecorativeSprite texture="door.png" sourcerect="176,469,31,31" depth="0.06" origin="0.5,0.5"/>
+    <Sprite texture="Content/Items/Door/door.png" sourcerect="37,430,64,64" depth="0.01" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Items/Door/door.png" sourcerect="176,469,31,31" depth="0.06" origin="0.5,0.5"/>
     <Door canbeselected="true" horizontal="true" canbepicked="true" pickkey="Action" impassable="true" msg="ItemMsgForceOpenCrowbar" PickingTime="3.0" autoorientgap="true">
       <RequiredItem items="crowbar" type="Equipped" />
-      <Sprite texture="door.png" sourcerect="313,430,64,64" depth="0.05" origin="0.0,0.5" />
-      <WeldedSprite texture="door.png" sourcerect="103,430,65,65" depth="0.0" origin="0.5,0.5" />
-      <BrokenSprite texture="door.png" sourcerect="215,412,93,93" depth="0.0" origin="0.15,0.5" scale="false" />
+      <Sprite texture="Content/Items/Door/door.png" sourcerect="313,430,64,64" depth="0.05" origin="0.0,0.5" />
+      <WeldedSprite texture="Content/Items/Door/door.png" sourcerect="103,430,65,65" depth="0.0" origin="0.5,0.5" />
+      <BrokenSprite texture="Content/Items/Door/door.png" sourcerect="215,412,93,93" depth="0.0" origin="0.15,0.5" scale="false" />
       <sound file="Content/Items/Door/Duct1.ogg" type="OnUse" selectionmode="Random" range="300" />
       <sound file="Content/Items/Door/Duct2.ogg" type="OnUse" range="300" />
       <sound file="Content/Items/Tools/Crowbar.ogg" type="OnPicked" range="500.0" />

--- a/doors.xml
+++ b/doors.xml
@@ -1,0 +1,360 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Items>
+  <Item name="" identifier="door" tags="door,weldable" scale="0.5" health="100" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyexplosions="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" allowrotatingineditor="false" allowedlinks="structure,item" ondamagedthreshold="2" linkable="true">
+    <Sprite texture="door.png" sourcerect="0,0,49,416" depth="0.51" origin="0.5,0.5" />
+    <DecorativeSprite texture="door.png" sourcerect="49,0,49,416" depth="0.89" origin="0.5,0.5"/>
+    <Door canbeselected="true" canbepicked="true" pickkey="Action" msg="ItemMsgForceOpenCrowbar" PickingTime="7.5" shadowscale="0.7,1">
+      <Upgrade gameversion="0.22.0.0" PickingTime="7.5" />
+      <RequiredItem items="crowbar" type="Equipped" />
+      <Sprite texture="door.png" sourcerect="158,0,42,416" depth="0.05" origin="0.5,0.0" />
+      <WeldedSprite texture="door.png" sourcerect="203,0,65,377" depth="0.0" origin="0.5,0.5" />
+      <BrokenSprite texture="door.png" sourcerect="271,0,121,416" depth="0.509" origin="0.5,0.0" scale="true" />
+      <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door3.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door4.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Tools/Crowbar.ogg" type="OnPicked" range="2000.0" onlyinsamesub="true" />
+      <sound file="Content/Items/Door/Duct1.ogg" type="OnFailure" selectionmode="Random" range="300" />
+      <sound file="Content/Items/Door/Duct2.ogg" type="OnFailure" range="300" />
+      <sound file="Content/Items/Door/DoorBreak1.ogg" type="OnBroken" selectionmode="Random" range="2000" />
+      <sound file="Content/Items/Door/DoorBreak2.ogg" type="OnBroken" range="2000" />
+      <StatusEffect type="OnDamaged" target="This">
+        <sound file="Content/Items/Door/DoorBreak1.ogg" selectionmode="Random" range="800" />
+        <sound file="Content/Items/Door/DoorBreak2.ogg" range="800" />
+      </StatusEffect>
+    </Door>
+    <AiTarget sightrange="1500.0" static="True"/>
+    <Repairable selectkey="Action" header="mechanicalrepairsheader" fixDurationHighSkill="10" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI" />
+      <RequiredSkill identifier="mechanical" level="40" />
+      <RequiredItem items="wrench" type="equipped" />
+    </Repairable>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+      <output name="state_out" displayname="connection.stateout" fallbackdisplayname="connection.signalout"/>
+      <output name="condition_out" displayname="connection.conditionout" />
+      <output name="activate_out" displayname="connection.activateout" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" identifier="windoweddoor" tags="door,weldable" scale="0.5" health="100" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" allowrotatingineditor="false" allowedlinks="structure,item" ondamagedthreshold="2" linkable="true">
+    <Sprite texture="door.png" sourcerect="0,0,49,416" depth="0.51" origin="0.5,0.5" />
+    <DecorativeSprite texture="door.png" sourcerect="49,0,49,416" depth="0.89" origin="0.5,0.5"/>
+    <Door window="0,-76,50,153" canbepicked="true" canbeselected="true" pickkey="Action" msg="ItemMsgForceOpenCrowbar" PickingTime="7.5" shadowscale="0.7,1">
+      <Upgrade gameversion="0.22.0.0" PickingTime="7.5" />
+      <RequiredItem items="crowbar" type="Equipped" />
+      <Sprite texture="door.png" sourcerect="106,0,50,416" depth="0.05" origin="0.5,0.0" />
+      <WeldedSprite texture="door.png" sourcerect="203,0,65,377" depth="0.0" origin="0.5,0.5" />
+      <BrokenSprite texture="door.png" sourcerect="392,0,120,416" depth="0.509" origin="0.5,0.0" scale="true" />
+      <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door3.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door4.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Tools/Crowbar.ogg" type="OnPicked" range="2000.0" onlyinsamesub="true" />
+      <sound file="Content/Items/Door/Duct1.ogg" type="OnFailure" selectionmode="Random" range="300" />
+      <sound file="Content/Items/Door/Duct2.ogg" type="OnFailure" range="300" />
+      <sound file="Content/Items/Door/DoorBreak1.ogg" type="OnBroken" selectionmode="Random" range="2000" />
+      <sound file="Content/Items/Door/DoorBreak2.ogg" type="OnBroken" range="2000" />
+      <StatusEffect type="OnDamaged" target="This">
+        <sound file="Content/Items/Door/DoorBreak1.ogg" selectionmode="Random" range="800" />
+        <sound file="Content/Items/Door/DoorBreak2.ogg" range="800" />
+      </StatusEffect>
+    </Door>
+    <AiTarget sightrange="1500.0" static="True"/>
+    <Repairable selectkey="Action" header="mechanicalrepairsheader" fixDurationHighSkill="10" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI" />
+      <RequiredSkill identifier="mechanical" level="40" />
+      <RequiredItem items="wrench" type="equipped" />
+    </Repairable>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+      <output name="state_out" displayname="connection.stateout" fallbackdisplayname="connection.signalout"/>
+      <output name="condition_out" displayname="connection.conditionout" />
+      <output name="activate_out" displayname="connection.activateout" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" identifier="hatch" allowedlinks="gap,hull,structure,item" linkable="true" tags="door,weldable" scale="0.5" health="100" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" ondamagedthreshold="2" allowrotatingineditor="false">
+    <Upgrade gameversion="0.9.7.0" spritedepth="0.7"/>
+    <Sprite texture="hatch.png" sourcerect="0,0,256,98" depth="0.7" origin="0.5,0.5" />
+    <Door canbeselected="true" canbepicked="true" horizontal="true" pickkey="Action" msg="ItemMsgForceOpenCrowbar" PickingTime="7.5" shadowscale="1,0.8">
+      <Upgrade gameversion="0.22.0.0" PickingTime="7.5" />
+      <RequiredItem items="crowbar" type="Equipped" />
+      <Sprite texture="hatch.png" sourcerect="256,0,256,38" depth="0.05" origin="0.0,0.5" />
+      <WeldedSprite texture="hatch.png" sourcerect="0,100,227,75" depth="0.0" origin="0.5,0.5" />
+      <BrokenSprite texture="hatch.png" sourcerect="256,45,256,114" depth="0.509" origin="0.0,0.5" scale="true" />
+      <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door3.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door4.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Tools/Crowbar.ogg" type="OnPicked" range="2000.0" onlyinsamesub="true" />
+      <sound file="Content/Items/Door/Duct1.ogg" type="OnFailure" selectionmode="Random" range="300" />
+      <sound file="Content/Items/Door/Duct2.ogg" type="OnFailure" range="300" />
+      <sound file="Content/Items/Door/DoorBreak1.ogg" type="OnBroken" selectionmode="Random" range="2000" />
+      <sound file="Content/Items/Door/DoorBreak2.ogg" type="OnBroken" range="2000" />
+      <StatusEffect type="OnDamaged" target="This">
+        <sound file="Content/Items/Door/DoorBreak1.ogg" selectionmode="Random" range="800" />
+        <sound file="Content/Items/Door/DoorBreak2.ogg" range="800" />
+      </StatusEffect>
+    </Door>
+    <AiTarget sightrange="1500.0" static="True"/>
+    <Repairable selectkey="Action" header="mechanicalrepairsheader" fixDurationHighSkill="10" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI" />
+      <RequiredSkill identifier="mechanical" level="40" />
+      <RequiredItem items="wrench" type="equipped" />
+    </Repairable>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+      <output name="state_out" displayname="connection.stateout" fallbackdisplayname="connection.signalout"/>
+      <output name="condition_out" displayname="connection.conditionout" />
+      <output name="activate_out" displayname="connection.activateout" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" identifier="doorwbuttons" tags="door,weldable" scale="0.5" health="100" requirebodyinsidetrigger="false" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" allowrotatingineditor="false" allowedlinks="structure,item" ondamagedthreshold="2" linkable="true">
+    <Sprite texture="door.png" sourcerect="0,0,49,416" depth="0.51" origin="0.5,0.5" />
+    <DecorativeSprite texture="door.png" sourcerect="49,0,49,416" depth="0.89" origin="0.5,0.5"/>
+    <DecorativeSprite texture="Content/Items/Button/button.png" sourcerect="28,70,34,51" depth="0.75" origin="1.65,0.76" />
+    <DecorativeSprite texture="Content/Items/Button/button.png" sourcerect="28,70,34,51" depth="0.75" origin="-0.65,0.76" />
+    <Door canbeselected="true" canbepicked="true" pickkey="Action" msg="ItemMsgForceOpenCrowbar" PickingTime="7.5" shadowscale="0.7,1" hasintegratedbuttons="true">
+      <Upgrade gameversion="0.22.0.0" PickingTime="7.5" />
+      <RequiredItem items="crowbar" type="Equipped" optional="true"/>
+      <Requireditem items="idcard" type="Picked" optional="true"/>
+      <Sprite texture="door.png" sourcerect="158,0,42,416" depth="0.05" origin="0.5,0.0" />
+      <WeldedSprite texture="door.png" sourcerect="203,0,65,377" depth="0.0" origin="0.5,0.5" />
+      <BrokenSprite texture="door.png" sourcerect="271,0,121,416" depth="0.509" origin="0.5,0.0" scale="true" />
+      <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door3.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door4.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Tools/Crowbar.ogg" type="OnPicked" range="2000.0" onlyinsamesub="true" />
+      <sound file="Content/Items/Door/Duct1.ogg" type="OnFailure" selectionmode="Random" range="300" />
+      <sound file="Content/Items/Door/Duct2.ogg" type="OnFailure" range="300" />
+      <sound file="Content/Items/Door/DoorBreak1.ogg" type="OnBroken" selectionmode="Random" range="2000" />
+      <sound file="Content/Items/Door/DoorBreak2.ogg" type="OnBroken" range="2000" />
+      <StatusEffect type="OnDamaged" target="This">
+        <sound file="Content/Items/Door/DoorBreak1.ogg" selectionmode="Random" range="800" />
+        <sound file="Content/Items/Door/DoorBreak2.ogg" range="800" />
+      </StatusEffect>
+    </Door>
+    <trigger x="-60" y="-140" width="170" height="85" />
+    <AiTarget sightrange="1500.0" static="True"/>
+    <Repairable selectkey="Action" header="mechanicalrepairsheader" fixDurationHighSkill="10" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI" />
+      <RequiredSkill identifier="mechanical" level="40" />
+      <RequiredItem items="wrench" type="equipped" />
+    </Repairable>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+      <output name="state_out" displayname="connection.stateout" fallbackdisplayname="connection.signalout"/>
+      <output name="condition_out" displayname="connection.conditionout" />
+      <output name="activate_out" displayname="connection.activateout" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" identifier="windoweddoorwbuttons" tags="door,weldable" scale="0.5" health="100" requirebodyinsidetrigger="false" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" allowrotatingineditor="false" allowedlinks="structure,item" ondamagedthreshold="2" linkable="true">
+    <Sprite texture="door.png" sourcerect="0,0,49,416" depth="0.51" origin="0.5,0.5" />
+    <DecorativeSprite texture="door.png" sourcerect="49,0,49,416" depth="0.89" origin="0.5,0.5"/>
+    <DecorativeSprite texture="Content/Items/Button/button.png" sourcerect="28,70,34,51" depth="0.75" origin="1.65,0.76" />
+    <DecorativeSprite texture="Content/Items/Button/button.png" sourcerect="28,70,34,51" depth="0.75" origin="-0.65,0.76" />
+    <Door window="0,-76,50,153" canbepicked="true" canbeselected="true" pickkey="Action" msg="ItemMsgForceOpenCrowbar" PickingTime="7.5" shadowscale="0.7,1" hasintegratedbuttons="true">
+      <Upgrade gameversion="0.22.0.0" PickingTime="7.5" />
+      <RequiredItem items="crowbar" type="Equipped" optional="true"/>
+      <Requireditem items="idcard" type="Picked" optional="true"/>
+      <Sprite texture="door.png" sourcerect="106,0,50,416" depth="0.05" origin="0.5,0.0" />
+      <WeldedSprite texture="door.png" sourcerect="203,0,65,377" depth="0.0" origin="0.5,0.5" />
+      <BrokenSprite texture="door.png" sourcerect="392,0,120,416" depth="0.509" origin="0.5,0.0" scale="true" />
+      <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door3.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door4.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Tools/Crowbar.ogg" type="OnPicked" range="4000.0" onlyinsamesub="true" />
+      <sound file="Content/Items/Door/Duct1.ogg" type="OnFailure" selectionmode="Random" range="300" />
+      <sound file="Content/Items/Door/Duct2.ogg" type="OnFailure" range="300" />
+      <sound file="Content/Items/Door/DoorBreak1.ogg" type="OnBroken" selectionmode="Random" range="3000" />
+      <sound file="Content/Items/Door/DoorBreak2.ogg" type="OnBroken" range="3000" />
+      <StatusEffect type="OnDamaged" target="This">
+        <sound file="Content/Items/Door/DoorBreak1.ogg" selectionmode="Random" range="800" />
+        <sound file="Content/Items/Door/DoorBreak2.ogg" range="800" />
+      </StatusEffect>
+    </Door>
+    <trigger x="-60" y="-140" width="170" height="85" />
+    <AiTarget sightrange="1500.0" static="True"/>
+    <Repairable selectkey="Action" header="mechanicalrepairsheader" fixDurationHighSkill="10" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI" />
+      <RequiredSkill identifier="mechanical" level="40" />
+      <RequiredItem items="wrench" type="equipped" />
+    </Repairable>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+      <output name="state_out" displayname="connection.stateout" fallbackdisplayname="connection.signalout"/>
+      <output name="condition_out" displayname="connection.conditionout" />
+      <output name="activate_out" displayname="connection.activateout" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" identifier="hatchwbuttons" allowedlinks="gap,hull,structure,item" linkable="true" tags="door,weldable" scale="0.5" health="100" requirebodyinsidetrigger="false" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" ondamagedthreshold="2" allowrotatingineditor="false">
+    <Upgrade gameversion="0.9.7.0" spritedepth="0.7"/>
+    <Sprite texture="hatch.png" sourcerect="0,0,256,98" depth="0.7" origin="0.5,0.5" />
+    <DecorativeSprite texture="hatch.png" sourcerect="0,234,256,193" depth="0.89" origin="0.5,0.5"/>
+    <Door canbeselected="true" canbepicked="true" horizontal="true" pickkey="Action" msg="ItemMsgOpen" PickingTime="7.5" shadowscale="1,0.8" hasintegratedbuttons="true">
+      <Upgrade gameversion="0.22.0.0" PickingTime="7.5" />
+      <RequiredItem items="crowbar" type="Equipped" optional="true"/>
+      <Requireditem items="idcard" type="Picked" optional="true"/>
+      <Sprite texture="hatch.png" sourcerect="256,0,256,38" depth="0.05" origin="0.0,0.5" />
+      <WeldedSprite texture="hatch.png" sourcerect="0,100,227,75" depth="0.0" origin="0.5,0.5" />
+      <BrokenSprite texture="hatch.png" sourcerect="256,45,256,114" depth="0.509" origin="0.0,0.5" scale="true" />
+      <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door3.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door4.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Tools/Crowbar.ogg" type="OnPicked" range="2000.0" onlyinsamesub="true" />
+      <sound file="Content/Items/Door/Duct1.ogg" type="OnFailure" selectionmode="Random" range="300" />
+      <sound file="Content/Items/Door/Duct2.ogg" type="OnFailure" range="300" />
+      <sound file="Content/Items/Door/DoorBreak1.ogg" type="OnBroken" selectionmode="Random" range="2000" />
+      <sound file="Content/Items/Door/DoorBreak2.ogg" type="OnBroken" range="2000" />
+      <StatusEffect type="OnDamaged" target="This">
+        <sound file="Content/Items/Door/DoorBreak1.ogg" selectionmode="Random" range="800" />
+        <sound file="Content/Items/Door/DoorBreak2.ogg" range="800" />
+      </StatusEffect>
+    </Door>
+    <trigger x="170" y="51" width="70" height="200" />
+    <AiTarget sightrange="1500.0" static="True"/>
+    <Repairable selectkey="Action" header="mechanicalrepairsheader" fixDurationHighSkill="10" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI" />
+      <RequiredSkill identifier="mechanical" level="40" />
+      <RequiredItem items="wrench" type="equipped" />
+    </Repairable>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+      <output name="state_out" displayname="connection.stateout" fallbackdisplayname="connection.signalout"/>
+      <output name="condition_out" displayname="connection.conditionout" />
+      <output name="activate_out" displayname="connection.activateout" />
+    </ConnectionPanel>
+  </Item>
+
+  <Item name="" identifier="dockingport" tags="dock" linkable="true" indestructible="true" scale="0.5" requirecursorinsidetrigger="true" requirebodyinsidetrigger="false">
+    <Upgrade gameversion="0.10.0.0" scale="*0.5"/>
+    <Sprite texture="dockingport.png" sourcerect="0,0,226,418" depth="0.94" origin="0.5,0.5" />
+    <trigger x="0" y="0" width="226" height="60" />
+    <trigger x="0" y="-358" width="226" height="60" />
+    <DockingPort IsHorizontal="true" DistanceTolerance="200,64" DockedDistance="172">
+      <StatusEffect type="OnSecondaryUse" target="This">
+        <sound file="Content/Items/Door/DockingPort2.ogg" type="OnSecondaryUse" range="15000.0" />
+      </StatusEffect>
+      <StatusEffect type="OnUse" target="This">
+        <Explosion range="5000.0" camerashake="5"
+           stun="0" force="0.0" flames="false" shockwave="false" sparks="true" underwaterbubble="false" />
+        <sound file="Content/Items/Door/DockingPort1.ogg" type="OnUse" range="15000.0" />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="This">
+        <sound file="Content/Items/Door/DoorBreak2.ogg" range="3000" />
+      </StatusEffect>
+    </DockingPort>
+    <PowerTransfer CanBeOverloaded="false" FireProbability="0.0" />
+    <Wire />
+    <LightComponent range="10.0" lightcolor="255,0,0,0" scale="2.0" alphablend="false" powerconsumption="0" IsOn="false" castshadows="false" allowingameediting="false">
+      <Upgrade gameversion="0.9.9000.0" lightcolor="255,0,0,0"/>
+      <IsActive targetitemcomponent="DockingPort" docked="false" />
+      <Sprite texture="Content/Items/Door/dockingportlights.png" sourcerect="0,0,113,209" depth="0.9" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+    <LightComponent range="10.0" lightcolor="0,255,0,0" scale="2.0" alphablend="false" powerconsumption="0" IsOn="false" castshadows="false" allowingameediting="false">
+      <Upgrade gameversion="0.9.9000.0" lightcolor="0,255,0,0"/>
+      <IsActive targetitemcomponent="DockingPort" docked="true" />
+      <Sprite texture="Content/Items/Door/dockingportlights.png" sourcerect="0,0,113,209" depth="0.9" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem identifier="screwdriver" type="Equipped" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+      <output name="power" displayname="connection.power" maxwires="6" maxplayerconnectablewires="5"/>
+      <output name="state_out" displayname="connection.stateout" fallbackdisplayname="connection.signalout"/>
+      <output name="proximity_sensor" displayname="connection.dockingproximitysensor" fallbackdisplayname="label.readytodock"/>
+    </ConnectionPanel>
+  </Item>
+  <Item name="" identifier="dockinghatch" tags="dock" linkable="true" scale="0.5" indestructible="true" requirecursorinsidetrigger="true" requirebodyinsidetrigger="false">
+    <Upgrade gameversion="0.10.0.0" scale="*0.5"/>
+    <Sprite texture="dockingport.png" sourcerect="252,4,256,224" depth="0.94" origin="0.5,0.5" />
+    <trigger x="0" y="0" width="60" height="224" />
+    <trigger x="196" y="0" width="60" height="224" />
+    <DockingPort IsHorizontal="false" DistanceTolerance="64,200" DockedDistance="172">
+      <StatusEffect type="OnSecondaryUse" target="This">
+        <sound file="Content/Items/Door/DockingPort2.ogg" type="OnSecondaryUse" range="15000.0" />
+      </StatusEffect>
+      <StatusEffect type="OnUse" target="This">
+        <Explosion range="5000.0" camerashake="5"
+           stun="0" force="0.0" flames="false" shockwave="false" sparks="true" underwaterbubble="false" />
+        <sound file="Content/Items/Door/DockingPort1.ogg" type="OnUse" range="15000.0" />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="This">
+        <sound file="Content/Items/Door/DoorBreak2.ogg" range="2000" />
+      </StatusEffect>
+    </DockingPort>
+    <PowerTransfer CanBeOverloaded="false" FireProbability="0.0" />
+    <Wire />
+    <LightComponent range="10.0" lightcolor="255,0,0,0" scale="2.0" alphablend="false" powerconsumption="0" IsOn="false" castshadows="false" allowingameediting="false">
+      <Upgrade gameversion="0.9.9000.0" lightcolor="255,0,0,0"/>
+      <IsActive targetitemcomponent="DockingPort" docked="false" />
+      <Sprite texture="Content/Items/Door/dockingportlights.png" sourcerect="126,2,128,112" depth="0.9" origin="0.5,0.5" alpha="1.0"  />
+    </LightComponent>
+    <LightComponent range="10.0" lightcolor="0,255,0,0" scale="2.0" alphablend="false" powerconsumption="0" IsOn="false" castshadows="false" allowingameediting="false">
+      <Upgrade gameversion="0.9.9000.0" lightcolor="0,255,0,0"/>
+      <IsActive targetitemcomponent="DockingPort" docked="true" />
+      <Sprite texture="Content/Items/Door/dockingportlights.png" sourcerect="126,2,128,112" depth="0.9" origin="0.5,0.5" alpha="1.0"  />
+    </LightComponent>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+      <output name="power" displayname="connection.power" maxwires="6" maxplayerconnectablewires="5"/>
+      <output name="state_out" displayname="connection.stateout" fallbackdisplayname="connection.signalout"/>
+      <output name="proximity_sensor" displayname="connection.dockingproximitysensor" fallbackdisplayname="label.readytodock"/>
+    </ConnectionPanel>
+  </Item>
+  <Item name="" identifier="ductblock" tags="ductblock,weldable" scale="0.5" showinstatusmonitor="false" damagedbyrepairtools="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" allowrotatingineditor="false">
+    <Upgrade gameversion="0.10.5.0">
+      <Repairable>
+        <RequiredItem items="wrench" type="equipped" />
+      </Repairable>
+    </Upgrade>
+    <Sprite texture="door.png" sourcerect="37,430,64,64" depth="0.01" origin="0.5,0.5" />
+    <DecorativeSprite texture="door.png" sourcerect="176,469,31,31" depth="0.06" origin="0.5,0.5"/>
+    <Door canbeselected="true" horizontal="true" canbepicked="true" pickkey="Action" impassable="true" msg="ItemMsgForceOpenCrowbar" PickingTime="3.0" autoorientgap="true">
+      <RequiredItem items="crowbar" type="Equipped" />
+      <Sprite texture="door.png" sourcerect="313,430,64,64" depth="0.05" origin="0.0,0.5" />
+      <WeldedSprite texture="door.png" sourcerect="103,430,65,65" depth="0.0" origin="0.5,0.5" />
+      <BrokenSprite texture="door.png" sourcerect="215,412,93,93" depth="0.0" origin="0.15,0.5" scale="false" />
+      <sound file="Content/Items/Door/Duct1.ogg" type="OnUse" selectionmode="Random" range="300" />
+      <sound file="Content/Items/Door/Duct2.ogg" type="OnUse" range="300" />
+      <sound file="Content/Items/Tools/Crowbar.ogg" type="OnPicked" range="500.0" />
+      <sound file="Content/Items/Door/DuctBreak.ogg" type="OnBroken" range="1000" />
+    </Door>
+    <Repairable selectkey="Action" header="mechanicalrepairsheader" fixDurationHighSkill="10" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI" />
+      <RequiredSkill identifier="mechanical" level="40" />
+      <RequiredItem items="wrench" type="equipped" />
+    </Repairable>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+      <output name="state_out" displayname="connection.stateout" fallbackdisplayname="connection.signalout"/>
+    </ConnectionPanel>
+  </Item>
+</Items>

--- a/wreckeditems.xml
+++ b/wreckeditems.xml
@@ -1,0 +1,703 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Items>
+  <Item name="" identifier="reactor1wrecked" nameidentifier="reactor1" variantof="reactor1" category="Wrecked" condition="0" spritecolor="200,150,100,255">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
+    <Repairable>
+      <!-- don't emit particles unless repaired above 0 condition -->
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+    </Repairable>
+  </Item>
+  <Item name="" identifier="railgunwrecked" nameidentifier="railgun" variantof="railgun" category="Wrecked" condition="0" scale="1.0">
+    <Upgrade gameversion="0.20.6.0" scale="1.0" condition="0" refreshrect="true" barrelpos="126,89" />
+    <!-- remove SwappableItem element (can't be swapped with normal turrets) -->
+    <SwappableItem />
+    <Sprite texture="Content/Items/Shipwrecks/TurretsWrecked.png" sourcerect="0,256,256,256"/>
+    <Turret targetcharacters="false" targetsubmarines="true" randommovement="true" targetitems="false" randomaimmaxtime="3" randomaimmintime="1" randomaimamount="60" aimdelay="true" barrelpos="126,89">
+      <RailSprite texture="Content/Items/Shipwrecks/TurretsWrecked.png" sourcerect="716,0,167,228" />
+      <BarrelSprite texture="Content/Items/Shipwrecks/TurretsWrecked.png" sourcerect="578,8,129,284" />
+    </Turret>
+  </Item>
+  <Item name="" identifier="periscopewrecked" nameidentifier="periscope" variantof="periscope" category="Wrecked" condition="1">
+    <Upgrade gameversion="0.20.8.0" scale="0.5" condition="1" />
+    <Sprite texture="Content/Items/Shipwrecks/TurretsWrecked.png" sourcerect="888,1,134,203" />
+  </Item>
+  <Item name="" identifier="railgunloaderwrecked" nameidentifier="railgunloader" variantof="railgunloader" category="Wrecked" condition="0">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" />
+    <Sprite texture="Content/Items/Shipwrecks/TurretsWrecked.png" sourcerect="719,231,298,276" />
+    <Repairable>
+      <!-- don't emit particles unless repaired above 0 condition -->
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+    </Repairable>
+  </Item>
+  <Item name="" identifier="railgunloadersingleverticalwrecked" nameidentifier="railgunloadersinglevertical" variantof="railgunloadersinglevertical" category="Wrecked" condition="0" spritecolor="200,150,100,255">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
+  </Item>
+  <Item name="" identifier="railgunloadersinglehorizontalwrecked" nameidentifier="railgunloadersinglehorizontal" variantof="railgunloadersinglehorizontal" category="Wrecked" condition="0" spritecolor="200,150,100,255">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
+  </Item>
+  <Item name="" identifier="coilgunwrecked" nameidentifier="coilgun" variantof="coilgun" category="Wrecked" condition="0">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" />
+    <!-- remove SwappableItem element (can't be swapped with normal turrets) -->
+    <SwappableItem />
+    <Sprite texture="Content/Items/Shipwrecks/TurretsWrecked.png" sourcerect="0,0,256,256" />
+    <Turret targetcharacters="true" targetmonsters="false" targetsubmarines="false" targetitems="false" randommovement="true" randomaimmaxtime="3" randomaimmintime="1" randomaimamount="60" aimdelay="true">
+      <RailSprite texture="Content/Items/Shipwrecks/TurretsWrecked.png" sourcerect="405,16,120,287" />
+      <BarrelSprite texture="Content/Items/Shipwrecks/TurretsWrecked.png" sourcerect="261,8,125,333" />
+    </Turret>
+  </Item>
+  <Item name="" identifier="coilgunloaderwrecked" nameidentifier="coilgunloader" variantof="coilgunloader" category="Wrecked" condition="0">
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="778,1676,149,368" />
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" />
+    <Repairable>
+      <!-- don't emit particles unless repaired above 0 condition -->
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+    </Repairable>
+  </Item>
+  <Item name="" identifier="oxygeneratorwrecked" nameidentifier="oxygenerator" variantof="oxygenerator" category="Wrecked" condition="0" spritecolor="200,150,100,255">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
+    <Repairable>
+      <!-- don't emit particles unless repaired above 0 condition -->
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+    </Repairable>
+  </Item>
+  <Item name="" identifier="shuttleoxygeneratorwrecked" nameidentifier="shuttleoxygenerator" variantof="shuttleoxygenerator" category="Wrecked" condition="0" spritecolor="200,150,100,255">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
+    <Repairable>
+      <!-- don't emit particles unless repaired above 0 condition -->
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+    </Repairable>
+  </Item>
+  <Item name="" identifier="ventwrecked" nameidentifier="vent" variantof="vent" category="Wrecked" condition="0">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="100,75,50,255" />
+    <Sprite name="Vent (Wrecked)" texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1902,363,143,143" />
+  </Item>
+  <Item name="" identifier="ladderwrecked" nameidentifier="ladder" variantof="ladder" category="Wrecked" condition="0">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="981,1600,22,240" />
+    <Ladder>
+      <BackgroundSprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="955,1600,26,240" />
+    </Ladder>
+  </Item>
+  <Item name="" identifier="fabricatorwrecked" nameidentifier="fabricator" category="Wrecked" variantof="fabricator" condition="0" spritecolor="250,200,150,256">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
+    <Repairable>
+      <!-- don't emit particles unless repaired above 0 condition -->
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+    </Repairable>
+  </Item>
+  <Item name="" identifier="medicalfabricatorwrecked" nameidentifier="medicalfabricator" category="Wrecked" variantof="medicalfabricator" condition="0" spritecolor="250,200,150,256">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
+    <Repairable>
+      <!-- don't emit particles unless repaired above 0 condition -->
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+    </Repairable>
+  </Item>
+  <Item name="" identifier="deconstructorwrecked" nameidentifier="deconstructor" category="Wrecked" variantof="deconstructor" condition="0" spritecolor="250,200,150,256">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
+    <Repairable>
+      <!-- don't emit particles unless repaired above 0 condition -->
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+    </Repairable>
+  </Item>
+  <Item name="" identifier="enginewrecked" nameidentifier="engine" category="Wrecked" variantof="engine" condition="0" spritecolor="250,200,150,256">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
+    <Repairable>
+      <!-- don't emit particles unless repaired above 0 condition -->
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+    </Repairable>
+  </Item>
+  <Item name="" identifier="largeenginewrecked" nameidentifier="largeengine" category="Wrecked" variantof="largeengine" condition="0" spritecolor="250,200,150,256">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
+    <Repairable>
+      <!-- don't emit particles unless repaired above 0 condition -->
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+    </Repairable>
+  </Item>
+  <Item name="" identifier="shuttleenginewrecked" nameidentifier="shuttleengine" category="Wrecked" variantof="shuttleengine" condition="0" spritecolor="250,200,150,256">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
+    <Repairable>
+      <!-- don't emit particles unless repaired above 0 condition -->
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+    </Repairable>
+  </Item>
+  <Item name="" identifier="doorwrecked" nameidentifier="door" tags="door" scale="0.5" health="75" category="Wrecked" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" ondamagedthreshold="10">
+    <Sprite name="doorwrecked.background" texture="MiscWrecked.png" sourcerect="1790,1236,49,416" depth="0.51" origin="0.5,0.5" />
+    <DecorativeSprite texture="MiscWrecked.png" sourcerect="1841,1236,44,417" depth="0.89" origin="0.5,0.5" />
+    <Door canbeselected="true" canbepicked="true" pickkey="Action" msg="ItemMsgForceOpenCrowbar" PickingTime="6.0" shadowscale="0.7,1">
+      <Upgrade gameversion="0.22.0.0" PickingTime="6.0" />
+      <RequiredItem items="crowbar" type="Equipped" />
+      <Sprite name="doorwrecked.door" texture="MiscWrecked.png" sourcerect="1936,1025,42,416" depth="0.05" origin="0.5,0" />
+      <WeldedSprite name="doorwrecked.welded" texture="MiscWrecked.png" sourcerect="957,1,65,377" depth="0.0" origin="0.5,0.5" />
+      <BrokenSprite name="doorwrecked.broken" texture="Content/Items/Door/door.png" sourcerect="271,0,121,416" depth="0.509" origin="0.5,0.0" scale="true" />
+      <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door3.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door4.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Tools/Crowbar.ogg" type="OnPicked" range="2000.0" onlyinsamesub="true" />
+      <sound file="Content/Items/Door/Duct1.ogg" type="OnFailure" selectionmode="Random" range="300" />
+      <sound file="Content/Items/Door/Duct2.ogg" type="OnFailure" range="300" />
+      <sound file="Content/Items/Door/DoorBreak1.ogg" type="OnBroken" selectionmode="Random" range="2000" />
+      <sound file="Content/Items/Door/DoorBreak2.ogg" type="OnBroken" range="2000" />
+      <StatusEffect type="OnDamaged" target="This">
+        <sound file="Content/Items/Door/DoorBreak1.ogg" selectionmode="Random" range="800" />
+        <sound file="Content/Items/Door/DoorBreak2.ogg" range="800" />
+      </StatusEffect>    
+    </Door>
+    <AiTarget sightrange="3000.0" static="True" />
+    <Repairable selectkey="Action" header="mechanicalrepairsheader" fixDurationHighSkill="10" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI" />
+      <RequiredSkill identifier="mechanical" level="40" />
+      <RequiredItem items="wrench" type="equipped" />
+    </Repairable>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+      <output name="state_out" displayname="connection.stateout" fallbackdisplayname="connection.signalout" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" identifier="windoweddoorwrecked" nameidentifier="windoweddoor" tags="door" scale="0.5" health="75" category="Wrecked" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" ondamagedthreshold="10">
+    <Sprite name="windoweddoorwrecked.background" texture="MiscWrecked.png" sourcerect="1789,1236,49,416" depth="0.51" origin="0.5,0.5" />
+    <DecorativeSprite texture="MiscWrecked.png" sourcerect="1840,1236,46,417" depth="0.89" origin="0.5,0.5" />
+    <Door window="0,-76,50,153" canbepicked="true" canbeselected="true" pickkey="Action" msg="ItemMsgForceOpenCrowbar" PickingTime="6.0" shadowscale="0.7,1">
+      <Upgrade gameversion="0.22.0.0" PickingTime="6.0" />
+      <RequiredItem items="crowbar" type="Equipped" />
+      <Sprite name="windoweddoorwrecked.door" texture="MiscWrecked.png" sourcerect="1885,1025,50,416" depth="0.05" origin="0.5,0" />
+      <WeldedSprite name="windoweddoorwrecked.welded" texture="MiscWrecked.png" sourcerect="957,1,65,377" depth="0.0" origin="0.5,0.5" />
+      <BrokenSprite name="doorwrecked.broken" texture="Content/Items/Door/door.png" sourcerect="392,0,120,416" depth="0.509" origin="0.5,0.0" scale="true" />
+      <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door3.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door4.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Tools/Crowbar.ogg" type="OnPicked" range="2000.0" onlyinsamesub="true" />
+      <sound file="Content/Items/Door/Duct1.ogg" type="OnFailure" selectionmode="Random" range="300" />
+      <sound file="Content/Items/Door/Duct2.ogg" type="OnFailure" range="300" />
+      <sound file="Content/Items/Door/DoorBreak1.ogg" type="OnBroken" selectionmode="Random" range="2000" />
+      <sound file="Content/Items/Door/DoorBreak2.ogg" type="OnBroken" range="2000" />
+      <StatusEffect type="OnDamaged" target="This">
+        <sound file="Content/Items/Door/DoorBreak1.ogg" selectionmode="Random" range="800" />
+        <sound file="Content/Items/Door/DoorBreak2.ogg" range="800" />
+      </StatusEffect>
+    </Door>
+    <AiTarget sightrange="3000.0" static="True" />
+    <Repairable selectkey="Action" header="mechanicalrepairsheader" fixDurationHighSkill="10" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI" />
+      <RequiredSkill identifier="mechanical" level="40" />
+      <RequiredItem items="wrench" type="equipped" />
+    </Repairable>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+      <output name="state_out" displayname="connection.stateout" fallbackdisplayname="connection.signalout" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" identifier="hatchwrecked" nameidentifier="hatch" allowedlinks="gap, hull" tags="door" scale="0.5" health="75" category="Wrecked" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" ondamagedthreshold="10">
+    <Sprite name="hatchwrecked.background" texture="MiscWrecked.png" sourcerect="1234,1815,256,98" depth="0.7" origin="0.5,0.5" />
+    <Door canbeselected="true" canbepicked="true" horizontal="true" pickkey="Action" msg="ItemMsgForceOpenCrowbar" PickingTime="6.0" shadowscale="1,0.8">
+      <Upgrade gameversion="0.22.0.0" PickingTime="6.0" />
+      <RequiredItem items="crowbar" type="Equipped" />
+      <Sprite name="hatchwrecked.door" texture="MiscWrecked.png" sourcerect="1775,1883,256,38" depth="0.05" origin="0,0.5" />
+      <WeldedSprite name="hatchwrecked.welded" texture="MiscWrecked.png" sourcerect="1233,1915,227,75" depth="0.0" origin="0.5,0.5" />
+      <BrokenSprite name="hatchwrecked.broken" texture="MiscWrecked.png" sourcerect="1775,1927,256,114" depth="0.051" origin="0,0.5" scale="true" />
+      <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door3.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door4.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Tools/Crowbar.ogg" type="OnPicked" range="2000.0" onlyinsamesub="true" />
+      <sound file="Content/Items/Door/Duct1.ogg" type="OnFailure" selectionmode="Random" range="300" />
+      <sound file="Content/Items/Door/Duct2.ogg" type="OnFailure" range="300" />
+      <sound file="Content/Items/Door/DoorBreak1.ogg" type="OnBroken" selectionmode="Random" range="2000" />
+      <sound file="Content/Items/Door/DoorBreak2.ogg" type="OnBroken" range="2000" />
+      <StatusEffect type="OnDamaged" target="This">
+        <sound file="Content/Items/Door/DoorBreak1.ogg" selectionmode="Random" range="800" />
+        <sound file="Content/Items/Door/DoorBreak2.ogg" range="800" />
+      </StatusEffect>
+    </Door>
+    <AiTarget sightrange="1500.0" static="True" />
+    <Repairable selectkey="Action" header="mechanicalrepairsheader" fixDurationHighSkill="10" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI" />
+      <RequiredSkill identifier="mechanical" level="40" />
+      <RequiredItem items="wrench" type="equipped" />
+    </Repairable>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+      <output name="state_out" displayname="connection.stateout" fallbackdisplayname="connection.signalout" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" identifier="doorwbuttonswrecked" nameidentifier="doorwbuttons" tags="door" scale="0.5" health="75" requirebodyinsidetrigger="false" category="Wrecked" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" ondamagedthreshold="10">
+    <Sprite name="doorwbuttonswrecked.background" texture="MiscWrecked.png" sourcerect="1789,1236,49,416" depth="0.51" origin="0.5,0.5" />
+    <DecorativeSprite texture="MiscWrecked.png" sourcerect="1884,1452,164,416" depth="0.89" origin="0.5,0.5" />
+    <Door canbeselected="true" canbepicked="true" pickkey="Action" msg="ItemMsgForceOpenCrowbar" PickingTime="6.0" shadowscale="0.7,1" hasintegratedbuttons="true">
+      <Upgrade gameversion="0.22.0.0" PickingTime="6.0" />
+      <RequiredItem items="crowbar" type="Equipped" optional="true" />
+      <Requireditem items="idcard" type="Picked" optional="true" msg="itemmsgunauthorizedaccess" />
+      <Sprite name="doorwbuttonswrecked.door" texture="MiscWrecked.png" sourcerect="1936,1025,42,416" depth="0.05" origin="0.5,0" />
+      <BrokenSprite name="doorwrecked.broken" texture="Content/Items/Door/door.png" sourcerect="271,0,121,416" depth="0.509" origin="0.5,0.0" scale="true" />
+      <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door3.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door4.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Tools/Crowbar.ogg" type="OnPicked" range="2000.0" onlyinsamesub="true" />
+      <sound file="Content/Items/Door/Duct1.ogg" type="OnFailure" selectionmode="Random" range="300" />
+      <sound file="Content/Items/Door/Duct2.ogg" type="OnFailure" range="300" />
+      <sound file="Content/Items/Door/DoorBreak1.ogg" type="OnBroken" selectionmode="Random" range="2000" />
+      <sound file="Content/Items/Door/DoorBreak2.ogg" type="OnBroken" range="2000" />
+      <StatusEffect type="OnDamaged" target="This">
+        <sound file="Content/Items/Door/DoorBreak1.ogg" selectionmode="Random" range="800" />
+        <sound file="Content/Items/Door/DoorBreak2.ogg" range="800" />
+      </StatusEffect>
+    </Door>
+    <trigger x="-60" y="-140" width="170" height="85" />
+    <AiTarget sightrange="3000.0" static="True" />
+    <Repairable selectkey="Action" header="mechanicalrepairsheader" fixDurationHighSkill="10" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI" />
+      <RequiredSkill identifier="mechanical" level="40" />
+      <RequiredItem items="wrench" type="equipped" />
+    </Repairable>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+      <output name="state_out" displayname="connection.stateout" fallbackdisplayname="connection.signalout" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" identifier="windoweddoorwbuttonswrecked" nameidentifier="windoweddoorwbuttons" tags="door" scale="0.5" health="75" requirebodyinsidetrigger="false" category="Wrecked" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" ondamagedthreshold="10">
+    <Sprite name="windoweddoorwbuttonswrecked.background" texture="MiscWrecked.png" sourcerect="1789,1236,49,416" depth="0.51" origin="0.5,0.5" />
+    <DecorativeSprite texture="MiscWrecked.png" sourcerect="1884,1452,164,416" depth="0.89" origin="0.5,0.5" />
+    <Door window="0,-76,50,153" canbepicked="true" canbeselected="true" pickkey="Action" msg="ItemMsgForceOpenCrowbar" PickingTime="6.0" shadowscale="0.7,1" hasintegratedbuttons="true">
+      <Upgrade gameversion="0.22.0.0" PickingTime="6.0" />
+      <RequiredItem items="crowbar" type="Equipped" optional="true" />
+      <Requireditem items="idcard" type="Picked" optional="true" msg="itemmsgunauthorizedaccess" />
+      <Sprite name="windoweddoorwbuttonswrecked.door" texture="MiscWrecked.png" sourcerect="1885,1025,50,416" depth="0.05" origin="0.5,0" />
+      <BrokenSprite name="doorwrecked.broken" texture="Content/Items/Door/door.png" sourcerect="392,0,120,416" depth="0.509" origin="0.5,0.0" scale="true" />
+      <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door3.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door4.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Tools/Crowbar.ogg" type="OnPicked" range="2000.0" onlyinsamesub="true" />
+      <sound file="Content/Items/Door/Duct1.ogg" type="OnFailure" selectionmode="Random" range="300" />
+      <sound file="Content/Items/Door/Duct2.ogg" type="OnFailure" range="300" />
+      <sound file="Content/Items/Door/DoorBreak1.ogg" type="OnBroken" selectionmode="Random" range="2000" />
+      <sound file="Content/Items/Door/DoorBreak2.ogg" type="OnBroken" range="2000" />
+      <StatusEffect type="OnDamaged" target="This">
+        <sound file="Content/Items/Door/DoorBreak1.ogg" selectionmode="Random" range="800" />
+        <sound file="Content/Items/Door/DoorBreak2.ogg" range="800" />
+      </StatusEffect>
+    </Door>
+    <trigger x="-60" y="-140" width="170" height="85" />
+    <AiTarget sightrange="3000.0" static="True" />
+    <Repairable selectkey="Action" header="mechanicalrepairsheader" fixDurationHighSkill="10" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI" />
+      <RequiredSkill identifier="mechanical" level="40" />
+      <RequiredItem items="wrench" type="equipped" />
+    </Repairable>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+      <output name="state_out" displayname="connection.stateout" fallbackdisplayname="connection.signalout" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" identifier="hatchwbuttonswrecked" nameidentifier="hatchwbuttons" allowedlinks="gap, hull" tags="door" scale="0.5" health="75" requirebodyinsidetrigger="false" category="Wrecked" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" ondamagedthreshold="10">
+    <Upgrade gameversion="0.9.7.0" spritedepth="0.7" />
+    <Sprite name="hatchwbuttonswrecked.background" texture="MiscWrecked.png" sourcerect="1234,1815,256,98" depth="0.7" origin="0.5,0.5" />
+    <DecorativeSprite texture="MiscWrecked.png" sourcerect="1502,1853,256,193" depth="0.89" origin="0.5,0.5" />
+    <Door canbeselected="true" canbepicked="true" horizontal="true" pickkey="Action" msg="ItemMsgOpen" PickingTime="6.0" shadowscale="1,0.8" hasintegratedbuttons="true">
+      <Upgrade gameversion="0.22.0.0" PickingTime="6.0" />
+      <RequiredItem items="crowbar" type="Equipped" optional="true" />
+      <Requireditem items="idcard" type="Picked" optional="true" msg="itemmsgunauthorizedaccess" />
+      <Sprite name="hatchwbuttonswrecked.door" texture="MiscWrecked.png" sourcerect="1775,1883,256,38" depth="0.05" origin="0,0.5" />
+      <WeldedSprite name="hatchwbuttonswrecked.welded" texture="MiscWrecked.png" sourcerect="1233,1915,227,75" depth="0.0" origin="0.5,0.5" />
+      <BrokenSprite name="hatchwbuttonswrecked.broken" texture="MiscWrecked.png" sourcerect="1775,1927,256,114" depth="0.051" origin="0,0.5" scale="true" />
+      <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door3.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Door/Door4.ogg" type="OnUse" range="500.0" />
+      <sound file="Content/Items/Tools/Crowbar.ogg" type="OnPicked" range="2000.0" onlyinsamesub="true" />
+      <sound file="Content/Items/Door/Duct1.ogg" type="OnFailure" selectionmode="Random" range="300" />
+      <sound file="Content/Items/Door/Duct2.ogg" type="OnFailure" range="300" />
+      <sound file="Content/Items/Door/DoorBreak1.ogg" type="OnBroken" selectionmode="Random" range="2000" />
+      <sound file="Content/Items/Door/DoorBreak2.ogg" type="OnBroken" range="2000" />
+      <StatusEffect type="OnDamaged" target="This">
+        <sound file="Content/Items/Door/DoorBreak1.ogg" selectionmode="Random" range="800" />
+        <sound file="Content/Items/Door/DoorBreak2.ogg" range="800" />
+      </StatusEffect>
+    </Door>
+    <trigger x="170" y="51" width="70" height="200" />
+    <AiTarget sightrange="1500.0" static="True" />
+    <Repairable selectkey="Action" header="mechanicalrepairsheader" fixDurationHighSkill="10" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI" />
+      <RequiredSkill identifier="mechanical" level="40" />
+      <RequiredItem items="wrench" type="equipped" />
+    </Repairable>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+      <output name="state_out" displayname="connection.stateout" fallbackdisplayname="connection.signalout" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" identifier="dockingportwrecked" nameidentifier="dockingport" tags="dock" linkable="true" indestructible="true" category="Wrecked">
+    <Sprite texture="MiscWrecked.png" sourcerect="1745,1025,113,209" depth="0.94" origin="0.5,0.5" />
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem identifier="screwdriver" type="Equipped" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+      <input name="power" displayname="connection.power" />
+      <output name="state_out" displayname="connection.stateout" fallbackdisplayname="connection.signalout" />
+      <output name="proximity_sensor" displayname="connection.dockingproximitysensor" fallbackdisplayname="label.readytodock" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" identifier="dockinghatchwrecked" nameidentifier="dockinghatch" tags="dock" linkable="true" indestructible="true" category="Wrecked">
+    <Sprite texture="MiscWrecked.png" sourcerect="1595,1403,128,112" depth="0.94" origin="0.5,0.5" />
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+      <input name="power" displayname="connection.power" />
+      <output name="state_out" displayname="connection.stateout" fallbackdisplayname="connection.signalout" />
+      <output name="proximity_sensor" displayname="connection.dockingproximitysensor" fallbackdisplayname="label.readytodock" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" identifier="suppliescabinetwrecked" variantof="suppliescabinet" nameidentifier="suppliescabinet" tags="container,suppliescontainer,wrecksupplycab" category="Wrecked">
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" depth="0.84" sourcerect="1601,1519,120,132" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="mediumsteelcabinetwrecked" variantof="mediumsteelcabinet" nameidentifier="mediumsteelcabinet" tags="locker,container" category="Wrecked">
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" depth="0.84" sourcerect="1569,1026,175,374" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="mediumwindowedsteelcabinetwrecked" variantof="mediumwindowedsteelcabinet" nameidentifier="mediumwindowedsteelcabinet" tags="locker,container" category="Wrecked">
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" depth="0.84" sourcerect="1399,1024,168,377" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="steelcabinetwrecked" variantof="steelcabinet" nameidentifier="steelcabinet" tags="locker,container" category="Wrecked">
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" depth="0.84" sourcerect="1022,1025,364,373" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="securesteelcabinetwrecked" variantof="securesteelcabinet" nameidentifier="securesteelcabinet" tags="container,securecontainer" category="Wrecked">
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" depth="0.84" sourcerect="1574,1651,105,160" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="railgunshellrackwrecked" nameidentifier="railgunshellrack" variantof="railgunshellrack" tags="container,wreckrailgunammocontainer" category="Wrecked">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" />
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="936,1869,182,176" />
+    <ItemContainer capacity="4" slotsperrow="4" itempos="42,-60" iteminterval="32,0" />
+  </Item>
+  <Item name="" identifier="coilgunammoshelfwrecked" nameidentifier="coilgunammoshelf" variantof="coilgunammoshelf" tags="container,wreckammoboxcontainer" category="Wrecked" spritecolor="200,150,100,255">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1028,1407,140,306" />
+  </Item>
+  <Item name="" identifier="medcabinetwrecked" nameidentifier="medcabinet" variantof="medcabinet" category="Wrecked" scale="0.5" condition="0">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" spritecolor="200,150,100,255" />
+    <Sprite name="Medical Cabinet (Wrecked)" texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1691,10,208,346" />
+  </Item>
+  <Item name="" identifier="toxcabinetwrecked" variantof="toxcabinet" nameidentifier="toxcabinet" tags="container,wrecktoxcontainer" waterproof="true" scale="0.4" category="Wrecked">
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" depth="0.84" sourcerect="1682,1654,157,185" canflipx="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="divingsuitlockerwrecked" nameidentifier="divingsuitlocker" tags="divingsuitcontainerwindow,wreckdivingsuitcontainer" pickdistance="50" scale="0.5" category="Wrecked">
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" depth="0.84" sourcerect="1126,1710,99,254" origin="0.5,0.5" />
+    <!-- 70% opacity wrecked locker sprite on top, to make the window look more dirty when there's a suit inside -->
+    <DecorativeSprite texture="Content/Items/Shipwrecks/MiscWrecked.png" depth="0.83" sourcerect="1126,1710,99,254" origin="0.5,0.5" color="255,255,255,150" />
+    <ItemContainer hideitems="false" drawinventory="true" capacity="1" slotsperrow="1" itempos="0,0" iteminterval="0,0" canbeselected="true" msg="ItemMsgInteractSelect">
+      <GuiFrame relativesize="0.2,0.25" anchor="Center" minsize="140,170" maxsize="280,280" style="ItemUI" />
+      <SlotIcon slotindex="0" texture="Content/Map/LabelIcons.png" sourcerect="512,0,256,256" origin="0.5,0.5" />
+      <Containable items="deepdiving" excludeditems="deepdivinglarge" />
+    </ItemContainer>
+  </Item>
+  <Item name="" identifier="oxygentankshelf2wrecked" nameidentifier="oxygentankshelf" tags="wreckoxygentankcontainer" pickdistance="50" scale="0.5" category="Wrecked">
+    <Sprite name="Diving Suit Locker Small" texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1126,1964,99,83" depth="0.84" origin="0.5,0.5" />
+    <ItemContainer hideitems="false" drawinventory="true" capacity="3" maxstacksize="1" slotsperrow="3" itempos="27,-42" iteminterval="22.5,0" itemrotation="0" canbeselected="true" containedspritedepth="0.83" msg="ItemMsgInteractSelect">
+      <GuiFrame relativesize="0.16,0.18" anchor="Center" style="ItemUI" />
+      <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
+      <SlotIcon slotindex="1" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
+      <SlotIcon slotindex="2" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
+      <Containable items="oxygensource,weldingfuel" />
+    </ItemContainer>
+  </Item>
+  <Item name="" identifier="extinguisherbracketwrecked" nameidentifier="extinguisherbracket" variantof="extinguisherbracket" tags="wreckextinguisherholder" spritecolor="200,150,100,255" category="Wrecked">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" spritecolor="200,150,100,255" />
+  </Item>
+  <Item name="" identifier="weaponholderwrecked" nameidentifier="weaponholder" variantof="weaponholder" tags="wreckweaponholder" scale="0.5" category="Wrecked" spritecolor="200,150,100,255">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" spritecolor="200,150,100,255" />
+  </Item>
+  <Item name="" identifier="navterminalwrecked" nameidentifier="navterminal" variantof="navterminal" category="Wrecked" condition="0" spritecolor="200,150,100,255">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
+    <Repairable>
+      <!-- don't emit particles unless repaired above 0 condition -->
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+    </Repairable>
+  </Item>
+  <Item name="" identifier="shuttlenavterminalwrecked" nameidentifier="shuttlenavterminal" variantof="shuttlenavterminal" category="Wrecked" condition="0" spritecolor="200,150,100,255">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
+    <Repairable>
+      <!-- don't emit particles unless repaired above 0 condition -->
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+    </Repairable>
+  </Item>
+  <Item name="" identifier="statusmonitorwrecked" nameidentifier="statusmonitor" variantof="statusmonitor" category="Wrecked" condition="0" spritecolor="200,150,100,255">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
+    <Repairable>
+      <!-- don't emit particles unless repaired above 0 condition -->
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+    </Repairable>
+  </Item>
+  <Item name="" identifier="sonartransducerwrecked" nameidentifier="sonartransducer" variantof="sonartransducer" category="Wrecked" condition="0" spritecolor="200,150,100,255">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
+  </Item>
+  <Item name="" identifier="junctionboxwrecked" nameidentifier="junctionbox" variantof="junctionbox" category="Wrecked" condition="0" spritecolor="200,150,100,255">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
+    <Repairable>
+      <!-- don't emit particles unless repaired above 0 condition -->
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+    </Repairable>
+  </Item>
+  <Item name="" identifier="batterywrecked" nameidentifier="battery" variantof="battery" category="Wrecked" condition="0" spritecolor="200,150,100,255">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
+    <Repairable>
+      <!-- don't emit particles unless repaired above 0 condition -->
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+    </Repairable>
+  </Item>
+  <Item name="" identifier="shuttlebatterywrecked" nameidentifier="shuttlebattery" variantof="shuttlebattery" category="Wrecked" condition="0" spritecolor="200,150,100,255">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
+  </Item>
+  <Item name="" identifier="supercapacitorwrecked" nameidentifier="supercapacitor" variantof="supercapacitor" category="Wrecked" condition="0" spritecolor="200,150,100,255">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
+    <Repairable>
+      <!-- don't emit particles unless repaired above 0 condition -->
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+      <ParticleEmitter mincondition="1.0" />
+    </Repairable>
+  </Item>
+  <Item name="" identifier="chargingdockwrecked" nameidentifier="chargingdock" variantof="chargingdock" category="Wrecked" condition="0" spritecolor="200,150,100,255">
+    <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
+  </Item>
+  <Item name="" nameidentifier="lamp" identifier="lightfluorescentm01wrecked" category="Wrecked" Tags="smallitem,light" scale="0.5">
+    <Sprite texture="MiscWrecked.png" sourcerect="1170,1402,85,124" depth="0.8" origin="0.5,0.5" />
+    <LightComponent lightcolor="1.0,1.0,1.0,0.5" range="800.0" LightSpriteScale="1.3" powerconsumption="5">
+      <LightTexture texture="Content/Lights/pointlight_bounce.png" origin="0.5,0.5" />
+      <sprite texture="Content/Items/Electricity/signalcomp.png" sourcerect="480,528,80,112" origin="0.5,0.5" />
+    </LightComponent>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="power" displayname="connection.power" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" nameidentifier="lamp" identifier="lightfluorescentm02wrecked" category="Wrecked" Tags="smallitem,light" scale="0.5">
+    <Sprite texture="MiscWrecked.png" sourcerect="1258,1401,74,126" depth="0.8" origin="0.5,0.5" />
+    <LightComponent lightcolor="1.0,1.0,1.0,0.5" range="800.0" LightSpriteScale="1.3" powerconsumption="5">
+      <LightTexture texture="Content/Lights/pointlight_bounce.png" origin="0.5,0.5" />
+      <sprite texture="Content/Items/Electricity/signalcomp.png" sourcerect="560,528,80,112" />
+    </LightComponent>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="power" displayname="connection.power" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" nameidentifier="lamp" identifier="lightfluorescentm03wrecked" category="Wrecked" Tags="smallitem,light" scale="0.5">
+    <Sprite texture="MiscWrecked.png" sourcerect="1335,1401,68,124" depth="0.8" origin="0.5,0.5" />
+    <LightComponent lightcolor="1.0,1.0,1.0,0.5" range="800.0" LightSpriteScale="1.3" powerconsumption="5">
+      <LightTexture texture="Content/Lights/pointlight_bounce.png" origin="0.5,0.5" />
+      <sprite texture="Content/Items/Electricity/signalcomp.png" sourcerect="640,528,64,112" />
+    </LightComponent>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="power" displayname="connection.power" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" nameidentifier="lamp" identifier="lightfluorescentm04wrecked" category="Wrecked" Tags="smallitem,light" scale="0.5">
+    <Sprite texture="MiscWrecked.png" sourcerect="1407,1400,85,126" depth="0.8" origin="0.5,0.5" />
+    <LightComponent lightcolor="1.0,1.0,1.0,0.5" range="800.0" LightSpriteScale="1.3" powerconsumption="5">
+      <LightTexture texture="Content/Lights/pointlight_bounce.png" origin="0.5,0.5" />
+      <sprite texture="Content/Items/Electricity/signalcomp.png" sourcerect="704,528,80,112" origin="0.5,0.5" />
+    </LightComponent>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="power" displayname="connection.power" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" nameidentifier="lamp" identifier="lightfluorescentl01wrecked" category="Wrecked" Tags="largeitem,light" scale="0.5">
+    <Sprite texture="MiscWrecked.png" sourcerect="1228,1711,346,90" depth="0.8" origin="0.5,0.5" />
+    <LightComponent lightcolor="1.0,1.0,1.0,0.5" range="800.0" LightSpriteScale="1.3" powerconsumption="5">
+      <LightTexture texture="Content/Lights/pointlight_bounce.png" origin="0.5,0.5" />
+      <sprite texture="Content/Items/Electricity/signalcomp.png" sourcerect="480,816,240,64" />
+    </LightComponent>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="power" displayname="connection.power" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" nameidentifier="lamp" identifier="lightfluorescentl02wrecked" category="Wrecked" Tags="largeitem,light" scale="0.5">
+    <Sprite texture="MiscWrecked.png" sourcerect="1169,1650,367,59" depth="0.8" origin="0.5,0.5" />
+    <LightComponent lightcolor="1.0,1.0,1.0,0.5" range="800.0" LightSpriteScale="1.3" powerconsumption="5">
+      <LightTexture texture="Content/Lights/light_fluorescent_L2.png" origin="0.5,0.5" />
+      <sprite texture="Content/Items/Electricity/signalcomp.png" sourcerect="480,896,288,48" />
+    </LightComponent>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="power" displayname="connection.power" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" nameidentifier="lamp" identifier="lighthalogenmm01wrecked" category="Wrecked" Tags="smallitem,light" scale="0.5">
+    <Sprite texture="MiscWrecked.png" sourcerect="1171,1528,76,124" depth="0.8" origin="0.5,0.5" />
+    <LightComponent lightcolor="1.0,1.0,1.0,0.5" range="800.0" LightSpriteScale="1.3" powerconsumption="5">
+      <LightTexture texture="Content/Lights/pointlight_bounce.png" origin="0.5,0.5" />
+      <sprite texture="Content/Items/Electricity/signalcomp.png" sourcerect="480,672,80,128" origin="0.5,0.5" />
+    </LightComponent>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="power" displayname="connection.power" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" nameidentifier="lamp" identifier="lighthalogenmm02wrecked" category="Wrecked" Tags="smallitem,light" scale="0.5">
+    <Sprite texture="MiscWrecked.png" sourcerect="1248,1547,124,77" depth="0.8" origin="0.5,0.5" />
+    <LightComponent lightcolor="1.0,1.0,1.0,0.5" range="800.0" LightSpriteScale="1.3" powerconsumption="5">
+      <LightTexture texture="Content/Lights/pointlight_bounce.png" origin="0.5,0.5" />
+      <sprite texture="Content/Items/Electricity/signalcomp.png" sourcerect="560,672,128,80" origin="0.5,0.5" />
+    </LightComponent>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="power" displayname="connection.power" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" nameidentifier="lamp" identifier="lighthalogenmm03wrecked" category="Wrecked" Tags="smallitem,light" scale="0.5">
+    <Sprite texture="MiscWrecked.png" sourcerect="1370,1526,103,123" depth="0.8" origin="0.5,0.5" />
+    <LightComponent lightcolor="1.0,1.0,1.0,0.5" range="800.0" LightSpriteScale="1.3" powerconsumption="5">
+      <LightTexture texture="Content/Lights/pointlight_bounce.png" origin="0.5,0.5" />
+      <sprite texture="Content/Items/Electricity/signalcomp.png" sourcerect="688,672,112,128" />
+    </LightComponent>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="power" displayname="connection.power" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" nameidentifier="lamp" identifier="lighthalogenm04wrecked" category="Wrecked" Tags="smallitem,light" scale="0.5">
+    <Sprite texture="MiscWrecked.png" sourcerect="1473,1534,124,101" depth="0.8" origin="0.5,0.5" />
+    <LightComponent lightcolor="1.0,1.0,1.0,0.5" range="800.0" LightSpriteScale="1.3" powerconsumption="5">
+      <LightTexture texture="Content/Lights/pointlight_bounce.png" origin="0.5,0.5" />
+      <sprite texture="Content/Items/Electricity/signalcomp.png" sourcerect="800,672,128,96" origin="0.5,0.5" />
+    </LightComponent>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="power" displayname="connection.power" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" nameidentifier="lamp" identifier="lightleds01wrecked" category="Wrecked" Tags="smallitem,light" scale="0.5">
+    <Sprite texture="MiscWrecked.png" sourcerect="1492,1402,99,99" depth="0.8" origin="0.5,0.5" />
+    <LightComponent lightcolor="1.0,1.0,1.0,0.5" range="800.0" LightSpriteScale="1.3" powerconsumption="5">
+      <LightTexture texture="Content/Lights/pointlight_bounce.png" origin="0.5,0.5" />
+      <sprite texture="Content/Items/Electricity/signalcomp.png" sourcerect="842,794,59,59" origin="0.5,0.5" />
+    </LightComponent>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="power" displayname="connection.power" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" identifier="bunkwrecked" nameidentifier="bunk" width="173" height="129" category="Wrecked">
+    <sprite texture="Content/Items/Shipwrecks/BackgroundStructuresWrecked.png" sourcerect="497,692,173,129" depth="0.88" origin="0.5,0.5" />
+    <Controller UserPos="0,-150" direction="Right" hidehud="false" canbeselected="true" drawuserbehind="true">
+      <limbposition limb="Head" position="-13,-85" />
+      <limbposition limb="Torso" position="42,-70" />
+      <limbposition limb="Waist" position="112,-80" />
+      <limbposition limb="RightFoot" position="222,-80" />
+      <limbposition limb="LeftFoot" position="222,-80" />
+      <limbposition limb="RightHand" position="112,-80" allowusinglimb="false" />
+      <limbposition limb="LeftHand" position="112,-80" allowusinglimb="false" />
+      <StatusEffect type="OnActive" target="Character">
+        <reduceaffliction type="damage" strength="0.05" />
+        <reduceaffliction identifier="bloodloss" strength="0.05" />
+        <reduceaffliction identifier="bleeding" strength="0.05" />
+        <reduceaffliction identifier="nausea" strength="0.05" />
+        <reduceaffliction identifier="opiatewithdrawal" strength="0.05" />
+        <reduceaffliction identifier="opiateaddiction" strength="0.05" />
+        <reduceaffliction identifier="drunk" strength="0.05" />
+      </StatusEffect>
+    </Controller>
+  </Item>
+</Items>

--- a/wreckeditems.xml
+++ b/wreckeditems.xml
@@ -152,13 +152,13 @@
     </Repairable>
   </Item>
   <Item name="" identifier="doorwrecked" nameidentifier="door" tags="door" scale="0.5" health="75" category="Wrecked" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" ondamagedthreshold="10">
-    <Sprite name="doorwrecked.background" texture="MiscWrecked.png" sourcerect="1790,1236,49,416" depth="0.51" origin="0.5,0.5" />
-    <DecorativeSprite texture="MiscWrecked.png" sourcerect="1841,1236,44,417" depth="0.89" origin="0.5,0.5" />
+    <Sprite name="doorwrecked.background" texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1790,1236,49,416" depth="0.51" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1841,1236,44,417" depth="0.61" origin="0.5,0.5" />
     <Door canbeselected="true" canbepicked="true" pickkey="Action" msg="ItemMsgForceOpenCrowbar" PickingTime="6.0" shadowscale="0.7,1">
       <Upgrade gameversion="0.22.0.0" PickingTime="6.0" />
       <RequiredItem items="crowbar" type="Equipped" />
-      <Sprite name="doorwrecked.door" texture="MiscWrecked.png" sourcerect="1936,1025,42,416" depth="0.05" origin="0.5,0" />
-      <WeldedSprite name="doorwrecked.welded" texture="MiscWrecked.png" sourcerect="957,1,65,377" depth="0.0" origin="0.5,0.5" />
+      <Sprite name="doorwrecked.door" texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1936,1025,42,416" depth="0.05" origin="0.5,0" />
+      <WeldedSprite name="doorwrecked.welded" texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="957,1,65,377" depth="0.0" origin="0.5,0.5" />
       <BrokenSprite name="doorwrecked.broken" texture="Content/Items/Door/door.png" sourcerect="271,0,121,416" depth="0.509" origin="0.5,0.0" scale="true" />
       <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
       <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
@@ -189,13 +189,13 @@
     </ConnectionPanel>
   </Item>
   <Item name="" identifier="windoweddoorwrecked" nameidentifier="windoweddoor" tags="door" scale="0.5" health="75" category="Wrecked" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" ondamagedthreshold="10">
-    <Sprite name="windoweddoorwrecked.background" texture="MiscWrecked.png" sourcerect="1789,1236,49,416" depth="0.51" origin="0.5,0.5" />
-    <DecorativeSprite texture="MiscWrecked.png" sourcerect="1840,1236,46,417" depth="0.89" origin="0.5,0.5" />
+    <Sprite name="windoweddoorwrecked.background" texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1789,1236,49,416" depth="0.51" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1840,1236,46,417" depth="0.61" origin="0.5,0.5" />
     <Door window="0,-76,50,153" canbepicked="true" canbeselected="true" pickkey="Action" msg="ItemMsgForceOpenCrowbar" PickingTime="6.0" shadowscale="0.7,1">
       <Upgrade gameversion="0.22.0.0" PickingTime="6.0" />
       <RequiredItem items="crowbar" type="Equipped" />
-      <Sprite name="windoweddoorwrecked.door" texture="MiscWrecked.png" sourcerect="1885,1025,50,416" depth="0.05" origin="0.5,0" />
-      <WeldedSprite name="windoweddoorwrecked.welded" texture="MiscWrecked.png" sourcerect="957,1,65,377" depth="0.0" origin="0.5,0.5" />
+      <Sprite name="windoweddoorwrecked.door" texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1885,1025,50,416" depth="0.05" origin="0.5,0" />
+      <WeldedSprite name="windoweddoorwrecked.welded" texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="957,1,65,377" depth="0.0" origin="0.5,0.5" />
       <BrokenSprite name="doorwrecked.broken" texture="Content/Items/Door/door.png" sourcerect="392,0,120,416" depth="0.509" origin="0.5,0.0" scale="true" />
       <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
       <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
@@ -226,13 +226,13 @@
     </ConnectionPanel>
   </Item>
   <Item name="" identifier="hatchwrecked" nameidentifier="hatch" allowedlinks="gap, hull" tags="door" scale="0.5" health="75" category="Wrecked" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" ondamagedthreshold="10">
-    <Sprite name="hatchwrecked.background" texture="MiscWrecked.png" sourcerect="1234,1815,256,98" depth="0.7" origin="0.5,0.5" />
+    <Sprite name="hatchwrecked.background" texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1234,1815,256,98" depth="0.7" origin="0.5,0.5" />
     <Door canbeselected="true" canbepicked="true" horizontal="true" pickkey="Action" msg="ItemMsgForceOpenCrowbar" PickingTime="6.0" shadowscale="1,0.8">
       <Upgrade gameversion="0.22.0.0" PickingTime="6.0" />
       <RequiredItem items="crowbar" type="Equipped" />
-      <Sprite name="hatchwrecked.door" texture="MiscWrecked.png" sourcerect="1775,1883,256,38" depth="0.05" origin="0,0.5" />
-      <WeldedSprite name="hatchwrecked.welded" texture="MiscWrecked.png" sourcerect="1233,1915,227,75" depth="0.0" origin="0.5,0.5" />
-      <BrokenSprite name="hatchwrecked.broken" texture="MiscWrecked.png" sourcerect="1775,1927,256,114" depth="0.051" origin="0,0.5" scale="true" />
+      <Sprite name="hatchwrecked.door" texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1775,1883,256,38" depth="0.05" origin="0,0.5" />
+      <WeldedSprite name="hatchwrecked.welded" texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1233,1915,227,75" depth="0.0" origin="0.5,0.5" />
+      <BrokenSprite name="hatchwrecked.broken" texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1775,1927,256,114" depth="0.051" origin="0,0.5" scale="true" />
       <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
       <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
       <sound file="Content/Items/Door/Door3.ogg" type="OnUse" range="500.0" />
@@ -262,13 +262,13 @@
     </ConnectionPanel>
   </Item>
   <Item name="" identifier="doorwbuttonswrecked" nameidentifier="doorwbuttons" tags="door" scale="0.5" health="75" requirebodyinsidetrigger="false" category="Wrecked" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" ondamagedthreshold="10">
-    <Sprite name="doorwbuttonswrecked.background" texture="MiscWrecked.png" sourcerect="1789,1236,49,416" depth="0.51" origin="0.5,0.5" />
-    <DecorativeSprite texture="MiscWrecked.png" sourcerect="1884,1452,164,416" depth="0.89" origin="0.5,0.5" />
+    <Sprite name="doorwbuttonswrecked.background" texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1789,1236,49,416" depth="0.51" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1884,1452,164,416" depth="0.61" origin="0.5,0.5" />
     <Door canbeselected="true" canbepicked="true" pickkey="Action" msg="ItemMsgForceOpenCrowbar" PickingTime="6.0" shadowscale="0.7,1" hasintegratedbuttons="true">
       <Upgrade gameversion="0.22.0.0" PickingTime="6.0" />
       <RequiredItem items="crowbar" type="Equipped" optional="true" />
       <Requireditem items="idcard" type="Picked" optional="true" msg="itemmsgunauthorizedaccess" />
-      <Sprite name="doorwbuttonswrecked.door" texture="MiscWrecked.png" sourcerect="1936,1025,42,416" depth="0.05" origin="0.5,0" />
+      <Sprite name="doorwbuttonswrecked.door" texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1936,1025,42,416" depth="0.05" origin="0.5,0" />
       <BrokenSprite name="doorwrecked.broken" texture="Content/Items/Door/door.png" sourcerect="271,0,121,416" depth="0.509" origin="0.5,0.0" scale="true" />
       <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
       <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
@@ -300,13 +300,13 @@
     </ConnectionPanel>
   </Item>
   <Item name="" identifier="windoweddoorwbuttonswrecked" nameidentifier="windoweddoorwbuttons" tags="door" scale="0.5" health="75" requirebodyinsidetrigger="false" category="Wrecked" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" ondamagedthreshold="10">
-    <Sprite name="windoweddoorwbuttonswrecked.background" texture="MiscWrecked.png" sourcerect="1789,1236,49,416" depth="0.51" origin="0.5,0.5" />
-    <DecorativeSprite texture="MiscWrecked.png" sourcerect="1884,1452,164,416" depth="0.89" origin="0.5,0.5" />
+    <Sprite name="windoweddoorwbuttonswrecked.background" texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1789,1236,49,416" depth="0.51" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1884,1452,164,416" depth="0.61" origin="0.5,0.5" />
     <Door window="0,-76,50,153" canbepicked="true" canbeselected="true" pickkey="Action" msg="ItemMsgForceOpenCrowbar" PickingTime="6.0" shadowscale="0.7,1" hasintegratedbuttons="true">
       <Upgrade gameversion="0.22.0.0" PickingTime="6.0" />
       <RequiredItem items="crowbar" type="Equipped" optional="true" />
       <Requireditem items="idcard" type="Picked" optional="true" msg="itemmsgunauthorizedaccess" />
-      <Sprite name="windoweddoorwbuttonswrecked.door" texture="MiscWrecked.png" sourcerect="1885,1025,50,416" depth="0.05" origin="0.5,0" />
+      <Sprite name="windoweddoorwbuttonswrecked.door" texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1885,1025,50,416" depth="0.05" origin="0.5,0" />
       <BrokenSprite name="doorwrecked.broken" texture="Content/Items/Door/door.png" sourcerect="392,0,120,416" depth="0.509" origin="0.5,0.0" scale="true" />
       <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
       <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
@@ -339,15 +339,15 @@
   </Item>
   <Item name="" identifier="hatchwbuttonswrecked" nameidentifier="hatchwbuttons" allowedlinks="gap, hull" tags="door" scale="0.5" health="75" requirebodyinsidetrigger="false" category="Wrecked" damagedbyrepairtools="true" damagedbymonsters="true" damagedbyprojectiles="true" damagedbymeleeweapons="true" damagedbyexplosions="true" ShowNameInHealthBar="false" explosiondamagemultiplier="0.1" ondamagedthreshold="10">
     <Upgrade gameversion="0.9.7.0" spritedepth="0.7" />
-    <Sprite name="hatchwbuttonswrecked.background" texture="MiscWrecked.png" sourcerect="1234,1815,256,98" depth="0.7" origin="0.5,0.5" />
-    <DecorativeSprite texture="MiscWrecked.png" sourcerect="1502,1853,256,193" depth="0.89" origin="0.5,0.5" />
+    <Sprite name="hatchwbuttonswrecked.background" texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1234,1815,256,98" depth="0.7" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1502,1853,256,193" depth="0.89" origin="0.5,0.5" />
     <Door canbeselected="true" canbepicked="true" horizontal="true" pickkey="Action" msg="ItemMsgOpen" PickingTime="6.0" shadowscale="1,0.8" hasintegratedbuttons="true">
       <Upgrade gameversion="0.22.0.0" PickingTime="6.0" />
       <RequiredItem items="crowbar" type="Equipped" optional="true" />
       <Requireditem items="idcard" type="Picked" optional="true" msg="itemmsgunauthorizedaccess" />
-      <Sprite name="hatchwbuttonswrecked.door" texture="MiscWrecked.png" sourcerect="1775,1883,256,38" depth="0.05" origin="0,0.5" />
-      <WeldedSprite name="hatchwbuttonswrecked.welded" texture="MiscWrecked.png" sourcerect="1233,1915,227,75" depth="0.0" origin="0.5,0.5" />
-      <BrokenSprite name="hatchwbuttonswrecked.broken" texture="MiscWrecked.png" sourcerect="1775,1927,256,114" depth="0.051" origin="0,0.5" scale="true" />
+      <Sprite name="hatchwbuttonswrecked.door" texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1775,1883,256,38" depth="0.05" origin="0,0.5" />
+      <WeldedSprite name="hatchwbuttonswrecked.welded" texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1233,1915,227,75" depth="0.0" origin="0.5,0.5" />
+      <BrokenSprite name="hatchwbuttonswrecked.broken" texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1775,1927,256,114" depth="0.051" origin="0,0.5" scale="true" />
       <sound file="Content/Items/Door/Door1.ogg" type="OnUse" range="500.0" />
       <sound file="Content/Items/Door/Door2.ogg" type="OnUse" range="500.0" />
       <sound file="Content/Items/Door/Door3.ogg" type="OnUse" range="500.0" />
@@ -378,7 +378,7 @@
     </ConnectionPanel>
   </Item>
   <Item name="" identifier="dockingportwrecked" nameidentifier="dockingport" tags="dock" linkable="true" indestructible="true" category="Wrecked">
-    <Sprite texture="MiscWrecked.png" sourcerect="1745,1025,113,209" depth="0.94" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1745,1025,113,209" depth="0.94" origin="0.5,0.5" />
     <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
       <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
       <RequiredItem identifier="screwdriver" type="Equipped" />
@@ -390,7 +390,7 @@
     </ConnectionPanel>
   </Item>
   <Item name="" identifier="dockinghatchwrecked" nameidentifier="dockinghatch" tags="dock" linkable="true" indestructible="true" category="Wrecked">
-    <Sprite texture="MiscWrecked.png" sourcerect="1595,1403,128,112" depth="0.94" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1595,1403,128,112" depth="0.94" origin="0.5,0.5" />
     <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
       <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
       <RequiredItem items="screwdriver" type="Equipped" />
@@ -526,7 +526,7 @@
     <Upgrade gameversion="0.20.4.0" scale="0.5" condition="0" spritecolor="200,150,100,255" />
   </Item>
   <Item name="" nameidentifier="lamp" identifier="lightfluorescentm01wrecked" category="Wrecked" Tags="smallitem,light" scale="0.5">
-    <Sprite texture="MiscWrecked.png" sourcerect="1170,1402,85,124" depth="0.8" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1170,1402,85,124" depth="0.8" origin="0.5,0.5" />
     <LightComponent lightcolor="1.0,1.0,1.0,0.5" range="800.0" LightSpriteScale="1.3" powerconsumption="5">
       <LightTexture texture="Content/Lights/pointlight_bounce.png" origin="0.5,0.5" />
       <sprite texture="Content/Items/Electricity/signalcomp.png" sourcerect="480,528,80,112" origin="0.5,0.5" />
@@ -540,7 +540,7 @@
     </ConnectionPanel>
   </Item>
   <Item name="" nameidentifier="lamp" identifier="lightfluorescentm02wrecked" category="Wrecked" Tags="smallitem,light" scale="0.5">
-    <Sprite texture="MiscWrecked.png" sourcerect="1258,1401,74,126" depth="0.8" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1258,1401,74,126" depth="0.8" origin="0.5,0.5" />
     <LightComponent lightcolor="1.0,1.0,1.0,0.5" range="800.0" LightSpriteScale="1.3" powerconsumption="5">
       <LightTexture texture="Content/Lights/pointlight_bounce.png" origin="0.5,0.5" />
       <sprite texture="Content/Items/Electricity/signalcomp.png" sourcerect="560,528,80,112" />
@@ -554,7 +554,7 @@
     </ConnectionPanel>
   </Item>
   <Item name="" nameidentifier="lamp" identifier="lightfluorescentm03wrecked" category="Wrecked" Tags="smallitem,light" scale="0.5">
-    <Sprite texture="MiscWrecked.png" sourcerect="1335,1401,68,124" depth="0.8" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1335,1401,68,124" depth="0.8" origin="0.5,0.5" />
     <LightComponent lightcolor="1.0,1.0,1.0,0.5" range="800.0" LightSpriteScale="1.3" powerconsumption="5">
       <LightTexture texture="Content/Lights/pointlight_bounce.png" origin="0.5,0.5" />
       <sprite texture="Content/Items/Electricity/signalcomp.png" sourcerect="640,528,64,112" />
@@ -568,7 +568,7 @@
     </ConnectionPanel>
   </Item>
   <Item name="" nameidentifier="lamp" identifier="lightfluorescentm04wrecked" category="Wrecked" Tags="smallitem,light" scale="0.5">
-    <Sprite texture="MiscWrecked.png" sourcerect="1407,1400,85,126" depth="0.8" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1407,1400,85,126" depth="0.8" origin="0.5,0.5" />
     <LightComponent lightcolor="1.0,1.0,1.0,0.5" range="800.0" LightSpriteScale="1.3" powerconsumption="5">
       <LightTexture texture="Content/Lights/pointlight_bounce.png" origin="0.5,0.5" />
       <sprite texture="Content/Items/Electricity/signalcomp.png" sourcerect="704,528,80,112" origin="0.5,0.5" />
@@ -582,7 +582,7 @@
     </ConnectionPanel>
   </Item>
   <Item name="" nameidentifier="lamp" identifier="lightfluorescentl01wrecked" category="Wrecked" Tags="largeitem,light" scale="0.5">
-    <Sprite texture="MiscWrecked.png" sourcerect="1228,1711,346,90" depth="0.8" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1228,1711,346,90" depth="0.8" origin="0.5,0.5" />
     <LightComponent lightcolor="1.0,1.0,1.0,0.5" range="800.0" LightSpriteScale="1.3" powerconsumption="5">
       <LightTexture texture="Content/Lights/pointlight_bounce.png" origin="0.5,0.5" />
       <sprite texture="Content/Items/Electricity/signalcomp.png" sourcerect="480,816,240,64" />
@@ -596,7 +596,7 @@
     </ConnectionPanel>
   </Item>
   <Item name="" nameidentifier="lamp" identifier="lightfluorescentl02wrecked" category="Wrecked" Tags="largeitem,light" scale="0.5">
-    <Sprite texture="MiscWrecked.png" sourcerect="1169,1650,367,59" depth="0.8" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1169,1650,367,59" depth="0.8" origin="0.5,0.5" />
     <LightComponent lightcolor="1.0,1.0,1.0,0.5" range="800.0" LightSpriteScale="1.3" powerconsumption="5">
       <LightTexture texture="Content/Lights/light_fluorescent_L2.png" origin="0.5,0.5" />
       <sprite texture="Content/Items/Electricity/signalcomp.png" sourcerect="480,896,288,48" />
@@ -610,7 +610,7 @@
     </ConnectionPanel>
   </Item>
   <Item name="" nameidentifier="lamp" identifier="lighthalogenmm01wrecked" category="Wrecked" Tags="smallitem,light" scale="0.5">
-    <Sprite texture="MiscWrecked.png" sourcerect="1171,1528,76,124" depth="0.8" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1171,1528,76,124" depth="0.8" origin="0.5,0.5" />
     <LightComponent lightcolor="1.0,1.0,1.0,0.5" range="800.0" LightSpriteScale="1.3" powerconsumption="5">
       <LightTexture texture="Content/Lights/pointlight_bounce.png" origin="0.5,0.5" />
       <sprite texture="Content/Items/Electricity/signalcomp.png" sourcerect="480,672,80,128" origin="0.5,0.5" />
@@ -624,7 +624,7 @@
     </ConnectionPanel>
   </Item>
   <Item name="" nameidentifier="lamp" identifier="lighthalogenmm02wrecked" category="Wrecked" Tags="smallitem,light" scale="0.5">
-    <Sprite texture="MiscWrecked.png" sourcerect="1248,1547,124,77" depth="0.8" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1248,1547,124,77" depth="0.8" origin="0.5,0.5" />
     <LightComponent lightcolor="1.0,1.0,1.0,0.5" range="800.0" LightSpriteScale="1.3" powerconsumption="5">
       <LightTexture texture="Content/Lights/pointlight_bounce.png" origin="0.5,0.5" />
       <sprite texture="Content/Items/Electricity/signalcomp.png" sourcerect="560,672,128,80" origin="0.5,0.5" />
@@ -638,7 +638,7 @@
     </ConnectionPanel>
   </Item>
   <Item name="" nameidentifier="lamp" identifier="lighthalogenmm03wrecked" category="Wrecked" Tags="smallitem,light" scale="0.5">
-    <Sprite texture="MiscWrecked.png" sourcerect="1370,1526,103,123" depth="0.8" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1370,1526,103,123" depth="0.8" origin="0.5,0.5" />
     <LightComponent lightcolor="1.0,1.0,1.0,0.5" range="800.0" LightSpriteScale="1.3" powerconsumption="5">
       <LightTexture texture="Content/Lights/pointlight_bounce.png" origin="0.5,0.5" />
       <sprite texture="Content/Items/Electricity/signalcomp.png" sourcerect="688,672,112,128" />
@@ -652,7 +652,7 @@
     </ConnectionPanel>
   </Item>
   <Item name="" nameidentifier="lamp" identifier="lighthalogenm04wrecked" category="Wrecked" Tags="smallitem,light" scale="0.5">
-    <Sprite texture="MiscWrecked.png" sourcerect="1473,1534,124,101" depth="0.8" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1473,1534,124,101" depth="0.8" origin="0.5,0.5" />
     <LightComponent lightcolor="1.0,1.0,1.0,0.5" range="800.0" LightSpriteScale="1.3" powerconsumption="5">
       <LightTexture texture="Content/Lights/pointlight_bounce.png" origin="0.5,0.5" />
       <sprite texture="Content/Items/Electricity/signalcomp.png" sourcerect="800,672,128,96" origin="0.5,0.5" />
@@ -666,7 +666,7 @@
     </ConnectionPanel>
   </Item>
   <Item name="" nameidentifier="lamp" identifier="lightleds01wrecked" category="Wrecked" Tags="smallitem,light" scale="0.5">
-    <Sprite texture="MiscWrecked.png" sourcerect="1492,1402,99,99" depth="0.8" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Shipwrecks/MiscWrecked.png" sourcerect="1492,1402,99,99" depth="0.8" origin="0.5,0.5" />
     <LightComponent lightcolor="1.0,1.0,1.0,0.5" range="800.0" LightSpriteScale="1.3" powerconsumption="5">
       <LightTexture texture="Content/Lights/pointlight_bounce.png" origin="0.5,0.5" />
       <sprite texture="Content/Items/Electricity/signalcomp.png" sourcerect="842,794,59,59" origin="0.5,0.5" />


### PR DESCRIPTION
There's too much of a difference between background and foreground depth for doors.

This means you don't have a choice: every item above 0.890 shows in front of the door background, this includes wires, cable holders, some walls... You can't change door depth if you want the background to hide those.

I simply changed the background to be closer to the foreground, so you can adjust the door depth if you want these things to show


On the left: vanilla door
On the right: modified door at different depths
![image](https://github.com/FakeFishGames/Barotrauma/assets/73229309/06ae793e-7650-454c-840c-aee530741ff2)


Changes:

_For reference Foreground is 0.51_
-Changed door background depth to 0.61 (from 0.89)
-Changed door buttons depth to 0.62 (from 0.75)
-Added complete texture file path instead of just "door.png"