### PR TITLE
Temp fix to attack cancelling in closein stage of circle attack pattern

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/EnemyAIController.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/EnemyAIController.cs
@@ -3731,7 +3731,7 @@ namespace Barotrauma
             }
             reachTimer = 0;
             sinTime = 0;
-            if (breakCircling && strikeTimer <= 0)
+            if (CirclePhase != CirclePhase.CloseIn && breakCircling && strikeTimer <= 0)
             {
                 CirclePhase = CirclePhase.Start;
             }


### PR DESCRIPTION
See [this "issue"](https://github.com/FakeFishGames/Barotrauma/discussions/13601)

This is the easiest "fix" to that
Just don't reset CirclePhase to start onTargetChanged in CloseIn phase

It works perfectly for Charybdis
She always strike, and doesn't fallback if target hull is changed in CloseIn phase

https://github.com/FakeFishGames/Barotrauma/assets/122838333/ae59941a-e20d-4b35-9195-ff4f0a68e22b

I tested all of the vanilla potentially affected characters and i think they are behaving normally
![Screenshot_1](https://github.com/FakeFishGames/Barotrauma/assets/122838333/4d012043-8064-4052-8b02-42d91ca056f9)