### PR TITLE
Remove RepairTool progress bars from indestructible structures and items.

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/RepairTool.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/RepairTool.cs
@@ -76,19 +76,22 @@ namespace Barotrauma.Items.Components
 
         partial void FixStructureProjSpecific(Character user, float deltaTime, Structure targetStructure, int sectionIndex)
         {
-            Vector2 progressBarPos = targetStructure.SectionPosition(sectionIndex);
-            if (targetStructure.Submarine != null)
+            if (!targetStructure.Indestructible && targetStructure.Submarine is not { GodMode: true })
             {
-                progressBarPos += targetStructure.Submarine.DrawPosition;
+                Vector2 progressBarPos = targetStructure.SectionPosition(sectionIndex);
+                if (targetStructure.Submarine != null)
+                {
+                    progressBarPos += targetStructure.Submarine.DrawPosition;
+                }
+
+                var progressBar = user.UpdateHUDProgressBar(
+                    targetStructure.ID * 1000 + sectionIndex, //unique "identifier" for each wall section
+                    progressBarPos,
+                    MathUtils.InverseLerp(targetStructure.Prefab.MinHealth, targetStructure.Health, targetStructure.Health - targetStructure.SectionDamage(sectionIndex)),
+                    GUIStyle.Red, GUIStyle.Green);
+
+                if (progressBar != null) progressBar.Size = new Vector2(60.0f, 20.0f);
             }
-
-            var progressBar = user.UpdateHUDProgressBar(
-                targetStructure.ID * 1000 + sectionIndex, //unique "identifier" for each wall section
-                progressBarPos,
-                MathUtils.InverseLerp(targetStructure.Prefab.MinHealth, targetStructure.Health, targetStructure.Health - targetStructure.SectionDamage(sectionIndex)),
-                GUIStyle.Red, GUIStyle.Green);
-
-            if (progressBar != null) progressBar.Size = new Vector2(60.0f, 20.0f);
 
             Vector2 particlePos = ConvertUnits.ToDisplayUnits(pickedPosition);
             if (targetStructure.Submarine != null) particlePos += targetStructure.Submarine.DrawPosition;
@@ -112,7 +115,7 @@ namespace Barotrauma.Items.Components
 
         partial void FixItemProjSpecific(Character user, float deltaTime, Item targetItem, bool showProgressBar)
         {
-            if (showProgressBar)
+            if (!targetItem.Indestructible && !targetItem.InvulnerableToDamage && showProgressBar)
             {
                 float progressBarState = targetItem.ConditionPercentage / 100.0f;
                 if (!MathUtils.NearlyEqual(progressBarState, prevProgressBarState) || prevProgressBarTarget != targetItem)

--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Repairable.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Repairable.cs
@@ -398,7 +398,7 @@ namespace Barotrauma.Items.Components
                         paused ? Color.Cyan : GUIStyle.Red, Color.Black * 0.5f);
                 }
                 GUI.DrawString(spriteBatch,
-                    new Vector2(item.DrawPosition.X, -item.DrawPosition.Y + 20), "Condition: " + (int)item.Condition + "/" + (int)item.MaxCondition,
+                    new Vector2(item.DrawPosition.X, -item.DrawPosition.Y + 20), "Condition: " + (int)item.Condition + "/" + (int)item.MaxCondition + (item.Indestructible || item.InvulnerableToDamage ? "\n[INDESTRUCTIBLE]" : ""),
                     GUIStyle.Orange);
             }
         }

--- a/Barotrauma/BarotraumaClient/ClientSource/Map/Structure.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Map/Structure.cs
@@ -577,7 +577,9 @@ namespace Barotrauma
                         {
                             var textPos = SectionPosition(i, true);
                             textPos.Y = -textPos.Y;
-                            GUI.DrawString(spriteBatch, textPos, "Damage: " + (int)((GetSection(i).damage / MaxHealth) * 100f) + "%", Color.Yellow);
+                            GUI.DrawString(spriteBatch,
+                                textPos, "Damage: " + (int)((GetSection(i).damage / MaxHealth) * 100f) + "%" + (Indestructible ? "\n[INDESTRUCTIBLE]" : (Submarine is { GodMode: true } ? "\n[GODMODE]" : "")),
+                                Color.Yellow);
                         }
                     }
                 }


### PR DESCRIPTION
This PR makes the progress/health bars of items and structures that appear when cutting/repairing not appear if the structure/item is unable to be damaged.
In addition, it adds extra debug info that tells if structures/items are invincible.

![image](https://github.com/FakeFishGames/Barotrauma/assets/67431770/f0adc8cf-f364-4ae6-8aea-a214d27e4485)
