### PR TITLE
Fix Cabinet Sorting Bug #13402

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/ItemContainer.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/ItemContainer.cs
@@ -267,6 +267,14 @@ namespace Barotrauma.Items.Components
             for (int i = 0; i < Inventory.Capacity; i++)
             {
                 var items = Inventory.GetItemsAt(i).ToList();
+
+                // Ignore any containers
+                bool isContainer = items.Any(item => item.IsContainer());
+                if (isContainer)
+                {
+                    break;
+                }
+
                 if (items.Any()) 
                 { 
                     itemsPerSlot.Add(items);
@@ -274,7 +282,16 @@ namespace Barotrauma.Items.Components
                 }
             }
 
-            itemsPerSlot.Sort((i1, i2) => i1.First().Name.CompareTo(i2.First().Name));
+            itemsPerSlot.Sort((i1, i2) =>
+            {
+                int primary = i1.First().Name.CompareTo(i2.First().Name);
+                if (primary == 0)
+                {
+                    // If names are the same, sort by stack size in decending order
+                    return i2.Count.CompareTo(i1.Count);
+                }
+                return primary;
+            });
             foreach (var items in itemsPerSlot)
             {
                 int firstFreeSlot = -1;

--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Item.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Item.cs
@@ -2462,5 +2462,9 @@ namespace Barotrauma
                 ic.OnPlayerSkillsChanged();
             }
         }
+        public bool IsContainer()
+        {
+            return components.Any(component => component is ItemContainer);
+        }
     }
 }


### PR DESCRIPTION
Fixed an issue where stacks of the same item in a cabinet would be rearranged when sorting alphabetically.

Added a function `IsContainer` to return whether or not an Item is an ItemContainer.

Also modified sorting to ignore any ItemContainer. Not sure if this is the ideal solution, but it was easier than figuring out a way to break ties between similar containers.

Edit: This is my first time contributing to something open source, so if I'm doing something wrong, feedback is appreciated.