### PR TITLE
Added requiredDestinationTypes on missionevents (solves #13941)

### DIFF
--- a/FactionEvents.xml
+++ b/FactionEvents.xml
@@ -868,11 +868,11 @@
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
     <!--                          Church of the Husk                               -->
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-    <ScriptedEvent identifier="missionevent_escort1huskcult" commonness="100">
+    <ScriptedEvent identifier="missionevent_escort1huskcult" commonness="100" requiredDestinationTypes="outpost,city,research,military,mine">
       <ConversationAction text="EventText.missionevent_escort1huskcult.c1" speakertag="huskcultist" endeventifinterrupted="false" dialogtype="Small" />
       <MissionAction missiontag="escortcommonershuskcult" />
     </ScriptedEvent>
-    <ScriptedEvent identifier="missionevent_cargohuskcult" commonness="100">
+    <ScriptedEvent identifier="missionevent_cargohuskcult" commonness="100" requiredDestinationTypes="outpost,city,research,military,mine">
       <ConversationAction text="eventtext.missionevent_cargohuskcult" speakertag="huskcultist" endeventifinterrupted="false" dialogtype="Small" />
       <MissionAction missiontag="cargohuskcult" />
     </ScriptedEvent>
@@ -1665,7 +1665,7 @@
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
     <!--                                  Clowns                                   -->
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-    <ScriptedEvent identifier="missionevent_escort1clowns" commonness="100">
+    <ScriptedEvent identifier="missionevent_escort1clowns" commonness="100" requiredDestinationTypes="outpost,city,research,military,mine">
       <ConversationAction text="EventText.missionevent_escort1clowns.c1" speakertag="clown" endeventifinterrupted="false" dialogtype="Small" />
       <MissionAction missiontag="escortcommonersclowns" />
     </ScriptedEvent>
@@ -1753,7 +1753,7 @@
       <CombatAction combatmode="offensive" npctag="clownnpc2" enemytag="clownvictimnpc" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
     </ScriptedEvent>
     <!--Infiltration-->
-    <ScriptedEvent identifier="infiltration" commonness="50">
+    <ScriptedEvent identifier="infiltration" commonness="50" requiredDestinationTypes="outpost,city,research,military,mine">
       <CheckDataAction identifier="infiltration_complete" condition="eq true">
         <Success>
           <!--Don't repeat-->

--- a/FactionEvents.xml
+++ b/FactionEvents.xml
@@ -1,0 +1,2488 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RandomEvents>
+  <EventPrefabs>
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!--                               Coalition                                   -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <ScriptedEvent identifier="coalitionspecialhire1">
+      <CheckReputationAction targettype="faction" identifier="coalition" condition="gte 80">
+        <Failure>
+          <!-- Do nothing -->
+        </Failure>
+        <Success>
+          <CheckDataAction identifier="coalitionspecialhire1_hired" condition="eq true">
+            <Success>
+              <!--Don't repeat event if already hired-->
+            </Success>
+            <Failure>
+              <ConversationAction text="eventtext.coalitionspecialhire1.announcement" eventsprite="NoticeBoard" />
+              <TagAction criteria="player" tag="player" />
+              <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="ignatiusmay" targettag="ignatiusmay" allowduplicates="false" spawnlocation="Outpost" targetmoduletags="admin,adminmodule" />
+              <Label name="beginning" />
+              <CheckDataAction identifier="coalitionspecialhire1_declinedonce" condition="eq true">
+                <Failure>
+                  <TriggerAction target1tag="ignatiusmay" target2tag="player" applytotarget2="triggerer_player" waitforinteraction="false" radius="300" />
+                  <NPCFollowAction npctag="ignatiusmay" targettag="triggerer_player" follow="true" />
+                  <!-- we haven't declined the offer before-->
+                  <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire1.c1" eventsprite="oldman">
+                    <Option text="eventtext.coalitionspecialhire1.o1">
+                      <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire1.o1.c1">
+                        <Option text="eventtext.coalitionspecialhire1.o1.o1">
+                          <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire1.o1.o1.c1">
+                            <Option text="eventtext.coalitionspecialhire1.o1.o1.o1">
+                              <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire1.o1.o1.o1.c1" />
+                              <NPCChangeTeamAction npctag="ignatiusmay" teamid="Team1" addtocrew="true" />
+                              <SetDataAction identifier="coalitionspecialhire1_hired" value="true" />
+                              <NPCFollowAction npctag="ignatiusmay" targettag="triggerer_player" follow="false" />
+                            </Option>
+                            <Option text="eventtext.separatistspecialhire2.o1.o1.o2">
+                              <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire1.o1.o1.o2.c1" />
+                              <SetDataAction identifier="coalitionspecialhire1_declinedonce" value="true" />
+                              <NPCFollowAction npctag="ignatiusmay" targettag="triggerer_player" follow="false" />
+                              <GoTo name="beginning" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Failure>
+                <Success>
+                  <!-- we've declined before, show different dialog this time -->
+                  <TriggerAction target1tag="ignatiusmay" target2tag="player" applytotarget2="triggerer_player" waitforinteraction="true" radius="300" />
+                  <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire1.repeat" eventsprite="oldman">
+                    <Option text="eventtext.separatistspecialhire2.o1.o1.o1">
+                      <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire1.o1.o1.o1.c1" />
+                      <NPCChangeTeamAction npctag="ignatiusmay" teamid="Team1" addtocrew="true" />
+                      <SetDataAction identifier="coalitionspecialhire1_hired" value="true" />
+                      <NPCFollowAction npctag="ignatiusmay" targettag="triggerer_player" follow="false" />
+                    </Option>
+                    <Option text="eventtext.separatistspecialhire1.o1.o2.repeat" endconversation="true">
+                      <NPCFollowAction npctag="ignatiusmay" targettag="triggerer_player" follow="false" />
+                      <GoTo name="beginning" />
+                    </Option>
+                  </ConversationAction>
+                </Success>
+              </CheckDataAction>
+            </Failure>
+          </CheckDataAction>
+        </Success>
+      </CheckReputationAction>
+    </ScriptedEvent>
+    <ScriptedEvent identifier="coalitionspecialhire2">
+      <CheckReputationAction targettype="faction" identifier="coalition" condition="gte 80">
+        <Failure>
+          <!-- Do nothing -->
+        </Failure>
+        <Success>
+          <CheckDataAction identifier="coalitionspecialhire2_hired" condition="eq true">
+            <Success>
+              <!--Don't repeat event if already hired-->
+            </Success>
+            <Failure>
+              <TagAction criteria="player" tag="player" />
+              <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="auntdoris" targettag="auntdoris" allowduplicates="false" spawnlocation="Outpost" />
+              <Label name="beginning" />
+              <TriggerAction target1tag="auntdoris" target2tag="player" applytotarget2="triggerer_player" waitforinteraction="true" />
+              <NPCFollowAction npctag="auntdoris" targettag="triggerer_player" follow="true" />
+              <CheckDataAction identifier="coalitionspecialhire2_declinedonce" condition="eq true">
+                <Failure>
+                  <!-- we haven't declined the offer before-->
+                  <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire2.c1">
+                    <Option text="eventtext.coalitionspecialhire2.o1">
+                      <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire2.o1.c1">
+                        <Option text="eventtext.coalitionspecialhire2.o1.o1">
+                          <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire2.o1.o1.c1">
+                            <Option text="eventtext.coalitionspecialhire2.o1.o1.o1">
+                              <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire2.o1.o1.o1.c1" />
+                              <NPCChangeTeamAction npctag="auntdoris" teamid="Team1" addtocrew="true" />
+                              <SetDataAction identifier="coalitionspecialhire2_hired" value="true" />
+                              <NPCFollowAction npctag="auntdoris" targettag="triggerer_player" follow="false" />
+                            </Option>
+                            <Option text="eventtext.separatistspecialhire2.o1.o1.o2">
+                              <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire2.o1.o1.o2.c1" />
+                              <SetDataAction identifier="coalitionspecialhire2_declinedonce" value="true" />
+                              <NPCFollowAction npctag="auntdoris" targettag="triggerer_player" follow="false" />
+                              <GoTo name="beginning" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Failure>
+                <Success>
+                  <!-- we've declined before, show different dialog this time -->
+                  <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire2.repeat">
+                    <Option text="eventtext.separatistspecialhire2.o1.o1.o1">
+                      <ConversationAction targettag="triggerer_player" text="eventtext.coalitionspecialhire2.o1.o1.o1.c1" />
+                      <NPCChangeTeamAction npctag="auntdoris" teamid="Team1" addtocrew="true" />
+                      <SetDataAction identifier="coalitionspecialhire2_hired" value="true" />
+                      <NPCFollowAction npctag="auntdoris" targettag="triggerer_player" follow="false" />
+                    </Option>
+                    <Option text="eventtext.separatistspecialhire1.o1.o2.repeat" endconversation="true">
+                      <NPCFollowAction npctag="auntdoris" targettag="triggerer_player" follow="false" />
+                      <GoTo name="beginning" />
+                    </Option>
+                  </ConversationAction>
+                </Success>
+              </CheckDataAction>
+            </Failure>
+          </CheckDataAction>
+        </Success>
+      </CheckReputationAction>
+    </ScriptedEvent>
+    
+    <!--Bomb scare-->
+    <ScriptedEvent identifier="bombscare" commonness="50">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemidentifier:mediumsteelcabinet" tag="bombcabinet" SubmarineType="Outpost" chooserandom="true" ContinueIfNoTargetsFound="false"  />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="securitynpc[faction]" targettag="bombsecurity" spawnlocation="Outpost" />
+      <Label name="beginning" />
+      <ClearTagAction tag="triggerer_player" />
+      <!-- talk to security NPC -->
+      <TriggerAction target1tag="player" target2tag="bombsecurity" applytotarget1="triggerer_player" waitforinteraction="true" />
+      <NPCFollowAction npctag="bombsecurity" targettag="triggerer_player" follow="true" />
+      <ConversationAction text="EventText.bombscare.c1" targettag="triggerer_player" eventsprite="BombScare1">
+        <Option text="EventText.bombscare.o1">
+          <ConversationAction text="EventText.bombscare.o1.c1" targettag="triggerer_player">
+            <Option text="EventText.bombscare.o1.o1">
+              <ConversationAction text="EventText.bombscare.o1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.bombscare.o1.o1.o1">
+                  <ConversationAction text="EventText.bombscare.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" />
+                  <NPCFollowAction npctag="bombsecurity" targettag="triggerer_player" follow="false" />
+                  <SpawnAction itemidentifier="traitortimebomb" targettag="bombscarebomb" targetinventory="bombcabinet" ignorebyai="true" />
+                  <!-- Find the bomb cabinet -->
+                  <TriggerAction target1tag="player" target2tag="bombcabinet" applytotarget1="noisehearer" waitforinteraction="false" radius="80" />
+                  <StatusEffectAction targettag="bombscarebomb">
+                    <StatusEffect target="This" condition="100" IsOn="true" setvalue="true" />
+                  </StatusEffectAction>
+                  <ConversationAction text="eventtext.bombscare.tickingnoise" targettag="noisehearer" endconversation="true" dialogtype="Small"/>
+                  <!-- must pick up bomb to proceed -->
+                  <TriggerAction target1tag="player" target2tag="bombscarebomb" applytotarget1="bombfinder" waitforinteraction="true" />
+                  <ConversationAction text="EventText.bombscare.o1.o1.o1.c1.c1" targettag="bombfinder" eventsprite="BombScare2">
+                    <Option text="eventtext.bombscare.o1.o1.o1.c1.o1">
+                      <SkillCheckAction requiredskill="electrical" requiredlevel="80" targettag="bombfinder">
+                        <Success>
+                          <StatusEffectAction targettag="bombscarebomb">
+                            <StatusEffect target="This" IsOn="false" setvalue="true" />
+                          </StatusEffectAction>
+                          <GiveSkillEXPAction skill="electrical" amount="10" targettag="bombfinder" />
+                          <ConversationAction text="EventText.bombscare.o1.o1.o1.c1.o1.c1" targettag="bombfinder" eventsprite="BombScare2"/>
+                          <!-- Bomb defused, go to security. -->
+                          <Label name="hasdefusedbomb" />
+                          <TriggerAction target1tag="player" target2tag="bombsecurity" applytotarget1="bombbringer" waitforinteraction="true" />
+                          <CheckItemAction targettag="bombbringer" itemtags="bombscarebomb" >
+                            <Success>
+                              <NPCFollowAction npctag="bombsecurity" targettag="bombbringer" follow="true" />
+                              <ConversationAction text="EventText.bombscare.o1.o1.o1.c1.o1.c1.c1" targettag="bombbringer" eventsprite="BombScare1"/>
+                              <StatusEffectAction targettag="bombscarebomb">
+                                <StatusEffect target="This">
+                                  <Remove />
+                                </StatusEffect>
+                              </StatusEffectAction>
+                              <MoneyAction amount="500" />
+                              <ReputationAction targettype="Faction" identifier="coalition" increase="5" />
+                              <ReputationAction targettype="Faction" identifier="separatists" increase="-5" />
+                              <NPCFollowAction npctag="bombsecurity" targettag="bombbringer" follow="false" />
+                            </Success>
+                            <Failure>
+                              <ConversationAction text="EventText.bombscare.nobombtogive" targettag="bombbringer" dialogtype="Small" eventsprite="BombScare1"/>
+                              <ClearTagAction tag="bombbringer" />
+                              <WaitAction time="1" />
+                              <Goto name="hasdefusedbomb" />
+                            </Failure>
+                          </CheckItemAction>
+                        </Success>
+                        <Failure>
+                          <!-- Bomb turns off then turns on again and ticks faster -->
+                          <StatusEffectAction targettag="bombscarebomb">
+                            <StatusEffect target="This" IsOn="false" setvalue="true" />
+                          </StatusEffectAction>
+                          <ConversationAction text="eventtext.bombscare.o1.o1.o1.c1.o1.c2" targettag="bombfinder" eventsprite="BombScare2">
+                            <Option text="eventtext.bombscare.o1.o1.o1.c1.o1.o1">
+                              <Waitaction Time="1" />
+                              <StatusEffectAction targettag="bombscarebomb">
+                                <StatusEffect target="This" IsOn="True" setvalue="true" />
+                                <StatusEffect target="This" type="OnActive" duration="100" Condition="-2" >
+                                  <sound file="Content/Items/Button/Switch1.ogg" range="200" frequencymultiplier="1" volume="0.75" loop="true" />
+                                </StatusEffect>
+                              </StatusEffectAction>
+                              <ConversationAction text="eventtext.bombscare.o1.o1.o1.c1.o1.o1.c1" targettag="bombfinder" endconversation="true" eventsprite="BombScare2"/>
+                            </Option>
+                          </ConversationAction>
+                        </Failure>
+                      </SkillCheckAction>
+                    </Option>
+                    <Option text="eventtext.bombscare.leavethebomb" endconversation="true">
+                      <!-- Let the bomb tick -->
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.bombscare.o1.o2" endconversation="true">
+              <!--END-->
+              <NPCFollowAction npctag="bombsecurity" targettag="triggerer_player" follow="false" />
+              <GoTo name="beginning" />
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.generic.ignore" endconversation="true">
+          <!--END-->
+          <NPCFollowAction npctag="bombsecurity" targettag="triggerer_player" follow="false" />
+          <GoTo name="beginning" />
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+    
+    <!--Nothing to see here-->
+    <ScriptedEvent identifier="nothingtoseehere" commonness="50">
+      <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="oldwoman" targettag="nothingtoseehere_oldwoman" spawnlocation="Outpost" spawnpointtype="Path" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="securitynpc[faction]" targettag="nothingtoseehere_guard" spawnlocation="Outpost" spawnpointtype="Path" targetmoduletags="securitymodule" />
+      <TagAction criteria="player" tag="player" />
+      <NPCWaitAction npctag="oldwoman" wait="true" />
+      <NPCWaitAction npctag="securitynpc[faction]" wait="true" />
+      <Label name="beginning" />
+      <ClearTagAction tag="triggerer_player" />
+      <TriggerAction target1tag="nothingtoseehere_oldwoman" target2tag="player" applytotarget2="triggerer_player" radius="100" waitforinteraction="true" />
+      <NPCFollowAction npctag="nothingtoseehere_oldwoman" targettag="triggerer_player" follow="true" />
+      <ConversationAction text="EventText.nothingtoseehere.c1" targettag="triggerer_player">
+        <Option text="EventText.nothingtoseehere.o1" endconversation="true">
+          <TagAction criteria="itemidentifier:opdeco_trashcan" tag="potentialtrashcan" submarinetype="outpost" />
+          <TriggerAction target1tag="potentialtrashcan" target2tag="triggerer_player" applytotarget1="selectedtrashcan" radius="100" waitforinteraction="true" />
+          <ConversationAction text="EventText.nothingtoseehere.o1.c1" targettag="triggerer_player" eventsprite="trashcan">
+            <Option text="EventText.nothingtoseehere.o1.o1">
+              <ConversationAction text="EventText.nothingtoseehere.o1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.generic.continue">
+                  <ConversationAction text="EventText.nothingtoseehere.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" />
+                  <NPCFollowAction npctag="nothingtoseehere_oldwoman" targettag="triggerer_player" follow="false" />
+                  <TriggerAction target1tag="nothingtoseehere_guard" target2tag="player" applytotarget2="triggerer_player" radius="100" waitforinteraction="true" />
+                  <NPCFollowAction npctag="nothingtoseehere_guard" targettag="triggerer_player" follow="true" />
+                  <ConversationAction text="EventText.nothingtoseehere.o1.o1.o1.c1.c1" targettag="triggerer_player">
+                    <Option text="EventText.nothingtoseehere.o1.o1.o1.c1.o1">
+                      <ConversationAction text="EventText.nothingtoseehere.o1.o1.o1.c1.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.nothingtoseehere.o1.o1.o1.c1.o1.o1">
+                          <ConversationAction text="EventText.nothingtoseehere.o1.o1.o1.c1.o1.o1.c1" targettag="triggerer_player" endconversation="true"/>
+                          <MoneyAction amount="500" />
+                          <ReputationAction targettype="Faction" identifier="coalition" increase="5" />
+                        </Option>
+                        <Option text="EventText.nothingtoseehere.o1.o1.o1.c1.o1.o2">
+                          <ConversationAction text="EventText.nothingtoseehere.o1.o1.o1.c1.o1.o2.c1" targettag="triggerer_player">
+                            <Option text="EventText.nothingtoseehere.o1.o1.o1.c1.o1.o2.o1">
+                              <ConversationAction text="EventText.nothingtoseehere.o1.o1.o1.c1.o1.o2.o1.c1" targettag="triggerer_player">
+                                <Option text="EventText.nothingtoseehere.o1.o1.o1.c1.o1.o2.o1.o1" endconversation="true">
+                                  <MoneyAction amount="500" />
+                                  <ReputationAction targettype="Faction" identifier="coalition" increase="1" />
+                                </Option>
+                                <Option text="EventText.nothingtoseehere.o1.o1.o1.c1.o1.o2.o1.o2" endconversation="true">
+                                  <ReputationAction targettype="Faction" identifier="coalition" increase="-5" />
+                                  <ReputationAction targettype="Faction" identifier="separatists" increase="5" />
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.nothingtoseehere.o1.o1.o1.c1.o2" endconversation="true">
+                      <!--END-->
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.generic.ignore" endconversation="true">
+              <!--END-->
+            </Option>
+          </ConversationAction>
+          <NPCFollowAction npctag="nothingtoseehere_guard" targettag="triggerer_player" follow="false" />
+        </Option>
+        <Option text="EventText.generic.ignore" endconversation="true">
+          <!--END-->
+          <GoTo name="beginning" />
+        </Option>
+      </ConversationAction>
+      <NPCFollowAction npctag="nothingtoseehere_oldwoman" targettag="triggerer_player" follow="false" />
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="missionevent_jailbreak_coalition" commonness="80">
+      <CheckReputationAction targettype="faction" identifier="coalition" condition="gte 30">
+        <Failure>
+          <!-- Do nothing -->
+        </Failure>
+        <Success>
+          <NPCWaitAction npctag="outpostmanager" wait="true" />
+          <ConversationAction text="EventText.missionevent_jailbreak_coalition.c1" speakertag="outpostmanager" invokertag="triggerer_player" endeventifinterrupted="false" eventsprite="Coalition">
+            <Option text="EventText.missionevent.pleasecontinue">
+              <!-- "please continue" -->
+              <ConversationAction text="EventText.missionevent_jailbreak_coalition.o1.c1" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Coalition" endconversation="true" />
+              <MissionAction missionidentifier="jailbreak_coalition" locationtype="City,Military" requiredfaction="separatists" minlocationdistance="1" />
+            </Option>
+          </ConversationAction>
+        </Success>
+      </CheckReputationAction>
+    </ScriptedEvent>
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!--                          Jovian Separatists                               -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <ScriptedEvent identifier="separatistspecialhire1">
+      <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 80">
+        <Failure>
+          <!-- Do nothing -->
+        </Failure>
+        <Success>
+          <CheckDataAction identifier="separatistspecialhire1_hired" condition="eq true">
+            <Success>
+              <!--Don't repeat event if already hired-->
+            </Success>
+            <Failure>
+              <TagAction criteria="player" tag="player" />
+              <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="victoriapetran" targettag="victoria" allowduplicates="false" spawnlocation="Outpost" />
+              <Label name="beginning" />
+              <TriggerAction target1tag="victoria" target2tag="player" applytotarget2="triggerer_player" waitforinteraction="true" />
+              <NPCFollowAction npctag="victoria" targettag="triggerer_player" follow="true" />
+              <CheckDataAction identifier="separatistspecialhire1_declinedonce" condition="eq true">
+                <Failure>
+                  <!-- we haven't declined the offer before-->
+                  <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire1.c1" eventsprite="HeartOfGold">
+                    <Option text="eventtext.separatistspecialhire1.o1">
+                      <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire1.o1.c1">
+                        <Option text="eventtext.separatistspecialhire1.o1.o1">
+                          <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire1.o1.o1.c1">
+                            <Option text="eventtext.separatistspecialhire1.o1.o1.o1">
+                              <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire1.o1.o1.o1.c1" />
+                              <NPCChangeTeamAction npctag="victoria" teamid="Team1" addtocrew="true" />
+                              <SetDataAction identifier="separatistspecialhire1_hired" value="true" />
+                              <NPCFollowAction npctag="victoria" targettag="triggerer_player" follow="false" />
+                            </Option>
+                            <Option text="eventtext.separatistspecialhire1.o1.o1.o2">
+                              <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire1.o1.o1.o2.c1" />
+                              <SetDataAction identifier="separatistspecialhire1_declinedonce" value="true" />
+                              <NPCFollowAction npctag="victoria" targettag="triggerer_player" follow="false" />
+                              <GoTo name="beginning" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Failure>
+                <Success>
+                  <!-- we've declined before, show different dialog this time -->
+                  <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire1.repeat" eventsprite="HeartOfGold">
+                    <Option text="eventtext.separatistspecialhire1.o1.o1.repeat">
+                      <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire1.o1.o1.o1.c1" />
+                      <NPCChangeTeamAction npctag="victoria" teamid="Team1" addtocrew="true" />
+                      <SetDataAction identifier="separatistspecialhire1_hired" value="true" />
+                      <NPCFollowAction npctag="victoria" targettag="triggerer_player" follow="false" />
+                    </Option>
+                    <Option text="eventtext.separatistspecialhire1.o1.o2.repeat" endconversation="true">
+                      <NPCFollowAction npctag="victoria" targettag="triggerer_player" follow="false" />
+                      <GoTo name="beginning" />
+                    </Option>
+                  </ConversationAction>
+                </Success>
+              </CheckDataAction>
+            </Failure>
+          </CheckDataAction>
+        </Success>
+      </CheckReputationAction>
+    </ScriptedEvent>
+    <ScriptedEvent identifier="separatistspecialhire2">
+      <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 80">
+        <Failure>
+          <!-- Do nothing -->
+        </Failure>
+        <Success>
+          <CheckDataAction identifier="separatistspecialhire2_hired" condition="eq true">
+            <Success>
+              <!--Don't repeat event if already hired-->
+            </Success>
+            <Failure>
+              <CheckDataAction identifier="sootman_freed" condition="eq true">
+                <Failure>
+                  <!-- don't allow hiring until jailbreak mission has been completed -->
+                </Failure>
+                <Success>
+                  <TagAction criteria="player" tag="player" />
+                  <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="sootman" targettag="sootman" allowduplicates="false" spawnlocation="Outpost" />
+                  <Label name="beginning" />
+                  <TriggerAction target1tag="sootman" target2tag="player" applytotarget2="triggerer_player" waitforinteraction="true" />
+                  <NPCFollowAction npctag="sootman" targettag="triggerer_player" follow="true" />
+                  <CheckDataAction identifier="separatistspecialhire2_declinedonce" condition="eq true">
+                    <Failure>
+                      <!-- we haven't declined the offer before-->
+                      <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire2.c1">
+                        <Option text="eventtext.separatistspecialhire2.o1">
+                          <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire2.o1.c1">
+                            <Option text="eventtext.separatistspecialhire2.o1.o1">
+                              <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire2.o1.o1.c1">
+                                <Option text="eventtext.separatistspecialhire2.o1.o1.o1">
+                                  <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire2.o1.o1.o1.c1" />
+                                  <NPCChangeTeamAction npctag="sootman" teamid="Team1" addtocrew="true" />
+                                  <SetDataAction identifier="separatistspecialhire2_hired" value="true" />
+                                  <NPCFollowAction npctag="sootman" targettag="triggerer_player" follow="false" />
+                                </Option>
+                                <Option text="eventtext.separatistspecialhire2.o1.o1.o2">
+                                  <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire2.o1.o1.o2.c1" />
+                                  <SetDataAction identifier="separatistspecialhire2_declinedonce" value="true" />
+                                  <NPCFollowAction npctag="sootman" targettag="triggerer_player" follow="false" />
+                                  <GoTo name="beginning" />
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Failure>
+                    <Success>
+                      <!-- we've declined before, show different dialog this time -->
+                      <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire2.repeat">
+                        <Option text="eventtext.separatistspecialhire1.o1.o1.o1">
+                          <ConversationAction targettag="triggerer_player" text="eventtext.separatistspecialhire2.o1.o1.o1.c1" />
+                          <NPCChangeTeamAction npctag="sootman" teamid="Team1" addtocrew="true" />
+                          <SetDataAction identifier="separatistspecialhire2_hired" value="true" />
+                          <NPCFollowAction npctag="sootman" targettag="triggerer_player" follow="false" />
+                        </Option>
+                        <Option text="eventtext.separatistspecialhire1.o1.o2.repeat" endconversation="true">
+                          <NPCFollowAction npctag="sootman" targettag="triggerer_player" follow="false" />
+                          <GoTo name="beginning" />
+                        </Option>
+                      </ConversationAction>
+                    </Success>
+                  </CheckDataAction>                  
+                </Success>
+              </CheckDataAction>
+            </Failure>
+          </CheckDataAction>
+        </Success>
+      </CheckReputationAction>
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_tormsdalereport" commonness="80">
+      <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 30">
+        <Failure>
+          <!-- Do nothing -->
+        </Failure>
+        <Success>
+          <CheckDataAction identifier="tormsdalereport" condition="eq 0">
+            <Failure>
+              <!-- do nothing -->
+            </Failure>
+            <Success>
+              <NPCWaitAction npctag="outpostmanager" wait="true" />
+              <ConversationAction text="EventText.missionevent_tormsdalereport.c1" speakertag="outpostmanager" invokertag="triggerer_player" endeventifinterrupted="false" eventsprite="Stuckinthemiddle1">
+                <Option text="EventText.missionevent_tormsdalereport.whosthat">
+                  <ConversationAction text="EventText.missionevent_tormsdalereport.whospetran" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Stuckinthemiddle1">
+                    <Option text="EventText.missionevent_tormsdalereport.o1.o1">
+                      <Goto name="givemission" />
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.missionevent.pleasecontinue">
+                  <Goto name="givemission" />
+                </Option>
+              </ConversationAction>
+              <Label name="givemission" />
+              <ConversationAction text="EventText.missionevent_tormsdalereport.c1.c1" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Stuckinthemiddle1">
+                <Option text="EventText.missionevent_tormsdalereport.c1.o1">
+                  <ConversationAction text="EventText.missionevent_tormsdalereport.c1.o1.c1" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Separatists">
+                    <Option text="EventText.missionevent_tormsdalereport.c1.o1.o1">
+                      <ConversationAction text="EventText.missionevent_tormsdalereport.c1.o1.o1.c1" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Separatists">
+                        <Option text="EventText.missionevent_tormsdalereport.c1.o1.o1.o1">
+                          <ConversationAction text="EventText.missionevent_tormsdalereport.c1.o1.o1.o1.c1" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Separatists">
+                            <Option text="EventText.missionevent_tormsdalereport.c1.o1.o1.o1.o1">
+                              <ConversationAction text="EventText.missionevent_tormsdalereport.c1.o1.o1.o1.o1.c1" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Separatists">
+                                <Option text="EventText.missionevent_tormsdalereport.c1.o1.o1.o1.o1.o1">
+                                  <ConversationAction text="EventText.missionevent_tormsdalereport.c1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Separatists" endconversation="true" />
+                                  <MissionAction missionidentifier="tormsdalereport" locationtype="City,Outpost,Military,Research,Mine" requiredfaction="coalition" minlocationdistance="2" CreateLocationIfNotFound="true" />
+                                  <NPCWaitAction npctag="outpostmanager" wait="false" />
+                                  <SetDataAction identifier="tormsdalereport" value="1" />
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Success>
+          </CheckDataAction>
+        </Success>
+      </CheckReputationAction>
+    </ScriptedEvent>
+    <ScriptedEvent identifier="tormsdalereport_outpost">
+      <StatusEffectAction targettag="outpostmanager">
+        <!-- force the outpost manager to be killable (killing outpost NPCs might be disabled in MP) -->
+        <StatusEffect Unkillable="false" target="This"/>
+      </StatusEffectAction>      
+      <ConversationAction text="EventText.tormsdalereport_outpost.c1" speakertag="outpostmanager" invokertag="triggerer_player" endeventifinterrupted="false" eventsprite="Separatists">
+        <Option text="EventText.tormsdalereport_outpost.o1">
+          <ConversationAction text="EventText.tormsdalereport_outpost.o1.c1" targettag="triggerer_player" endconversation="true" />
+        </Option>
+        <Option text="EventText.tormsdalereport_outpost.o2">
+          <ConversationAction text="EventText.tormsdalereport_outpost.o2.c1" targettag="triggerer_player" endconversation="true" />
+          <CombatAction combatmode="Offensive" npctag="outpostmanager" enemytag="triggerer_player" isinstigator="true" guardreaction="none" witnessreaction="retreat" />
+        </Option>
+        <Option text="EventText.tormsdalereport_outpost.o3">
+          <ConversationAction text="EventText.tormsdalereport_outpost.o3.c1" targettag="triggerer_player" endconversation="true" />
+          <NPCFollowAction npctag="outpostmanager" targettag="triggerer_player" follow="true" />
+          <WaitAction time="60" />
+          <ConversationAction text="EventText.tormsdalereport_outpost.o3.c1.c1" targettag="triggerer_player" waitforinteraction="false" eventsprite="Separatists" />
+          <NPCFollowAction npctag="outpostmanager" targettag="triggerer_player" follow="false" />
+        </Option>
+        <Option text="EventText.tormsdalereport_outpost.o4" endconversation="true" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <ScriptedEvent identifier="tormsdalereport_complete">
+      <CheckDataAction identifier="tormsdalereport" condition="eq 2">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>
+          <Label name="beginning" />
+          <ConversationAction text="EventText.tormsdalereport_complete.c1" speakertag="outpostmanager" invokertag="triggerer_player" endeventifinterrupted="false" eventsprite="Stuckinthemiddle1">
+            <Option text="EventText.tormsdalereport_complete.o1">
+              <CheckItemAction targettag="triggerer_player" itemidentifiers="tormsdalereport">
+                <Success>
+                  <ConversationAction text="EventText.tormsdalereport_complete.o1.c1" targettag="triggerer_player" endconversation="true" />
+                  <MoneyAction amount="5000" />
+                  <ReputationAction targettype="Faction" identifier="separatists" increase="10" />
+                  <ReputationAction targettype="Faction" identifier="coalition" increase="-10" />
+                  <SetDataAction identifier="tormsdalereport" value="3" />
+                  <RemoveItemAction targettag="triggerer_player" itemidentifier="tormsdalereport" />
+                </Success>
+                <Failure>
+                  <ConversationAction text="EventText.tormsdalereport_complete.o1.c2" targettag="triggerer_player" endconversation="true" />
+                  <GoTo name="beginning" />
+                </Failure>
+              </CheckItemAction>
+            </Option>
+            <Option text="EventText.tormsdalereport_complete.o2" endconversation="true">
+              <GoTo name="beginning" />
+            </Option>
+          </ConversationAction>
+        </Success>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_jailbreak_separatists" commonness="80">
+      <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 30">
+        <Failure>
+          <!-- Do nothing -->
+        </Failure>
+        <Success>
+          <NPCWaitAction npctag="outpostmanager" wait="true" />
+          <ConversationAction text="EventText.missionevent_jailbreak_separatists.c1" speakertag="outpostmanager" invokertag="triggerer_player" endeventifinterrupted="false" eventsprite="Stuckinthemiddle1">
+            <Option text="EventText.missionevent.pleasecontinue">
+              <!-- "please continue" -->
+              <ConversationAction text="EventText.missionevent_jailbreak_separatists.o1.c1" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Separatists" endconversation="true" />
+              <MissionAction missionidentifier="jailbreak_separatists" locationtype="City,Military" requiredfaction="coalition" minlocationdistance="1" />
+            </Option>
+          </ConversationAction>
+        </Success>
+      </CheckReputationAction>
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_jailbreak_sootman" commonness="80">
+      <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 50">
+        <Failure>
+          <!-- Do nothing -->
+        </Failure>
+        <Success>
+          <CheckDataAction identifier="jailbreak_sootman_unlocked" condition="eq true">
+            <Success>
+              <!-- do nothing -->
+            </Success>
+            <Failure>
+              <NPCWaitAction npctag="outpostmanager" wait="true" />
+              <ConversationAction text="EventText.missionevent_jailbreak_sootman.c1" speakertag="outpostmanager" invokertag="triggerer_player" endeventifinterrupted="false" eventsprite="Stuckinthemiddle1">
+                <Option text="EventText.missionevent_tormsdalereport.whosthat">
+                  <!-- who's that? -->
+                  <ConversationAction text="EventText.missionevent_tormsdalereport.whospetran" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Separatists">
+                    <Option text="EventText.missionevent_tormsdalereport.o1.o1">
+                      <!-- ok, what's the mission -->
+                      <Goto name="givemission" />
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.missionevent.pleasecontinue">
+                  <!-- we're interested -->
+                  <Goto name="givemission" />
+                </Option>
+              </ConversationAction>
+              <Label name="givemission" />
+              <ConversationAction text="EventText.missionevent_jailbreak_sootman.c1.c1" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Stuckinthemiddle1">
+                <Option text="EventText.missionevent_jailbreak_sootman.c1.o1">
+                  <ConversationAction text="EventText.missionevent_jailbreak_sootman.c1.o1.c1" targettag="triggerer_player" endeventifinterrupted="false" eventsprite="Stuckinthemiddle1" />
+                  <MissionAction missionidentifier="jailbreak_sootman" locationtype="City,Military" requiredfaction="coalition" minlocationdistance="1" CreateLocationIfNotFound="true" />
+                  <SetDataAction identifier="jailbreak_sootman_unlocked" value="true" />
+                </Option>
+              </ConversationAction>
+            </Failure>
+          </CheckDataAction>
+        </Success>
+      </CheckReputationAction>
+    </ScriptedEvent>
+    <ScriptedEvent identifier="jailbreak_sootman">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="humanprefabidentifier:sootman" tag="prisoner" />
+      <NPCWaitAction npctag="sootman" wait="true" />
+      <TriggerAction target1tag="sootman" target2tag="player" applytotarget2="triggerer_player" disableiftargetincapacitated="false" radius="50" waitforinteraction="false" />
+      <NPCFollowAction npctag="sootman" targettag="player" follow="true" />
+      <ConversationAction text="EventText.jailbreak_sootman.c1" targettag="triggerer_player" eventsprite="Separatists">
+        <Option text="EventText.jailbreak_sootman.o1">
+          <ConversationAction text="EventText.jailbreak_sootman.o1.c1" targettag="triggerer_player">
+            <Option text="EventText.jailbreak_sootman.o1.o1">
+              <ConversationAction text="EventText.jailbreak_sootman.o1.o1.c1" targettag="triggerer_player" />
+              <NPCWaitAction npctag="sootman" wait="false" />
+              <NPCFollowAction npctag="sootman" targettag="outpostmanager" follow="true" />
+              <WaitAction time="30" />
+              <TriggerEventAction identifier="jailbreak_alarm" />
+              <GodModeAction targettag="sootman" enabled="true" />
+              <FireAction size="100" targettag="outpostmanager" />
+              <TagAction criteria="itemtag:command" submarinetype="Player" tag="commandroom" />
+              <!-- change team to give Sootman access to the sub -->
+              <NPCChangeTeamAction npctag="sootman" teamid="Team1" addtocrew="false" />
+              <NPCFollowAction npctag="sootman" targettag="commandroom" follow="true" />
+              <WaitAction time="120" />
+              <Label name="forcefollow" />
+              <CheckConditionalAction targettag="sootman" IsInPlayerSub="true">
+                <Failure>
+                  <!-- if not in the player sub within 2 minutes (messed up waypoints, no command room in the sub?) make the NPC follow the player -->
+                  <NPCFollowAction npctag="sootman" targettag="player" follow="true" />
+                  <WaitAction time="10" />
+                  <Goto name="forcefollow" />                  
+                </Failure>
+              </CheckConditionalAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+    <ScriptedEvent identifier="jailbreak">
+      <TagAction criteria="player" tag="player" />
+      <TriggerAction target1tag="prisoner" target2tag="player" applytotarget2="triggerer_player" disableiftargetincapacitated="false" radius="50" waitforinteraction="false" />
+      <ConversationAction text="EventText.jailbreak.c1" targettag="triggerer_player" eventsprite="BombScare1" />
+      <TriggerEventAction identifier="jailbreak_alarm" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="jailbreak_alarm">
+      <!-- trigger alarm if any of the prisoners are close to security -->
+      <TriggerAction target1tag="prisoner" target2tag="securitynpc" applytotarget1="triggerer_prisoner" applytotarget2="triggerer_securitynpc" disableiftargetincapacitated="false" radius="200" waitforinteraction="false" />
+      <NPCFollowAction npctag="triggerer_prisoner" targettag="triggerer_securitynpc" follow="true" />
+      <WaitAction time="3" />
+      <TagAction criteria="itemtag:securityalarm" submarinetype="Outpost" tag="alarmbutton" />
+      <StatusEffectAction targettag="alarmbutton">
+        <StatusEffect State="true" target="This" />
+      </StatusEffectAction>
+      <ConversationAction text="EventText.jailbreak_alarm.c1" eventsprite="NoticeBoard" ContinueAutomatically="true" />
+      <NPCFollowAction npctag="triggerer_prisoner" targettag="triggerer_securitynpc" follow="false" />
+      <NPCChangeTeamAction npctag="securitynpc" teamid="Team2" />
+    </ScriptedEvent>
+    <!--"Separatist relations"
+    TODO:
+    -spawn correct npcs-->
+    <ScriptedEvent identifier="separatistrelations" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="vandal1" spawnlocation="Outpost" targetmoduletags="crewmodule" lootingisstealing="false" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="vandal2" spawnlocation="Outpost" targetmoduletags="crewmodule" lootingisstealing="false" />
+      <SpawnAction itemidentifier="wrench" targetinventory="vandal1" />
+      <SpawnAction itemidentifier="screwdriver" targetinventory="vandal2" />
+      <NPCFollowAction npctag="vandal1" targettag="vandal2" follow="true" />
+      <TriggerAction target1tag="vandal1" target2tag="player" applytotarget2="triggerer_player" radius="100" waitforinteraction="true" />
+      <NPCWaitAction npctag="vandal1" wait="true" />
+      <NPCWaitAction npctag="vandal2" wait="true" />
+      <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 30">
+        <Success>
+          <ConversationAction targettag="triggerer_player" text="EventText.separatistrelations.c1" eventsprite="group" />
+          <ReputationAction targettype="Faction" identifier="separatists" increase="1" />
+        </Success>
+        <Failure>
+          <ConversationAction targettag="triggerer_player" text="EventText.separatistrelations.c2" eventsprite="group">
+            <Option text="EventText.separatistrelations.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.separatistrelations.o1.c1" />
+              <ReputationAction targettype="Faction" identifier="separatists" increase="-2" />
+              <CombatAction combatmode="offensive" npctag="vandal1" enemytag="triggerer_player" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+              <CombatAction combatmode="offensive" npctag="vandal2" enemytag="triggerer_player" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+            </Option>
+            <Option text="EventText.separatistrelations.o2">
+              <ConversationAction targettag="triggerer_player" text="EventText.separatistrelations.o2.c1" />
+              <ReputationAction targettype="Faction" identifier="separatists" increase="2" />
+            </Option>
+            <Option text="EventText.separatistrelations.o3" />
+          </ConversationAction>
+        </Failure>
+      </CheckReputationAction>
+      <NPCWaitAction npctag="vandal1" wait="false" />
+      <NPCWaitAction npctag="vandal2" wait="false" />
+    </ScriptedEvent>
+    <!--Stuck in the middle-->
+    <ScriptedEvent identifier="stuckinthemiddle" commonness="50">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemtag:chair" tag="torturechair" SubmarineType="Outpost" RequiredModuleTag="adminmodule" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="separatist1" targetmoduletags="airlock" spawnlocation="Outpost" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="separatist2" targetmoduletags="airlock" spawnlocation="Outpost" />
+      <!-- spawns the NPC for later in the event and give it some bruises. -->
+      <SpawnAction npcsetidentifier="abandonedoutpostnpcs" npcidentifier="hostage" targettag="torturedseparatist" spawnlocation="Outpost" targetmoduletags="adminmodule" />
+      <AfflictionAction targettag="torturedseparatist" affliction="blunttrauma" strength="15" limbtype="head" />
+      <AfflictionAction targettag="torturedseparatist" affliction="blunttrauma" strength="25" limbtype="torso" />
+      <AfflictionAction targettag="torturedseparatist" affliction="stun" strength="10" />
+      <GodModeAction targettag="torturedseparatist" enabled="true" />
+      <NPCWaitAction npctag="torturedseparatist" wait="true" />
+      <NPCWaitAction npctag="separatist1" wait="true" />
+      <NPCWaitAction npctag="separatist2" wait="true" />
+      <Label name="beginning" />
+      <ClearTagAction tag="triggerer_player" />
+      <TriggerAction target1tag="player" target2tag="separatist1" applytotarget1="triggerer_player" waitforinteraction="true"/>
+      <ConversationAction text="EventText.stuckinthemiddle.c1" targettag="triggerer_player" eventsprite="crowd">
+        <Option text="EventText.stuckinthemiddle.o1">
+          <ConversationAction text="EventText.stuckinthemiddle.o1.c1" targettag="triggerer_player" eventsprite="separatists">
+            <Option text="EventText.stuckinthemiddle.o1.o1">
+              <ConversationAction text="EventText.stuckinthemiddle.o1.o1.c1" targettag="triggerer_player" eventsprite="separatists">
+                <Option text="EventText.stuckinthemiddle.o1.o1.o1">
+                  <ConversationAction text="EventText.stuckinthemiddle.o1.o1.o1.c1" targettag="triggerer_player" eventsprite="separatists">
+                    <Option text="EventText.stuckinthemiddle.o1.o1.o1.o1">
+                      <ConversationAction text="EventText.stuckinthemiddle.o1.o1.o1.o1.c1" targettag="triggerer_player" eventsprite="separatists">
+                        <Option text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1">
+                          <ConversationAction text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1.c1" targettag="triggerer_player" eventsprite="separatists">
+                            <Option text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1.o1" endconversation="true">
+                              <SetDataAction identifier="stuckinthemiddle_acceptedmission" value="true" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.stuckinthemiddle.o1.o1.o1.o2">
+                      <!--END-->
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.stuckinthemiddle.o1.o2">
+              <!--END-->
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.generic.ignore" endconversation="true">
+          <!--END-->
+          <GoTo name="beginning" />
+        </Option>
+      </ConversationAction>
+      <!--Conversation #2-->
+      <CheckDataAction identifier="stuckinthemiddle_acceptedmission" condition="eq true">
+        <Success>
+          <TriggerAction target1tag="triggerer_player" target2tag="torturedseparatist" radius="100" waitforinteraction="true" DisableIfTargetIncapacitated="false" />
+          <ConversationAction text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player" eventsprite="MentalBreakdown">
+            <Option text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1">
+              <ConversationAction text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player" eventsprite="MentalBreakdown">
+                <Option text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o1">
+                  <ConversationAction text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player" eventsprite="MentalBreakdown" endconversation="true" />
+                  <TriggerAction target1tag="triggerer_player" target2tag="separatist1" waitforinteraction="true" />
+                  <ConversationAction text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o1.c1.c1" targettag="triggerer_player" />
+                  <ReputationAction targettype="Faction" identifier="separatists" increase="3" />
+                </Option>
+                <Option text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o2">
+                  <ConversationAction text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o2.c1" targettag="triggerer_player" endconversation="true" eventsprite="Note2" />
+                  <TriggerAction target1tag="triggerer_player" target2tag="separatist1" waitforinteraction="true" />
+                  <ConversationAction text="EventText.stuckinthemiddle.o1.o1.o1.o1.o1.o1.o1.o2.c1.c1" targettag="triggerer_player" />
+                  <ReputationAction targettype="Faction" identifier="separatists" increase="5" />
+                  <MoneyAction amount="500" />
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.generic.ignore" endconversation="true">
+              <!--END-->
+            </Option>
+          </ConversationAction>
+        </Success>
+        <Failure>
+          <!--Do nothing-->
+        </Failure>
+      </CheckDataAction>
+      <GodModeAction targettag="torturedseparatist" enabled="false" />
+    </ScriptedEvent>
+    <!--Terrorism 101-->
+    <ScriptedEvent identifier="terrorism101" commonness="50">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemtag:vendingmachine" tag="selectedvendingmachine" SubmarineType="Outpost" chooserandom="true" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="terrorist" spawnpointtag="selectedvendingmachine" spawnlocation="Outpost" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="securitynpc[faction]" targettag="security" spawnlocation="Outpost" />
+      <NPCWaitAction npctag="terrorist" wait="true" />
+      <NPCOperateItemAction npctag="terrorist" targettag="selectedvendingmachine" ItemComponentName="Fabricator" Operate="true" />
+      <Label name="beginning" />
+      <ClearTagAction tag="triggerer_player" />
+      <TriggerAction target1tag="player" target2tag="terrorist" applytotarget1="triggerer_player" waitforinteraction="true" />
+      <ConversationAction text="EventText.terrorism101.c1" targettag="triggerer_player" eventsprite="Terrorism1">
+        <Option text="EventText.terrorism101.o1">
+          <ConversationAction text="EventText.terrorism101.o1.c1" targettag="triggerer_player" eventsprite="Terrorism2">
+            <Option text="EventText.terrorism101.o1.o1">
+              <ConversationAction text="EventText.terrorism101.o1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.terrorism101.o1.o1.o1">
+                  <Label name="bombtalk" />
+                  <ConversationAction text="EventText.terrorism101.excuse" targettag="triggerer_player">
+                    <Option text="EventText.terrorism101.abomb">
+                      <ConversationAction text="EventText.terrorism101.shh" targettag="triggerer_player">
+                        <Option text="EventText.terrorism101.help">
+                          <ConversationAction text="EventText.terrorism101.novice" targettag="triggerer_player">
+                            <Option text="EventText.terrorism101.armbomb">
+                              <ConversationAction text="EventText.terrorism101.bombarmed" targettag="triggerer_player" />
+                              <ReputationAction targettype="Faction" identifier="separatists" increase="5" />
+                              <MoneyAction amount="250" />
+                            </Option>
+                            <Option text="EventText.terrorism101.dismantlebomb">
+                              <ConversationAction text="EventText.terrorism101.bombdismantled" targettag="triggerer_player" />
+                              <ReputationAction targettype="Faction" identifier="coalition" increase="3" />
+                              <MoneyAction amount="250" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                        <Option text="EventText.terrorism101.o1.o1.o1.o1.o2" endconversation="true">
+                          <ReputationAction targettype="Faction" identifier="coalition" increase="3" />
+                          <ReputationAction targettype="Faction" identifier="separatists" increase="-3" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.terrorism101.o1.o1.o1.o2" endconversation="true">
+                      <CombatAction combatmode="arrest" npctag="security" enemytag="terrorist" isinstigator="false" guardreaction="arrest" witnessreaction="none" />
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.terrorism101.o1.o1.o2" endconversation="true">
+                  <!--END-->
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.terrorism101.o1.o2">
+              <Goto name="bombtalk" />
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.generic.ignore" endconversation="true">
+          <!--END-->
+          <GoTo name="beginning" />
+        </Option>
+      </ConversationAction>
+      <NPCWaitAction npctag="terrorist" wait="false" />
+    </ScriptedEvent>
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!--                          Church of the Husk                               -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <ScriptedEvent identifier="missionevent_escort1huskcult" commonness="100">
+      <ConversationAction text="EventText.missionevent_escort1huskcult.c1" speakertag="huskcultist" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="escortcommonershuskcult" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_cargohuskcult" commonness="100">
+      <ConversationAction text="eventtext.missionevent_cargohuskcult" speakertag="huskcultist" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="cargohuskcult" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="huskcultspecialhire1">
+      <CheckDataAction identifier="subraevent_state" condition="lt 3">
+        <Failure>
+          <!-- cannot start the way to ascension if Subra has been assassinated (see assassinationofjacovsubra4) -->
+        </Failure>
+        <Success>
+          <!-- Can't be hired until rescued in the "Way to Ascension" chain -->
+          <CheckDataAction identifier="waytoascension" condition="gt 7">
+            <Failure>
+              <!-- do nothing -->
+            </Failure>
+            <Success>
+              <CheckReputationAction targettype="faction" identifier="huskcult" condition="gte 80">
+                <Failure>
+                  <!-- Do nothing -->
+                </Failure>
+                <Success>
+                  <CheckDataAction identifier="huskcultspecialhire1_hired" condition="eq true">
+                    <Success>
+                      <!--Don't repeat event if already hired-->
+                    </Success>
+                    <Failure>
+                      <TagAction criteria="player" tag="player" />
+                      <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="jacovsubra" targettag="jacovsubra" allowduplicates="false" targetmoduletags="huskmodule" spawnlocation="Outpost" />
+                      <Label name="beginning" />
+                      <TriggerAction target1tag="jacovsubra" target2tag="player" applytotarget2="triggerer_player" waitforinteraction="true" />
+                      <NPCFollowAction npctag="jacovsubra" targettag="triggerer_player" follow="true" />
+                      <CheckDataAction identifier="huskcultspecialhire1_declinedonce" condition="eq true">
+                        <Failure>
+                          <!-- we haven't declined the offer before-->
+                          <ConversationAction targettag="triggerer_player" text="eventtext.huskcultspecialhire1.c1" eventsprite="JacovSubra4">
+                            <Option text="eventtext.huskcultspecialhire1.o1">
+                              <ConversationAction targettag="triggerer_player" text="eventtext.huskcultspecialhire1.o1.c1">
+                                <Option text="eventtext.huskcultspecialhire1.o1.o1">
+                                  <ConversationAction targettag="triggerer_player" text="eventtext.huskcultspecialhire1.o1.o1.c1">
+                                    <Option text="eventtext.huskcultspecialhire1.o1.o1.o1" endconversation="true">
+                                      <ConversationAction targettag="triggerer_player" text="eventtext.huskcultspecialhire1.o1.o1.o1.c1" />
+                                      <NPCChangeTeamAction npctag="jacovsubra" teamid="Team1" addtocrew="true" />
+                                      <SetDataAction identifier="huskcultspecialhire1_hired" value="true" />
+                                      <NPCFollowAction npctag="jacovsubra" targettag="triggerer_player" follow="false" />
+                                    </Option>
+                                    <Option text="eventtext.huskcultspecialhire1.o1.o1.o2" endconversation="true">
+                                      <ConversationAction targettag="triggerer_player" text="eventtext.huskcultspecialhire1.o1.o1.o2.c1" />
+                                      <SetDataAction identifier="huskcultspecialhire1_declinedonce" value="true" />
+                                      <NPCFollowAction npctag="jacovsubra" targettag="triggerer_player" follow="false" />
+                                      <GoTo name="beginning" />
+                                    </Option>
+                                  </ConversationAction>
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Failure>
+                        <Success>
+                          <!-- we've declined before, show different dialog this time -->
+                          <ConversationAction targettag="triggerer_player" text="eventtext.huskcultspecialhire1.repeat" eventsprite="JacovSubra4">
+                            <Option text="eventtext.huskcultspecialhire1.o1.o1.repeat" endconversation="true">
+                              <ConversationAction targettag="triggerer_player" text="eventtext.huskcultspecialhire1.o1.o1.o1.c1" />
+                              <NPCChangeTeamAction npctag="jacovsubra" teamid="Team1" addtocrew="true" />
+                              <SetDataAction identifier="huskcultspecialhire1_hired" value="true" />
+                              <NPCFollowAction npctag="jacovsubra" targettag="triggerer_player" follow="false" />
+                            </Option>
+                            <Option text="eventtext.huskcultspecialhire1.o1.o2.repeat" endconversation="true">
+                              <NPCFollowAction npctag="jacovsubra" targettag="triggerer_player" follow="false" />
+                              <GoTo name="beginning" />
+                            </Option>
+                          </ConversationAction>
+                        </Success>
+                      </CheckDataAction>
+                    </Failure>
+                  </CheckDataAction>
+                </Success>
+              </CheckReputationAction>
+            </Success>
+          </CheckDataAction>
+        </Success>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--"Husk cult relations" -->
+    <ScriptedEvent identifier="huskcultrelations">
+      <TagAction criteria="player" tag="player" />
+      <TriggerAction target1tag="huskcultist" target2tag="player" applytotarget1="targetcultist" applytotarget2="triggerer_player" radius="250" waitforinteraction="true" />
+      <NPCFollowAction npctag="targetcultist" targettag="triggerer_player" follow="true" />
+      <ConversationAction targettag="triggerer_player" text="EventText.huskcultrelations.c1" eventsprite="huskinvite">
+        <Option text="EventText.huskcultrelations.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.huskcultrelations.o1.c1" fadetoblack="true" eventsprite="dorm">
+            <Option text="EventText.huskcultrelations.o1.o1">
+              <ConversationAction text="EventText.huskcultrelations.o1.o1.c1" targettag="triggerer_player" />
+              <ReputationAction targettype="Faction" identifier="huskcult" increase="5" />
+              <SpawnAction itemidentifier="calyxanide" targetinventory="triggerer_player" />
+              <SpawnAction itemidentifier="calyxanide" targetinventory="triggerer_player" />
+              <AfflictionAction targettag="triggerer_player" affliction="huskinfection" strength="40" />
+            </Option>
+            <Option text="EventText.huskcultrelations.o1.o2" />
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.huskcultrelations.o2" />
+      </ConversationAction>
+      <NPCFollowAction npctag="targetcultist" targettag="triggerer_player" follow="false" />
+    </ScriptedEvent>
+    <!--"Husk cultist"-->
+    <ScriptedEvent identifier="huskcultist">
+      <TagAction criteria="player" tag="player" />
+      <TriggerAction target1tag="huskcultist" target2tag="player" applytotarget1="targetcultist" applytotarget2="triggerer_player" radius="150" waitforinteraction="true" />
+      <ConversationAction targettag="triggerer_player" text="EventText.huskcultist.c1" eventsprite="cultist">
+        <Option text="EventText.huskcultist.o1">
+          <CheckItemAction targettag="triggerer_player" itemidentifiers="huskeggsbasic">
+            <Success>
+              <Label name="checkpockets" />
+              <ConversationAction targettag="triggerer_player" text="EventText.huskcultist.o1.c1">
+                <Option text="EventText.huskcultist.o1.o1">
+                  <RemoveItemAction targettag="triggerer_player" itemidentifier="huskeggsbasic" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.huskcultist.o1.o1.c1" />
+                  <MoneyAction amount="1000" />
+                </Option>
+                <Option text="EventText.huskcultist.o1.o2">
+                  <RemoveItemAction targettag="triggerer_player" itemidentifier="huskeggsbasic" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.huskcultist.o1.o2.c1" />
+                  <ReputationAction targettype="Faction" identifier="huskcult" increase="5" />
+                  <ReputationAction targettype="Faction" identifier="clowns" increase="-3" />
+                </Option>
+                <Option text="EventText.huskcultist.o1.o3" />
+              </ConversationAction>
+            </Success>
+            <Failure>
+              <ConversationAction targettag="triggerer_player" text="EventText.huskcultist.o1.c2">
+                <Option text="EventText.huskcultist.o1.o4">
+                  <ConversationAction targettag="triggerer_player" text="EventText.huskcultist.o1.o4.c1" />
+                  <Label name="waitingforeggs" />
+                  <ConversationAction text="EventText.huskcultist_return.c1" eventsprite="cultist" speakertag="huskcultist" dialogtype="Small">
+                    <Option text="EventText.huskcultist_return.o1" endconversation="true">
+                      <CheckItemAction targettag="triggerer_player" itemidentifiers="huskeggsbasic">
+                        <Success>
+                          <GoTo name="checkpockets" />
+                        </Success>
+                        <Failure>
+                          <ConversationAction targettag="triggerer_player" waitforinteraction="false" text="EventText.huskcultist_return.o1.c2" eventsprite="cultist" dialogtype="Small" />
+                          <GoTo name="waitingforeggs" />
+                        </Failure>
+                      </CheckItemAction>
+                    </Option>
+                    <Option text="EventText.huskcultist_return.o2" endconversation="true">
+                      <GoTo name="waitingforeggs" />
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.huskcultist.o1.o5" />
+              </ConversationAction>
+            </Failure>
+          </CheckItemAction>
+        </Option>
+        <Option text="EventText.huskcultist.o2" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Husk cult ambush"-->
+    <ScriptedEvent identifier="huskcultambush">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="huskcultist" targettag="cultist1" spawnlocation="Outpost" lootingisstealing="false" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="huskcultist" targettag="cultist2" spawnlocation="Outpost" lootingisstealing="false" />
+      <NPCFollowAction npctag="cultist2" targettag="cultist1" follow="true" />
+      <TriggerAction target1tag="cultist1" target2tag="player" applytotarget2="triggerer_player" radius="300" />
+      <NPCFollowAction npctag="cultist2" targettag="cultist1" follow="false" />
+      <NPCFollowAction npctag="cultist1" targettag="triggerer_player" follow="true" />
+      <NPCFollowAction npctag="cultist2" targettag="triggerer_player" follow="true" />
+      <ConversationAction targettag="triggerer_player" text="EventText.huskcultambush.c1" eventsprite="cultist">
+        <Option text="EventText.huskcultambush.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.huskcultambush.o1.c1" />
+          <CombatAction combatmode="Offensive" npctag="cultist1" enemytag="triggerer_player" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+          <CombatAction combatmode="Offensive" npctag="cultist2" enemytag="triggerer_player" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+        </Option>
+        <Option text="EventText.huskcultambush.o2">
+          <CheckReputationAction targettype="faction" identifier="huskcult" condition="gte 20">
+            <Success>
+              <ConversationAction targettag="triggerer_player" text="EventText.huskcultambush.o2.c1" />
+              <ReputationAction targettype="Faction" identifier="huskcult" increase="5" />
+            </Success>
+            <Failure>
+              <ConversationAction targettag="triggerer_player" text="EventText.huskcultambush.o2.c2" />
+              <!-- give a bit of rep for the nice try -->
+              <ReputationAction targettype="Faction" identifier="huskcult" increase="3" />
+              <CombatAction combatmode="Offensive" npctag="cultist1" enemytag="triggerer_player" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+              <CombatAction combatmode="Offensive" npctag="cultist2" enemytag="triggerer_player" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+            </Failure>
+          </CheckReputationAction>
+        </Option>
+      </ConversationAction>
+      <NPCFollowAction npctag="cultist1" targettag="triggerer_player" follow="false" />
+      <NPCFollowAction npctag="cultist2" targettag="triggerer_player" follow="false" />
+    </ScriptedEvent>
+    <!--"Young cultists"-->
+    <ScriptedEvent identifier="youngcultists">
+      <CheckDataAction identifier="youngcultists_completed" condition="eq true">
+        <Success>
+          <!--Don't repeat event if already completed -->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player" />
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="huskcultist" targettag="patient" spawnlocation="Outpost" targetmoduletags="huskmodule" />
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="huskcultist" targettag="cultist2" spawnlocation="Outpost" targetmoduletags="huskmodule" />
+          <!-- use an existing cultist as the 1st NPC -->
+          <NPCFollowAction npctag="huskcultist" targettag="patient" maxtargets="1" follow="true" />
+          <NPCFollowAction npctag="cultist2" targettag="patient" maxtargets="1" follow="true" />
+          <AfflictionAction targettag="patient" affliction="huskinfection" strength="1000" />
+          <GodModeAction targettag="patient" updateafflictions="true" enabled="true" />
+          <TriggerAction target1tag="patient" target2tag="player" applytotarget2="triggerer_player" disableiftargetincapacitated="false" radius="100" waitforinteraction="true" />
+          <ConversationAction targettag="triggerer_player" text="EventText.youngcultists.c1" eventsprite="unconscious">
+            <Option text="EventText.youngcultists.o1">
+              <!-- only mark as completed if the player chooses to interact with the cultists (can occur again if the event is ignored) -->
+              <SetDataAction identifier="youngcultists_completed" value="true" />
+              <GodModeAction targettag="patient" enabled="false" />
+              <AfflictionAction targettag="patient" affliction="huskinfection" strength="-1000" />
+              <NPCFollowAction npctag="patient" targettag="cultist2" follow="true" />
+              <ConversationAction targettag="triggerer_player" text="EventText.youngcultists.o1.c1">
+                <Option text="EventText.youngcultists.o1.o1">
+                  <ConversationAction targettag="triggerer_player" text="EventText.youngcultists.o1.o1.c1">
+                    <Option text="EventText.youngcultists.o1.o1.o1">
+                      <ConversationAction targettag="triggerer_player" text="EventText.youngcultists.o1.o1.o1.c1">
+                        <Option text="EventText.youngcultists.o1.o1.o1.o1">
+                          <Label name="parasite" />
+                          <ConversationAction targettag="triggerer_player" text="EventText.youngcultists.o1.o1.o1.o1.c1">
+                            <Option text="EventText.youngcultists.o1.o1.o1.o1.o1">
+                              <Label name="callsecurity" />
+                              <ConversationAction targettag="triggerer_player" text="EventText.youngcultists.o1.o1.o1.o1.o1.c1" />
+                              <ReputationAction targettype="Faction" identifier="huskcult" increase="-10" />
+                              <CombatAction combatmode="Arrest" npctag="securitynpc" enemytag="cultist2" isinstigator="false" witnessreaction="retreat" />
+                            </Option>
+                            <Option text="EventText.youngcultists.o1.o1.o1.o1.o2"  endconversation="true">
+                              <ReputationAction targettype="Faction" identifier="huskcult" increase="-2" />
+                            </Option>
+                            <Option text="EventText.youngcultists.o1.o1.o1.o1.o3">
+                              <GoTo name="info" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.youngcultists.o1.o1.o2">
+                      <ConversationAction targettag="triggerer_player" text="EventText.youngcultists.o1.o1.o2.c1">
+                        <Option text="EventText.youngcultists.o1.o1.o2.o1">
+                          <Label name="info" />
+                          <ConversationAction targettag="triggerer_player" text="EventText.youngcultists.o1.o1.o2.o1.c1">
+                            <Option text="EventText.youngcultists.o1.o1.o2.o1.o1" endconversation="true">
+                              <ReputationAction targettype="Faction" identifier="huskcult" increase="5" />
+                            </Option>
+                            <Option text="EventText.youngcultists.o1.o1.o2.o1.o2">
+                              <GoTo name="callsecurity" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                        <Option text="EventText.youngcultists.o1.o1.o2.o2">
+                          <GoTo name="parasite" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.youngcultists.o2" targettag="triggerer_player" endconversation="true">
+              <ReputationAction targettype="Faction" identifier="huskcult" increase="-5" />
+              <GodModeAction targettag="patient" enabled="false" />
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!-- 
+    waytoascension states
+    0: not started
+    1: talked to the ecclesiast, but not been able to answer the question about the second metamorphosis
+    2: answered the question correctly, asked to deliver husk eggs
+    3: delivered husk eggs, offered to join the church
+    4: joined the church, will get a new task when talking to the ecclesiast again
+    5: tasked to assassinate someone who knows too much about the church
+    6: assassination done, will get a reward and a task to pick up Jacov Subra when talking to the ecclesiast
+    7: tasked to rescue Jacov Subra from an abandoned outpost
+    8: rescued Subra
+    -->
+    <!-- Way to Ascension 1 -->
+    <ScriptedEvent identifier="waytoascension1">
+      <CheckDataAction identifier="subraevent_state" condition="lt 3">
+        <Failure>
+          <!-- cannot start the way to ascension if Subra has been assassinated (see assassinationofjacovsubra4) -->
+        </Failure>
+        <Success>
+          <CheckReputationAction targettype="faction" identifier="huskcult" condition="gte 0">
+            <Failure>
+              <!-- Do nothing -->
+            </Failure>
+            <Success>              
+              <CheckDataAction identifier="waytoascension" condition="eq 0">
+                <Failure>
+                  <CheckDataAction identifier="waytoascension" condition="eq 1">
+                    <Failure>
+                      <!-- do nothing -->
+                    </Failure>
+                    <Success>
+                      <TagAction criteria="player" tag="player" />
+                      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="huskcultecclesiast" targettag="ecclesiast" spawnlocation="Outpost" targetmoduletags="huskmodule" />
+                      <TriggerAction target1tag="player" target2tag="ecclesiast" applytotarget1="triggerer_player" waitforinteraction="true" />
+                      <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="true" />
+                      <ConversationAction text="EventText.waytoascension1.c1" targettag="triggerer_player" eventsprite="Ecclesiast">
+                        <Option text="EventText.waytoascension1.o5.o1.o1.o1.o1">
+                          <Label name="wronganswer" />
+                          <ConversationAction text="EventText.waytoascension1.o5.o1.o1.o1.o1.c1" targettag="triggerer_player" eventsprite="Ecclesiast" endconversation="true" />
+                        </Option>
+                        <Option text="EventText.waytoascension1.o5.o1.o1.o1.o2">
+                          <GoTo name="wronganswer" />
+                        </Option>
+                        <Option text="EventText.waytoascension1.o5.o1.o1.o1.o3">
+                          <GoTo name="givetask" />
+                        </Option>
+                        <Option text="EventText.waytoascension1.o5.o1.o1.o1.o4">
+                          <ConversationAction text="EventText.waytoascension1.o5.o1.o1.o1.o4.c1" targettag="triggerer_player" eventsprite="Ecclesiast" endconversation="true" />
+                          <SetDataAction identifier="waytoascension" value="1" />
+                        </Option>
+                      </ConversationAction>
+                    </Success>
+                  </CheckDataAction>
+                </Failure>
+                <Success>
+                  <TagAction criteria="player" tag="player" />
+                  <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="huskcultecclesiast" targettag="ecclesiast" spawnlocation="Outpost" targetmoduletags="huskmodule" />
+                  <NPCFollowAction npctag="huskcultist" targettag="ecclesiast" follow="true" />
+                  <TriggerAction target1tag="player" target2tag="ecclesiast" applytotarget1="triggerer_player" waitforinteraction="true" />
+                  <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="true" />
+                  <ConversationAction text="EventText.waytoascension1.c2" targettag="triggerer_player" eventsprite="Ecclesiast">
+                    <Option text="EventText.waytoascension1.o5">
+                      <ConversationAction text="EventText.waytoascension1.o5.c1" targettag="triggerer_player" eventsprite="Ecclesiast">
+                        <Option text="EventText.waytoascension1.o5.o1">
+                          <ConversationAction text="EventText.waytoascension1.o5.o1.c1" targettag="triggerer_player" eventsprite="Ecclesiast">
+                            <Option text="EventText.waytoascension1.o5.o1.o1">
+                              <ConversationAction text="EventText.waytoascension1.o5.o1.o1.c1" targettag="triggerer_player" eventsprite="Ecclesiast">
+                                <Option text="EventText.waytoascension1.o5.o1.o1.o1">
+                                  <Label name="challenge" />
+                                  <ConversationAction text="EventText.waytoascension1.o5.o1.o1.o1.c1" targettag="triggerer_player" eventsprite="Ecclesiast">
+                                    <Option text="EventText.waytoascension1.o5.o1.o1.o1.o1">
+                                      <Label name="wronganswer" />
+                                      <ConversationAction text="EventText.waytoascension1.o5.o1.o1.o1.o1.c1" targettag="triggerer_player" eventsprite="Ecclesiast" endconversation="true" />
+                                      <SetDataAction identifier="waytoascension" value="1" />
+                                    </Option>
+                                    <Option text="EventText.waytoascension1.o5.o1.o1.o1.o2">
+                                      <GoTo name="wronganswer" />
+                                    </Option>
+                                    <Option text="EventText.waytoascension1.o5.o1.o1.o1.o3">
+                                      <Label name="givetask" />
+                                      <ReputationAction targettype="Faction" identifier="huskcult" increase="2" />
+                                      <ConversationAction text="EventText.waytoascension1.o5.o1.o1.o1.o3.c1" targettag="triggerer_player" eventsprite="Ecclesiast">
+                                        <Option text="EventText.waytoascension1.o5.o1.o1.o1.o3.o1">
+                                          <ConversationAction text="EventText.waytoascension1.o5.o1.o1.o1.o3.o1.c1" targettag="triggerer_player" eventsprite="Ecclesiast" />
+                                          <SetDataAction identifier="waytoascension" value="2" />
+                                        </Option>
+                                      </ConversationAction>
+                                    </Option>
+                                    <Option text="EventText.waytoascension1.o5.o1.o1.o1.o4">
+                                      <ConversationAction text="EventText.waytoascension1.o5.o1.o1.o1.o4.c1" eventsprite="Ecclesiast" targettag="triggerer_player" endconversation="true" />
+                                      <SetDataAction identifier="waytoascension" value="1" />
+                                    </Option>
+                                  </ConversationAction>
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                            <Option text="EventText.waytoascension1.o5.o1.o2">
+                              <ConversationAction text="EventText.waytoascension1.o5.o1.o2.c1" targettag="triggerer_player" eventsprite="Ecclesiast">
+                                <Option text="EventText.waytoascension1.o5.o1.o1.o1">
+                                  <GoTo name="challenge" />
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                        <Option text="EventText.waytoascension1.o5.o2" endconversation="true" />
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.waytoascension1.o6">
+                      <ConversationAction targettag="triggerer_player" text="EventText.waytoascension1.o6.c1" />
+                      <ReputationAction targettype="Faction" identifier="huskcult" increase="-10" />
+                      <CombatAction combatmode="Arrest" npctag="securitynpc" enemytag="ecclesiast" isinstigator="false" witnessreaction="retreat" />
+                    </Option>
+                    <Option text="EventText.waytoascension1.o7" endconversation="true" />
+                  </ConversationAction>
+                </Success>
+              </CheckDataAction>
+              <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="false" />
+            </Success>
+          </CheckReputationAction>
+        </Success>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!-- Way to Ascension 2 -->
+    <ScriptedEvent identifier="waytoascension2">
+      <CheckDataAction identifier="subraevent_state" condition="lt 3">
+        <Failure>
+          <!-- cannot continue the way to ascension if Subra has been assassinated (see assassinationofjacovsubra4) -->
+        </Failure>
+        <Success>
+          <TagAction criteria="player" tag="player" />
+          <CheckDataAction identifier="waytoascension" condition="eq 2">
+            <Failure>
+              <!-- do nothing -->
+            </Failure>
+            <Success>
+              <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="huskcultecclesiast" targettag="ecclesiast" spawnlocation="Outpost" targetmoduletags="huskmodule" />
+              <Label name="beginning" />
+              <TriggerAction target1tag="player" target2tag="ecclesiast" applytotarget1="triggerer_player" waitforinteraction="true" />
+              <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="true" />
+              <ConversationAction targettag="triggerer_player" text="EventText.waytoascension2.c1" eventsprite="Ecclesiast">
+                <Option text="EventText.waytoascension2.o1">
+                  <CheckItemAction targettag="triggerer_player" itemidentifiers="huskeggs,huskeggsbasic" amount="12">
+                    <Success>
+                      <RemoveItemAction targettag="triggerer_player" itemidentifier="huskeggs,huskeggsbasic" amount="12" />
+                      <ReputationAction targettype="Faction" identifier="huskcult" increase="5" />
+                      <ConversationAction targettag="triggerer_player" text="EventText.waytoascension2.o1.c1">
+                        <Option text="EventText.waytoascension2.o1.o1">
+                          <ConversationAction targettag="triggerer_player" text="EventText.waytoascension2.o1.o1.c1">
+                            <Option text="EventText.waytoascension2.o1.o1.o1">
+                              <ConversationAction targettag="triggerer_player" text="EventText.waytoascension2.o1.o1.o1.c1" endconversation="true" />
+                              <SetDataAction identifier="waytoascension" value="3" />
+                              <Goto name="answer" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Success>
+                    <Failure>
+                      <ConversationAction text="EventText.waytoascension2.o1.c2" eventsprite="Ecclesiast" />
+                      <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="false" />
+                      <Goto name="beginning" />
+                    </Failure>
+                  </CheckItemAction>
+                </Option>
+                <Option text="EventText.waytoascension2.o2" endconversation="true">
+                  <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="false" />
+                  <Goto name="beginning" />
+                </Option>
+              </ConversationAction>
+            </Success>
+          </CheckDataAction>
+          <CheckDataAction identifier="waytoascension" condition="eq 3">
+            <Failure>
+              <!-- do nothing -->
+            </Failure>
+            <Success>
+              <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="huskcultecclesiast" targettag="ecclesiast" spawnlocation="Outpost" targetmoduletags="huskmodule" />
+              <Label name="answer" />
+              <TriggerAction target1tag="player" target2tag="ecclesiast" applytotarget1="triggerer_player" waitforinteraction="true" />
+              <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="true" />
+              <ConversationAction targettag="triggerer_player" text="EventText.waytoascension2.c2" eventsprite="Ecclesiast">
+                <Option text="EventText.waytoascension2.o3">
+                  <ConversationAction targettag="triggerer_player" text="EventText.waytoascension2.o3.c1">
+                    <Option text="EventText.waytoascension2.o3.o1">
+                      <ConversationAction targettag="triggerer_player" text="EventText.waytoascension2.o3.o1.c1">
+                        <Option text="EventText.waytoascension2.o3.o1">
+                          <ConversationAction targettag="triggerer_player" text="EventText.waytoascension2.o3.o1.o1.c1">
+                            <Option text="EventText.waytoascension2.o3.o1">
+                              <SetDataAction identifier="waytoascension" value="4" />
+                              <ReputationAction targettype="Faction" identifier="huskcult" increase="10" />
+                              <ReputationAction targettype="Faction" identifier="clowns" increase="-10" />
+                              <ConversationAction targettag="triggerer_player" text="EventText.waytoascension2.o3.o1.o1.o1.c1">
+                                <Option text="EventText.waytoascension2.o3.o1.o1.o1.o1">
+                                  <ConversationAction targettag="triggerer_player" text="EventText.waytoascension2.o3.o1.o1.o1.o1.c1" endconversation="true" />
+                                  <SpawnAction itemidentifier="bookofchalices2" targetinventory="triggerer_player" />
+                                  <SpawnAction itemidentifier="cultistrobes" targetinventory="triggerer_player" />
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                            <Option text="EventText.waytoascension2.thinkaboutthis" endconversation="true">
+                              <Goto name="answer" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                        <Option text="EventText.waytoascension2.thinkaboutthis" endconversation="true">
+                          <Goto name="answer" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.waytoascension2.thinkaboutthis" endconversation="true">
+                      <Goto name="answer" />
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.waytoascension2.thinkaboutthis" endconversation="true">
+                  <Goto name="answer" />
+                </Option>
+              </ConversationAction>
+            </Success>
+          </CheckDataAction>
+          <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="false" />
+        </Success>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!-- Way to Ascension 3 -->
+    <ScriptedEvent identifier="waytoascension3">
+      <CheckDataAction identifier="subraevent_state" condition="lt 3">
+        <Failure>
+          <!-- cannot continue the way to ascension if Subra has been assassinated (see assassinationofjacovsubra4) -->
+        </Failure>
+        <Success>
+          <CheckDataAction identifier="waytoascension" condition="eq 4">
+            <Failure>
+              <!-- do nothing -->
+            </Failure>
+            <Success>
+              <TagAction criteria="player" tag="player" />
+              <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="huskcultecclesiast" targettag="ecclesiast" spawnlocation="Outpost" targetmoduletags="huskmodule" />
+              <TriggerAction target1tag="player" target2tag="ecclesiast" applytotarget1="triggerer_player" waitforinteraction="true" />
+              <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="true" />
+              <ConversationAction targettag="triggerer_player" text="EventText.waytoascension3.c1" eventsprite="Ecclesiast">
+                <Option text="EventText.waytoascension3.o1">
+                  <ConversationAction targettag="triggerer_player" text="EventText.waytoascension3.o1.c1" eventsprite="Ecclesiast">
+                    <Option text="EventText.waytoascension3.o1.o1">
+                      <GoTo name="givemission" />
+                    </Option>
+                    <Option text="EventText.waytoascension3.o1.o2">
+                      <ConversationAction targettag="triggerer_player" text="EventText.waytoascension3.o1.o2.c1" eventsprite="Ecclesiast">
+                        <Option text="EventText.waytoascension3.o1.o2.o1">
+                          <Label name="givemission" />
+                          <ConversationAction targettag="triggerer_player" text="EventText.waytoascension3.o1.o2.o1.c1" eventsprite="Ecclesiast" endconversation="true" />
+                          <MissionAction missionidentifier="huskcultspecialassassinate" minlocationdistance="2" requiredfaction="coalition" locationtype="City,Outpost,Military,Research,Mine" CreateLocationIfNotFound="true" />
+                          <SetDataAction identifier="waytoascension" value="5" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Success>
+          </CheckDataAction>
+          <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="false" />
+        </Success>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!-- Way to Ascension: assassination mission start -->
+    <ScriptedEvent identifier="waytoascension_assassination1">
+      <ConversationAction text="EventText.waytoascension_assassination1.c1" endeventifinterrupted="false" eventsprite="JacovSubra3" />
+      <ConversationAction text="EventText.waytoascension_assassination1.c1.c1" speakertag="coalitionspy" invokertag="triggerer_player" endeventifinterrupted="false" eventsprite="Infiltration1">
+        <Option text="EventText.waytoascension_assassination1.c1.o1">
+          <ConversationAction text="EventText.waytoascension_assassination1.c1.o1.c1" targettag="triggerer_player" endconversation="true" />
+          <CombatAction combatmode="Offensive" npctag="coalitionspy" enemytag="triggerer_player" isinstigator="true" guardreaction="none" witnessreaction="retreat" />
+        </Option>
+        <Option text="EventText.waytoascension_assassination1.c1.o2">
+          <ConversationAction text="EventText.waytoascension_assassination1.c1.o2.c1" targettag="triggerer_player" endconversation="true" />
+          <NPCFollowAction npctag="coalitionspy" targettag="triggerer_player" follow="true" />
+          <WaitAction time="60" />
+          <ConversationAction targettag="triggerer_player" text="EventText.waytoascension_assassination1.c1.o2.c1.c1" waitforinteraction="false" eventsprite="Infiltration1" />
+          <NPCFollowAction npctag="coalitionspy" targettag="triggerer_player" follow="false" />
+        </Option>
+        <Option text="EventText.waytoascension_assassination1.c1.o3" endconversation="true" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!-- Way to Ascension 4 -->
+    <ScriptedEvent identifier="waytoascension4">
+      <CheckDataAction identifier="waytoascension" condition="eq 6">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>
+          <TagAction criteria="player" tag="player" />
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="huskcultecclesiast" targettag="ecclesiast" spawnlocation="Outpost" targetmoduletags="huskmodule" />
+          <TriggerAction target1tag="player" target2tag="ecclesiast" applytotarget1="triggerer_player" waitforinteraction="true" />
+          <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="true" />
+          <ConversationAction targettag="triggerer_player" text="EventText.waytoascension4.c1" eventsprite="Ecclesiast">
+            <Option text="EventText.waytoascension4.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.waytoascension4.o1.c1" eventsprite="Ecclesiast">
+                <Option text="EventText.waytoascension4.o1.o1">
+                  <ConversationAction targettag="triggerer_player" text="EventText.waytoascension4.o1.o1.c1" eventsprite="Ecclesiast">
+                    <Option text="EventText.waytoascension4.o1.o1.o1">
+                      <ConversationAction targettag="triggerer_player" text="EventText.waytoascension4.o1.o1.o1.c1" eventsprite="Ecclesiast" endconversation="true" />
+                      <MissionAction missionidentifier="huskcultrescuesubra" locationtype="Abandoned" CreateLocationIfNotFound="true" />
+                      <SetDataAction identifier="waytoascension" value="7" />
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Success>
+      </CheckDataAction>
+      <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="waytoascensionfoundsubra" commonness="0">
+      <TagAction criteria="player" tag="player" />
+      <!-- enable godmode to ensure the player can't get locked from completing the rest of the event chain -->
+      <GodModeAction targettag="jacovsubra" />
+      <TriggerAction target1tag="player" target2tag="jacovsubra" applytotarget1="triggerer_player" radius="300" waitforinteraction="false" />
+      <NPCWaitAction npctag="jacovsubra" wait="true" />
+      <ConversationAction text="EventText.waytoascensionfoundsubra.c1" targettag="triggerer_player" eventsprite="JacovSubra4">
+        <Option text="EventText.waytoascensionfoundsubra.o1">
+          <ConversationAction text="EventText.waytoascensionfoundsubra.o1.c1" targettag="triggerer_player" eventsprite="JacovSubra4">
+            <Option text="EventText.waytoascensionfoundsubra.o1.o1">
+              <ConversationAction text="EventText.waytoascensionfoundsubra.o1.o1.c1" targettag="triggerer_player" eventsprite="JacovSubra4" />
+              <NPCFollowAction npctag="jacovsubra" targettag="triggerer_player" follow="true" />
+              <SpawnAction npcsetidentifier="combatmissioncoalitionnpcs" npcidentifier="coalitionsecuritybrute" spawnlocation="Outpost" teamid="Team2" targetmoduletags="airlock" />
+              <SpawnAction npcsetidentifier="combatmissioncoalitionnpcs" npcidentifier="coalitionsecuritybrute" spawnlocation="Outpost" teamid="Team2" targetmoduletags="airlock" />
+              <SpawnAction npcsetidentifier="combatmissioncoalitionnpcs" npcidentifier="coalitionsecuritygunner" spawnlocation="Outpost" teamid="Team2" targetmoduletags="airlock" />
+              <SpawnAction npcsetidentifier="combatmissioncoalitionnpcs" npcidentifier="coalitionsecurityelite" spawnlocation="Outpost" teamid="Team2" targetmoduletags="airlock" />
+            </Option>
+          </ConversationAction>
+        </Option>
+      </ConversationAction>
+      <TriggerEventAction identifier="waytoascensionsubraescort" nextround="true" />
+      <NPCWaitAction npctag="jacovsubra" wait="false" />
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="waytoascensionsubraescort" commonness="0">
+      <CheckDataAction identifier="waytoascension" condition="eq 8">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>
+          <SetDataAction identifier="waytoascension" value="9" />
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="jacovsubra" targettag="jacovsubra" allowduplicates="false" spawnlocation="MainSub" />
+          <TagAction criteria="player" tag="player" />
+          <WaitAction time="5" />
+          <!-- enable godmode to ensure the player can't get locked from completing the rest of the event chain -->
+          <GodModeAction targettag="jacovsubra" />
+          <TriggerAction target1tag="player" target2tag="jacovsubra" applytotarget1="triggerer_player" radius="300" waitforinteraction="false" />
+          <NPCWaitAction npctag="jacovsubra" wait="true" />
+          <ConversationAction text="EventText.waytoascensionsubraescort.c1" targettag="triggerer_player" eventsprite="JacovSubra4">
+            <Option text="EventText.waytoascensionsubraescort.o1">
+              <ConversationAction text="EventText.waytoascensionsubraescort.c2" targettag="triggerer_player" eventsprite="JacovSubra4" />
+            </Option>
+          </ConversationAction>
+          <NPCWaitAction npctag="jacovsubra" wait="false" />
+          <WaitAction time="120" />
+          <TriggerAction target1tag="player" target2tag="jacovsubra" applytotarget1="triggerer_player" radius="300" waitforinteraction="true" />
+          <NPCWaitAction npctag="jacovsubra" wait="true" />
+          <ConversationAction text="EventText.waytoascensionsubraescort.c3" targettag="triggerer_player" eventsprite="JacovSubra4">
+            <Option text="EventText.waytoascensionsubraescort.c3.o1">
+              <ConversationAction text="EventText.waytoascensionsubraescort.c4" targettag="triggerer_player" eventsprite="JacovSubra4" />
+            </Option>
+          </ConversationAction>
+          <ConversationAction text="EventText.waytoascensionsubraescort.c5" targettag="triggerer_player" eventsprite="JacovSubra4">
+            <Option text="EventText.waytoascensionsubraescort.c5.o1" targettag="triggerer_player" eventsprite="JacovSubra4">
+              <ConversationAction text="EventText.waytoascensionsubraescort.c6" targettag="triggerer_player" eventsprite="JacovSubra4" />
+            </Option>
+          </ConversationAction>          
+          <NPCWaitAction npctag="jacovsubra" wait="false" />
+        </Success>
+      </CheckDataAction>
+    </ScriptedEvent>
+
+    <!-- Way to Ascension 4 -->
+    <ScriptedEvent identifier="waytoascension5">
+      <CheckDataAction identifier="waytoascension" condition="eq 9">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>
+          <TagAction criteria="player" tag="player" />
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="huskcultecclesiast" targettag="ecclesiast" spawnpointtag="ritualchamber" spawnlocation="Outpost" targetmoduletags="huskmodule" />
+          <NPCFollowAction npctag="huskcultist" targettag="ecclesiast" follow="true" />
+          <NPCWaitAction npctag="ecclesiast" wait="true" />
+          <SpawnAction itemidentifier="rituallanternspecial" spawnlocation="Outpost" spawnpointtag="ritualchamber" offset="300" />
+          <SpawnAction itemidentifier="rituallanternspecial" spawnlocation="Outpost" spawnpointtag="ritualchamber" offset="300" />
+          <SpawnAction itemidentifier="rituallanternspecial" spawnlocation="Outpost" spawnpointtag="ritualchamber" offset="300" />
+          <SpawnAction itemidentifier="rituallanternspecial" spawnlocation="Outpost" spawnpointtag="ritualchamber" offset="300" />
+          <TriggerAction target1tag="player" target2tag="ecclesiast" applytotarget1="triggerer_player" radius="200" waitforinteraction="false" />
+          <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="true" />
+          <ConversationAction targettag="triggerer_player" text="EventText.waytoascension5.c1" eventsprite="Ecclesiast">
+            <Option text="EventText.waytoascension5.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.waytoascension5.o1.c1" eventsprite="Ecclesiast" endconversation="true" />
+              <GoTo name="wait" />
+            </Option>
+          </ConversationAction>
+          <Label name="wait" />
+          <NPCWaitAction npctag="ecclesiast" wait="true" />
+          <NPCFollowAction npctag="huskcultist" targettag="ecclesiast" follow="true" />
+          <TriggerAction target1tag="player" target2tag="ecclesiast" applytotarget1="triggerer_player" waitforinteraction="true" />
+          <ConversationAction targettag="triggerer_player" text="EventText.waytoascension5.c1.c1" eventsprite="Ecclesiast">
+            <Option text="EventText.waytoascension5.c1.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.waytoascension5.c1.o1.c1" eventsprite="Ecclesiast">
+                <Option text="EventText.waytoascension5.c1.o1.o1">
+                  <ConversationAction targettag="triggerer_player" text="EventText.waytoascension5.c1.o1.o1.c1" eventsprite="Ecclesiast">
+                    <Option text="EventText.waytoascension5.c1.o1.o1.o1">
+                      <ConversationAction targettag="triggerer_player" text="EventText.waytoascension5.c1.o1.o1.o1.c1" eventsprite="Ecclesiast">
+                        <Option text="EventText.waytoascension5.c1.o1.o1.o1.o1" endconversation="true">
+                          <AfflictionAction targettag="ecclesiast" affliction="husksymbiosis" strength="1000" />
+                          <AfflictionAction targettag="huskcultist" affliction="huskinfection" strength="1000" />
+                          <StatusEffectAction targettag="triggerer_player">
+                            <StatusEffect target="NearbyCharacters" range="800" duration="10">
+                              <Conditional TeamID="Team1" />
+                              <Sound file="Content/Items/Alien/AlienTurret2.ogg" range="1000" />
+                              <Affliction identifier="hallucinating" strength="10" />
+                              <Affliction identifier="husksymbiosis" strength="10" />
+                            </StatusEffect>
+                          </StatusEffectAction>
+                          <WaitAction time="3" />
+                          <ConversationAction targettag="triggerer_player" text="EventText.waytoascension5.c1.o1.o1.o1.o1.c1" eventsprite="Ecclesiast">
+                            <Option text="EventText.waytoascension5.c1.o1.o1.o1.o1.o1">
+                              <ConversationAction targettag="triggerer_player" text="EventText.waytoascension5.c1.o1.o1.o1.o1.o1.c1" eventsprite="Ecclesiast">
+                                <Option text="EventText.waytoascension5.c1.o1.o1.o1.o1.o1.o1">
+                                  <ConversationAction targettag="triggerer_player" text="EventText.waytoascension5.c1.o1.o1.o1.o1.o1.o1.c1" eventsprite="Ecclesiast" />
+                                  <ReputationAction targettype="Faction" identifier="huskcult" increase="10" />
+                                  <ReputationAction targettype="Faction" identifier="clowns" increase="-10" />
+                                  <SetDataAction identifier="waytoascension" value="10" />
+                                  <CombatAction combatmode="arrest" npctag="security" enemytag="ecclesiast" isinstigator="false" guardreaction="arrest" witnessreaction="none" />
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.waytoascension5.c1.o2" endconversation="true">
+              <GoTo name="wait" />
+            </Option>
+          </ConversationAction>
+        </Success>
+      </CheckDataAction>
+      <NPCFollowAction npctag="ecclesiast" targettag="triggerer_player" follow="false" />
+    </ScriptedEvent>
+    <!--Husk Extremists-->
+    <ScriptedEvent identifier="huskextremists">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="humanprefabidentifier:huskextremist" tag="cultist" />
+      <TagAction criteria="humanprefabidentifier:huskextremist_leader" tag="cultist" />
+      <NPCChangeTeamAction npctag="cultist" teamid="FriendlyNPC" />
+
+      <Label name="waitforspotting" />
+      <WaitAction time="1" />
+      <CheckVisibilityAction EntityTag="cultist" TargetTag="player" ApplyTagToEntity="talk_cultist" ApplyTagToTarget="triggerer_player">
+        <Failure>
+          <Goto name="waitforspotting" />
+        </Failure>
+      </CheckVisibilityAction>
+      
+      <NPCWaitAction npctag="talk_cultist" wait="true" />
+      <!-- Set cultists to passive until after the conversations -->
+      <ConversationAction text="eventtext.huskextremists1.c1" targettag="triggerer_player">
+        <Option text="eventtext.huskextremists1.o1">
+          <ConversationAction text="eventtext.huskextremists1.o1.c1" targettag="triggerer_player">
+            <Option text="eventtext.huskextremists1.o1.o1">
+              <ConversationAction text="eventtext.huskextremists1.o1.o1.c1" targettag="triggerer_player">
+                <Option text="eventtext.huskextremists1.o1.o1.o1" endconversation="true">
+                  <!-- Combat -->
+                  <NPCChangeTeamAction npctag="cultist" teamid="Team2" />
+                  <CombatAction combatmode="Offensive" npctag="cultist" enemytag="triggerer_player" isinstigator="true" guardreaction="none" witnessreaction="retreat"/>
+                  <ReputationAction targettype="Faction" identifier="huskcult" increase="5" />
+                  <ReputationAction targettype="Faction" identifier="clowns" increase="-5" />
+                </Option>
+                <Option text="eventtext.huskextremists1.o1.o1.o2" endconversation="true">
+                  <!-- Combat -->
+                  <NPCChangeTeamAction npctag="cultist" teamid="Team2" />
+                  <CombatAction combatmode="Offensive" npctag="cultist" enemytag="triggerer_player" isinstigator="true" guardreaction="none" witnessreaction="retreat"/>
+                  <ReputationAction targettype="Faction" identifier="huskcult" increase="-5" />
+                  <ReputationAction targettype="Faction" identifier="clowns" increase="5" />
+                </Option>
+                <Option text="eventtext.huskextremists1.o1.o1.o3" endconversation="true">
+                  <!-- Peace, but no mission reward -->
+                  <SpawnAction itemidentifier="geneticmaterialhusk" targetinventory="triggerer_player"/>
+                  <SpawnAction itemidentifier="geneticmaterialhusk" targetinventory="triggerer_player"/>
+                  <SpawnAction itemidentifier="geneticmaterialhusk" targetinventory="triggerer_player"/>
+                  <ReputationAction targettype="Faction" identifier="clowns" increase="-10" />
+                  <ReputationAction targettype="Faction" identifier="huskcult" increase="-3" />
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="eventtext.huskextremists1.o2">
+          <ConversationAction text="eventtext.huskextremists1.o2.c1" targettag="triggerer_player">
+            <Option text="eventtext.givingdirections.o2.o2" endconversation="true">
+              <!-- Uh oh. -->
+              <!-- Combat -->
+              <NPCChangeTeamAction npctag="cultist" teamid="Team2" />
+              <NPCWaitAction npctag="talk_cultist" wait="false" />
+              <CombatAction combatmode="Offensive" npctag="cultist" enemytag="triggerer_player" isinstigator="true" guardreaction="none" witnessreaction="retreat"/>
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="eventtext.huskextremists1.o3" endconversation="true">
+          <!-- Combat -->
+          <Label name="beforecheck2" />
+          <NPCChangeTeamAction npctag="cultist" teamid="Team2" />
+          <CombatAction combatmode="Offensive" npctag="cultist" enemytag="triggerer_player" isinstigator="true" guardreaction="none" witnessreaction="retreat"/>
+          <ReputationAction targettype="Faction" identifier="clowns" increase="5" />
+          <ReputationAction targettype="Faction" identifier="huskcult" increase="-5" />
+        </Option>
+      </ConversationAction>
+      <NPCWaitAction npctag="talk_cultist" wait="false" />
+    </ScriptedEvent>
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!--                                  Clowns                                   -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <ScriptedEvent identifier="missionevent_escort1clowns" commonness="100">
+      <ConversationAction text="EventText.missionevent_escort1clowns.c1" speakertag="clown" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="escortcommonersclowns" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_salvageclown" commonness="100">
+      <ConversationAction text="EventText.missionevent_salvageclown" speakertag="clown" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="salvageclown" />
+    </ScriptedEvent>
+    <!--"Clown relations 1"-->
+    <ScriptedEvent identifier="clownrelations1" commonness="100">
+      <SpawnAction itemidentifier="toolbelt" spawnlocation="outpost" targettag="clowntoolbelt" targetmoduletags="crewmodule" ignorebyai="true" />
+      <SpawnAction itemidentifier="bikehorn" targetinventory="clowntoolbelt" />
+      <SpawnAction itemidentifier="bikehorn" targetinventory="clowntoolbelt" />
+      <SpawnAction itemidentifier="clownmask" targetinventory="clowntoolbelt" />
+      <SpawnAction itemidentifier="clowncostume" targetinventory="clowntoolbelt" />
+      <TagAction criteria="player" tag="player" />
+      <TriggerAction target1tag="clowntoolbelt" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true" />
+      <ConversationAction targettag="triggerer_player" text="EventText.clownrelations1.c1">
+        <Option text="EventText.clownrelations1.o1">
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clown1" spawnlocation="Outpost" targetmoduletags="crewmodule" />
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clown1" spawnlocation="Outpost" targetmoduletags="crewmodule" />
+          <NPCFollowAction npctag="clown1" targettag="clowntoolbelt" follow="true" />
+          <NPCFollowAction npctag="clown2" targettag="triggerer_player" follow="true" />
+          <WaitAction time="2" />
+          <ConversationAction targettag="triggerer_player" text="EventText.clownrelations1.o1.c1" eventsprite="clown">
+            <Option text="EventText.clownrelations1.o1.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.clownrelations1.o1.o1.c1" />
+            </Option>
+            <Option text="EventText.clownrelations1.o1.o2">
+              <SpawnAction itemidentifier="bikehorn" targetinventory="triggerer_player" />
+              <ReputationAction targettype="Faction" identifier="clowns" increase="10" />
+              <ReputationAction targettype="Faction" identifier="huskcult" increase="-5" />
+              <StatusEffectAction targettag="triggerer_player">
+                <StatusEffect target="This">
+                  <Sound file="Content/Items/Weapons/honk.ogg" range="300" />
+                </StatusEffect>
+              </StatusEffectAction>
+              <ConversationAction targettag="triggerer_player" text="EventText.clownrelations1.o1.o2.c1" />
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.clownrelations1.o2" />
+      </ConversationAction>
+      <NPCFollowAction npctag="clown1" targettag="clowntoolbelt" follow="false" />
+      <NPCFollowAction npctag="clown2" targettag="triggerer_player" follow="false" />
+    </ScriptedEvent>
+    <!--"Clown relations 2"-->
+    <ScriptedEvent identifier="clownrelations2" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clown" spawnlocation="Outpost" spawnpointtype="Path" />
+      <TriggerAction target1tag="clown" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true" />
+      <NPCFollowAction npctag="clown" targettag="triggerer_player" follow="true" />
+      <ConversationAction targettag="triggerer_player" text="EventText.clownrelations2.c1" eventsprite="clown">
+        <Option text="EventText.clownrelations2.o1">
+          <CheckReputationAction targettype="faction" identifier="clowns" condition="gte 30">
+            <Success>
+              <ConversationAction targettag="triggerer_player" text="EventText.clownrelations2.o1.c1" endconversation="true"/>
+              <SpawnAction itemidentifier="bikehorn" targetinventory="triggerer_player" />
+            </Success>
+            <Failure>
+              <ConversationAction targettag="triggerer_player" text="EventText.clownrelations2.o1.c2">
+                <Option text="EventText.clownrelations2.o1.o1" />
+              </ConversationAction>
+              <AfflictionAction targettag="triggerer_player" affliction="blunttrauma" strength="3" limbtype="head" />
+              <CombatAction combatmode="retreat" npctag="clown" enemytag="triggerer_player" />
+            </Failure>
+          </CheckReputationAction>
+          <NPCFollowAction npctag="clown" targettag="triggerer_player" follow="false" />
+        </Option>
+        <Option text="EventText.clownrelations2.o2" endconversation="true">
+          <WaitAction time="10" />
+          <NPCFollowAction npctag="clown" targettag="triggerer_player" follow="false" />
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Clown brutality"-->
+    <ScriptedEvent identifier="clownbrutality" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clownnpc1" spawnlocation="Outpost" targetmoduletags="crewmodule" lootingisstealing="false" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clownnpc2" spawnlocation="Outpost" targetmoduletags="crewmodule" lootingisstealing="false" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="clownvictimnpc" spawnlocation="Outpost" targetmoduletags="crewmodule" />
+      <SpawnAction itemidentifier="toyhammer" targetinventory="clownnpc1" />
+      <SpawnAction itemidentifier="toyhammer" targetinventory="clownnpc2" />
+      <TriggerAction target1tag="clownvictimnpc" target2tag="player" radius="300" />
+      <CombatAction combatmode="offensive" npctag="clownnpc1" enemytag="clownvictimnpc" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+      <CombatAction combatmode="offensive" npctag="clownnpc2" enemytag="clownvictimnpc" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+    </ScriptedEvent>
+    <!--Infiltration-->
+    <ScriptedEvent identifier="infiltration" commonness="50">
+      <CheckDataAction identifier="infiltration_complete" condition="eq true">
+        <Success>
+          <!--Don't repeat-->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player" />
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clowntroublemaker" spawnlocation="Outpost" />
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clowntroublemaker" spawnlocation="Outpost" />
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clowntroublemaker" spawnlocation="Outpost" />
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clowntroublemaker" spawnlocation="Outpost" />
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clowntroublemaker" spawnlocation="Outpost" />
+          <SpawnAction itemidentifier="toyhammer" targetinventory="clowntroublemaker" />
+          <SpawnAction itemidentifier="toyhammer" targetinventory="clowntroublemaker" />
+          <TriggerAction target1tag="player" target2tag="outpostmanager" applytotarget1="triggerer_player" waitforinteraction="true" />
+          <ConversationAction text="EventText.infiltration.c1" targettag="triggerer_player" eventsprite="Infiltration1">
+            <Option text="EventText.infiltration.o1">
+              <ConversationAction text="EventText.infiltration.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.infiltration.o1.o1">
+                  <ConversationAction text="EventText.infiltration.o1.o1.c1" targettag="triggerer_player" eventsprite="Infiltration2">
+                    <Option text="EventText.infiltration.o1.o1.o1">
+                      <ConversationAction text="EventText.infiltration.o1.o1.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.infiltration.o1.o1.o1.o1">
+                          <ConversationAction text="EventText.infiltration.o1.o1.o1.o1.c1" targettag="triggerer_player" />
+                          <GoTo name="gotoclowns" />
+                        </Option>
+                        <Option text="EventText.infiltration.o1.o1.o1.o2" endconversation="true">
+                          <Label name="gotoclowns" />
+                          <TriggerAction target1tag="triggerer_player" target2tag="clowntroublemaker" waitforinteraction="true" allowmultipletargets="true" />
+                          <ConversationAction text="EventText.infiltration.o1.o1.o1.o2.c1" targettag="triggerer_player" eventsprite="infiltration2">
+                            <!-- threaten the clowns -->
+                            <Option text="EventText.infiltration.o1.o1.o1.o2.o1">
+                              <SkillCheckAction requiredskill="weapons" requiredlevel="50" targettag="triggerer_player">
+                                <!-- clowns flee to the airlock -->
+                                <Success>
+                                  <TagAction criteria="hullname:airlock" tag="airlock" submarinetype="Outpost" />
+                                  <ReputationAction targettype="Faction" identifier="clowns" increase="-2" />
+                                  <ReputationAction targettype="Faction" identifier="huskcult" increase="2" />
+                                  <ConversationAction targettag="triggerer_player" text="EventText.infiltration.o1.o1.o1.o2.o1.c1" eventsprite="clownambush" ContinueAutomatically="true" endconversation="true"/>
+                                  <NPCFollowAction npctag="clowntroublemaker" targettag="airlock" follow="true" />
+                                  <WaitAction time="3" />
+                                  <ConversationAction targettag="triggerer_player" text="EventText.infiltration.o1.o1.o1.o2.o1.o1.c1" eventsprite="clownambush" endconversation="true"/>
+                                  <MoneyAction amount="1000" />
+                                  <ReputationAction targettype="Location" increase="2" />
+                                  <!-- stop fleeing to not get stuck on ladder -->
+                                  <TriggerAction target1tag="clowntroublemaker" target2tag="airlock" radius="300" />
+                                  <WaitAction time="5" />
+                                  <NPCFollowAction npctag="clowntroublemaker" targettag="airlock" follow="false" />
+                                </Success>
+                                <!-- clowns laugh and bonk you -->
+                                <Failure>
+                                  <ConversationAction targettag="triggerer_player" text="EventText.infiltration.o1.o1.o1.o2.o1.c2" eventsprite="Jestmaster">
+                                    <Option text="EventText.infiltration.o1.o1.o1.o2.o1.o2" endconversation="true">
+                                      <CombatAction combatmode="offensive" npctag="clowntroublemaker" enemytag="triggerer_player" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+                                    </Option>
+                                  </ConversationAction>
+                                </Failure>
+                              </SkillCheckAction>
+                            </Option>
+                            <!-- reason with clowns -->
+                            <Option text="EventText.infiltration.o1.o1.o1.o2.o2">
+                              <!-- checks for clown gear -->
+                              <CheckItemAction targettag="triggerer_player" ItemTags="clowngear,clownmask" RequireEquipped="true">                                
+                                <Success>
+                                  <Label name="convincedclowns" />
+                                  <ConversationAction targettag="triggerer_player" text="eventtext.infiltration.clowncheckpassed" eventsprite="clownambush">
+                                    <Option text="eventtext.infiltration.wemustdepart">
+                                      <ConversationAction targettag="triggerer_player" text="eventtext.infiltration.timetoleave" eventsprite="clownambush"/>
+                                      <MissionAction missiontag="escortcommonersclowns" />
+                                      <NPCFollowAction npctag="clowntroublemaker" targettag="triggerer_player" follow="true" />
+                                    </Option>
+                                  </ConversationAction>
+                                </Success>
+                                <!-- if fails gear check, check for rep -->
+                                <Failure>
+                                  <CheckReputationAction targettype="faction" identifier="clowns" condition="gte 30">
+                                    <Success>
+                                      <Goto name="convincedclowns" />
+                                    </Success>
+                                    <Failure>
+                                      <Label name="unconvincedclowns" />
+                                      <ConversationAction targettag="triggerer_player" text="EventText.infiltration.o1.o1.o1.o2.o2.c1" eventsprite="Jestmaster">
+                                        <Option text="EventText.infiltration.o1.o1.o1.o2.o1.o2">
+                                          <ConversationAction targettag="triggerer_player" text="EventText.infiltration.o1.o1.o1.o2.o1.o2.c1" eventsprite="Jestmaster"/>
+                                        </Option>
+                                      </ConversationAction>
+                                    </Failure>
+                                  </CheckReputationAction>
+                                </Failure>
+                              </CheckItemAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.infiltration.o1.o1.o2">
+                      <!--END-->
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.infiltration.o2" endconversation="true">
+              <ReputationAction targettype="Faction" identifier="clowns" increase="5" />
+              <ReputationAction targettype="Location" increase="-2" />
+              <!--END-->
+            </Option>
+          </ConversationAction>
+          <SetDataAction identifier="infiltration_complete" value="true" />
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--Censorship-->
+    <ScriptedEvent identifier="censorship" commonness="50">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="clown" targettag="clown" targetmoduletags="clownmodule" spawnlocation="Outpost" />
+      <NPCWaitAction npctag="clown" wait="true" />
+      <Label name="beginning" />
+      <ClearTagAction tag="triggerer_player" />
+      <TriggerAction target1tag="player" target2tag="clown" applytotarget1="triggerer_player" waitforinteraction="true" />
+      <ConversationAction text="EventText.censorship.c1" targettag="triggerer_player" eventsprite="Censorship1">
+        <Option text="EventText.censorship.o1">
+          <ConversationAction text="EventText.censorship.o1.c1" targettag="triggerer_player">
+            <Option text="EventText.generic.continue">
+              <ConversationAction text="EventText.censorship.o1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.censorship.o1.o1.o1">
+                  <ConversationAction text="EventText.censorship.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" />
+                  <SpawnAction itemidentifier="metalcrate" spawnlocation="outpost" targettag="clownbox" targetmoduletags="adminmodule" ignorebyai="true" />
+                  <SpawnAction itemidentifier="bikehorn" targetinventory="clownbox" ignorebyai="true" />
+                  <SpawnAction itemidentifier="bikehorn" targetinventory="clownbox" ignorebyai="true" />
+                  <SpawnAction itemidentifier="bikehorn" targetinventory="clownbox" ignorebyai="true" />
+                  <SpawnAction itemidentifier="bikehorn" targetinventory="clownbox" ignorebyai="true" />
+                  <SpawnAction itemidentifier="bikehorn" targetinventory="clownbox" ignorebyai="true" />
+                  <SpawnAction itemidentifier="bikehorn" targetinventory="clownbox" ignorebyai="true" />
+                </Option>
+                <Option text="EventText.censorship.o1.o1.o2">
+                  <!--END-->
+                  <GoTo name="beginning" />
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.generic.ignore" endconversation="true">
+          <!--END-->
+          <GoTo name="beginning" />
+        </Option>
+      </ConversationAction>
+      <!--Trigger at box-->
+      <TriggerAction target1tag="triggerer_player" target2tag="clownbox" waitforinteraction="true" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="securitynpc[faction]" targettag="security" spawnpointtag="triggerer_player" />
+      <NPCFollowAction npctag="security" targettag="triggerer_player" follow="true" />
+      <ConversationAction text="EventText.censorship.o1.o1.o1.c1.c1" targettag="triggerer_player" eventsprite="Bombscare1">
+        <Option text="EventText.censorship.o1.o1.o1.c1.o1">
+          <ConversationAction text="EventText.censorship.o1.o1.o1.c1.o1.c1" targettag="triggerer_player">
+            <Option text="EventText.censorship.o1.o1.o1.c1.o1.o1">
+              <ConversationAction text="EventText.censorship.o1.o1.o1.c1.o1.o1.c1" targettag="triggerer_player" />
+              <RemoveItemAction targettag="clownbox" />
+            </Option>
+            <Option text="EventText.censorship.o1.o1.o1.c1.o1.o2">
+              <ConversationAction text="EventText.censorship.o1.o1.o1.c1.o1.o2.c1" targettag="triggerer_player" />
+              <CombatAction combatmode="arrest" npctag="security" enemytag="triggerer_player" isinstigator="false" guardreaction="arrest" witnessreaction="none" />
+              <ReputationAction targettype="Faction" identifier="clowns" increase="10" />
+              <ReputationAction targettype="Faction" identifier="huskcult" increase="-5" />
+              <RemoveItemAction targettag="clownbox" />
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.censorship.o1.o1.o1.c1.o2">
+          <ConversationAction text="EventText.censorship.o1.o1.o1.c1.o2.c1" targettag="triggerer_player">
+            <Option text="EventText.censorship.o1.o1.o1.c1.o2.o1">
+              <SkillCheckAction requiredskill="Helm" requiredlevel="30" targettag="triggerer_player">
+                <Success>
+                  <NPCFollowAction npctag="security" targettag="triggerer_player" follow="false" />
+                  <ConversationAction text="EventText.censorship.o1.o1.o1.c1.o2.o1.c1" targettag="triggerer_player" />
+                  <Label name="censorship_returnbox" />
+                  <TriggerAction target1tag="triggerer_player" target2tag="clown" waitforinteraction="true" />
+                  <CheckItemAction targettag="triggerer_player" itemtags="clownbox">
+                    <Success>
+                      <ConversationAction text="EventText.censorship.o1.o1.o1.c1.o2.o1.c1.c1" targettag="triggerer_player" eventsprite="Censorship1" />
+                      <RemoveItemAction targettag="clownbox" />
+                      <ReputationAction targettype="Faction" identifier="clowns" increase="10" />
+                      <ReputationAction targettype="Faction" identifier="huskcult" increase="-5" />
+                    </Success>
+                    <Failure>
+                      <ConversationAction text="EventText.censorship.o1.o1.o1.c1.o2.o1.c2.c2" targettag="triggerer_player" eventsprite="Censorship1" />
+                      <GoTo name="censorship_returnbox" />
+                    </Failure>
+                  </CheckItemAction>
+                </Success>
+                <Failure>
+                  <ConversationAction text="EventText.censorship.o1.o1.o1.c1.o2.o1.c2" targettag="triggerer_player" />
+                  <RemoveItemAction targettag="clownbox" />
+                  <ConversationAction text="EventText.censorship.o1.o1.o1.c1.o2.o1.c2.c2" speakertag="clown" targettag="triggerer_player" />
+                </Failure>
+              </SkillCheckAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+      </ConversationAction>
+      <NPCFollowAction npctag="security" targettag="triggerer_player" follow="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="clownspecialhire1">
+      <CheckDataAction identifier="pathofthebikehorn" condition="eq 7">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>
+          <CheckReputationAction targettype="faction" identifier="clowns" condition="gte 80">
+            <Failure>
+              <!-- Do nothing -->
+            </Failure>
+            <Success>
+              <CheckDataAction identifier="clownspecialhire1_hired" condition="eq true">
+                <Success>
+                  <!--Don't repeat event if already hired-->
+                </Success>
+                <Failure>
+                  <TagAction criteria="player" tag="player" />
+                  <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="jestmaster" targettag="jestmaster" spawnlocation="Outpost" allowduplicates="false" />
+                  <Label name="beginning" />
+                  <TriggerAction target1tag="jestmaster" target2tag="player" applytotarget2="triggerer_player" waitforinteraction="true" />
+                  <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="true" />
+                  <CheckDataAction identifier="clownspecialhire1_declinedonce" condition="eq true">
+                    <Failure>
+                      <!-- we haven't declined the offer before-->
+                      <ConversationAction targettag="triggerer_player" text="eventtext.clownspecialhire1.c1" eventsprite="Jestmaster">
+                        <Option text="eventtext.clownspecialhire1.o1">
+                          <ConversationAction targettag="triggerer_player" text="eventtext.clownspecialhire1.o1.c1">
+                            <Option text="eventtext.clownspecialhire1.o1.o1">
+                              <ConversationAction targettag="triggerer_player" text="eventtext.clownspecialhire1.o1.o1.c1">
+                                <Option text="eventtext.clownspecialhire1.o1.o1.o1">
+                                  <ConversationAction targettag="triggerer_player" text="eventtext.clownspecialhire1.o1.o1.o1.c1" />
+                                  <NPCChangeTeamAction npctag="jestmaster" teamid="Team1" addtocrew="true" />
+                                  <SetDataAction identifier="clownspecialhire1_hired" value="true" />
+                                  <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+                                </Option>
+                                <Option text="eventtext.clownspecialhire1.o1.o1.o2">
+                                  <ConversationAction targettag="triggerer_player" text="eventtext.clownspecialhire1.o1.o1.o2.c1" />
+                                  <SetDataAction identifier="clownspecialhire1_declinedonce" value="true" />
+                                  <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+                                  <GoTo name="beginning" />
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Failure>
+                    <Success>
+                      <!-- we've declined before, show different dialog this time -->
+                      <ConversationAction targettag="triggerer_player" text="eventtext.clownspecialhire1.repeat" eventsprite="Jestmaster">
+                        <Option text="eventtext.clownspecialhire1.o1.o1.repeat">
+                          <ConversationAction targettag="triggerer_player" text="eventtext.clownspecialhire1.o1.o1.o1.c1" />
+                          <NPCChangeTeamAction npctag="jestmaster" teamid="Team1" addtocrew="true" />
+                          <SetDataAction identifier="clownspecialhire1_hired" value="true" />
+                          <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+                        </Option>
+                        <Option text="eventtext.clownspecialhire1.o1.o2.repeat" endconversation="true">
+                          <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+                          <GoTo name="beginning" />
+                        </Option>
+                      </ConversationAction>
+                    </Success>
+                  </CheckDataAction>
+                </Failure>
+              </CheckDataAction>
+            </Success>
+          </CheckReputationAction>
+        </Success>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!-- Path of the Bike Horn 1-->
+    <ScriptedEvent identifier="pathofthebikehorn1">
+      <CheckReputationAction targettype="faction" identifier="clowns" condition="gte 15">
+        <Failure>
+          <!-- Do nothing -->
+        </Failure>
+        <Success>
+          <CheckDataAction identifier="pathofthebikehorn" condition="eq 0">
+            <Failure>
+              <!-- do nothing -->
+            </Failure>
+            <Success>
+              <TagAction criteria="player" tag="player" />
+              <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="jestmaster" targettag="jestmaster" spawnlocation="Outpost" targetmoduletags="clownmodule" />
+              <TriggerAction target1tag="player" target2tag="jestmaster" applytotarget1="triggerer_player" waitforinteraction="true" />
+              <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="true" />
+              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn1.c1" eventsprite="Jestmaster">
+                <Option text="EventText.pathofthebikehorn1.o1">
+                  <ConversationAction text="EventText.pathofthebikehorn1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.pathofthebikehorn1.o1.o1">
+                      <ConversationAction text="EventText.pathofthebikehorn1.o1.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.pathofthebikehorn1.o1.o1.o1">
+                          <GoTo name="teaching" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.pathofthebikehorn1.o2">
+                  <ReputationAction targettype="Faction" identifier="clowns" increase="-2" />
+                  <ConversationAction text="EventText.pathofthebikehorn1.o2.c1" targettag="triggerer_player">
+                    <Option text="EventText.pathofthebikehorn1.o2.o1">
+                      <ReputationAction targettype="Faction" identifier="clowns" increase="-2" />
+                    </Option>
+                    <Option text="EventText.pathofthebikehorn1.o2.o2">
+                      <ConversationAction text="EventText.pathofthebikehorn1.o2.o2.c1" targettag="triggerer_player">
+                        <Option text="EventText.pathofthebikehorn1.o2.o2.o1" endconversation="true" />
+                      </ConversationAction>
+                      <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+                      <Label name="waitforcostume" />
+                      <TriggerAction target1tag="triggerer_player" target2tag="jestmaster" waitforinteraction="true" />
+                      <CheckItemAction targettag="triggerer_player" itemtags="clownmask,clowngear">
+                        <Success>
+                          <GoTo name="teaching" />
+                        </Success>
+                        <Failure>
+                          <ConversationAction text="EventText.pathofthebikehorn1.o2.o2.c1.c1" targettag="triggerer_player" eventsprite="Jestmaster" />
+                          <GoTo name="waitforcostume" />
+                        </Failure>
+                      </CheckItemAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.pathofthebikehorn1.o3">
+                  <ConversationAction text="EventText.pathofthebikehorn1.o3.c1" targettag="triggerer_player">
+                    <Option text="EventText.pathofthebikehorn1.o3.o1">
+                      <Label name="teaching" />
+                      <ConversationAction text="EventText.pathofthebikehorn1.o3.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.pathofthebikehorn1.o3.o1.o1">
+                          <ConversationAction text="EventText.pathofthebikehorn1.o3.o1.o1.c1" targettag="triggerer_player" />
+                          <ReputationAction targettype="Faction" identifier="clowns" increase="2" />
+                          <SetDataAction identifier="pathofthebikehorn" value="1" />
+                          <SpawnAction itemidentifier="honkmotherianscriptures1" targetinventory="triggerer_player" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Success>
+          </CheckDataAction>
+          <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />              
+        </Success>
+      </CheckReputationAction>
+    </ScriptedEvent>
+    <!-- Path of the Bike Horn 2-->
+    <ScriptedEvent identifier="pathofthebikehorn2">
+      <CheckDataAction identifier="pathofthebikehorn" condition="eq 1">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>
+          <TagAction criteria="player" tag="player" />
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="jestmaster" targettag="jestmaster" spawnlocation="Outpost" targetmoduletags="clownmodule" />
+          <Label name="beginning" />
+          <TriggerAction target1tag="player" target2tag="jestmaster" applytotarget1="triggerer_player" waitforinteraction="true" />
+          <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="true" />
+          <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.c1" eventsprite="Jestmaster">
+            <Option text="EventText.pathofthebikehorn2.o1">
+              <CheckItemAction targettag="triggerer_player" itemidentifiers="clownmaskunique">
+                <Success>
+                  <ReputationAction targettype="Faction" identifier="clowns" increase="10" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.o1.c1" eventsprite="Jestmaster">
+                    <Option text="EventText.pathofthebikehorn2.o1.o1">
+                      <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.o1.o1.c1">
+                        <Option text="EventText.pathofthebikehorn2.o1.o1.o1">
+                          <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.o1.o1.o1.c1">
+                            <Option text="EventText.pathofthebikehorn2.o1.o1.o1.o1">
+                              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.o1.o1.o1.o1.c1">
+                                <Option text="EventText.pathofthebikehorn2.o1.o1.o1.o1.o1">
+                                  <Label name="teaching" />
+                                  <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.o1.o1.o1.o1.o1.c1">
+                                    <Option text="EventText.pathofthebikehorn2.o1.o1.o1.o1.o1.o1">
+                                      <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.o1.o1.o1.o1.o1.o1.c1">
+                                        <Option text="EventText.pathofthebikehorn2.o1.o1.o1.o1.o1.o1.o1">
+                                          <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.o1.o1.o1.o1.o1.o1.o1.c1"/>
+                                          <SetDataAction identifier="pathofthebikehorn" value="2" />
+                                          <ReputationAction targettype="Faction" identifier="clowns" increase="2" />
+                                          <SpawnAction itemidentifier="honkmotherianscriptures2" targetinventory="triggerer_player" />
+                                        </Option>
+                                        <Option text="EventText.pathofthebikehorn2.o1.o1.o1.o1.o1.o1.o2">
+                                          <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.o1.o1.o1.o1.o1.o1.o2.c1"/>
+                                          <SetDataAction identifier="pathofthebikehorn" value="2" />
+                                          <ReputationAction targettype="Faction" identifier="clowns" increase="2" />
+                                          <SpawnAction itemidentifier="honkmotherianscriptures2" targetinventory="triggerer_player" />
+                                        </Option>
+                                      </ConversationAction>
+                                    </Option>
+                                  </ConversationAction>
+                                </Option>
+                                <Option text="EventText.pathofthebikehorn2.o1.o1.o1.o1.o2">
+                                  <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.o1.o1.o1.o1.o2.c1">
+                                    <Option text="EventText.pathofthebikehorn2.o1.o1.o1.o1.o2.o1">
+                                      <GoTo name="teaching" />
+                                    </Option>
+                                  </ConversationAction>
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Success>
+                <Failure>
+                  <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.o1.c2" eventsprite="Jestmaster" />
+                  <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+                  <Goto name="beginning" />
+                </Failure>
+              </CheckItemAction>
+            </Option>
+            <Option text="EventText.pathofthebikehorn2.o2">
+              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn2.o2.c1" eventsprite="Jestmaster">
+                <Option text="EventText.pathofthebikehorn2.o2.o1" endconversation="true">
+                  <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+                  <Goto name="beginning" />
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Success>
+      </CheckDataAction>
+      <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+    </ScriptedEvent>
+    <!-- Hitting an abyss monster with a toy hammer-->
+    <ScriptedEvent identifier="toyhammeronabyssmonster">
+      <CheckDataAction identifier="pathofthebikehorn" condition="eq 2">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>
+          <SetDataAction identifier="pathofthebikehorn" value="3" />
+          <ReputationAction targettype="Faction" identifier="clowns" increase="5" />
+          <!-- target tag is set by the status effect that triggers this event (defined in the toy hammer) -->
+          <ConversationAction text="EventText.toyhammeronabyssmonster.c1" targettag="statuseffectuser" eventsprite="Jestmaster" />
+        </Success>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!-- Path of the Bike Horn 3 -->
+    <ScriptedEvent identifier="pathofthebikehorn3">
+      <CheckDataAction identifier="pathofthebikehorn" condition="eq 3">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>
+          <TagAction criteria="player" tag="player" />
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="jestmaster" targettag="jestmaster" spawnlocation="Outpost" targetmoduletags="clownmodule" />
+          <TriggerAction target1tag="player" target2tag="jestmaster" applytotarget1="triggerer_player" waitforinteraction="true" />
+          <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="true" />
+          <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn3.c0" eventsprite="Jestmaster">
+            <Option text="EventText.pathofthebikehorn3.o0">
+              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn3.c1" eventsprite="Jestmaster">
+                <Option text="EventText.pathofthebikehorn3.o1">
+                  <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn3.o1.c1">
+                    <Option text="EventText.pathofthebikehorn3.o1.o1">
+                      <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn3.o1.o1.c1">
+                        <Option text="EventText.pathofthebikehorn3.o1.o1.o1">
+                          <GoTo name="idontgetit" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.pathofthebikehorn3.o1.o2">
+                      <GoTo name="idontgetit" />
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.pathofthebikehorn3.o2">
+                  <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn3.o2.c1">
+                    <Option text="EventText.pathofthebikehorn3.o2.o1">
+                      <Label name="idontgetit" />
+                      <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn3.o2.o1.c1">
+                        <Option text="EventText.pathofthebikehorn3.o2.o1.o1">
+                          <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn3.o2.o1.o1.c1">
+                            <Option text="EventText.pathofthebikehorn3.o2.o1.o1.o1">
+                              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn3.o2.o1.o1.o1.c1" endconversation="true" />
+                              <ReputationAction targettype="Faction" identifier="clowns" increase="3" />
+                              <SetDataAction identifier="pathofthebikehorn" value="4" />
+                            </Option>
+                            <Option text="EventText.pathofthebikehorn3.o2.o1.o1.o2">
+                              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn3.o2.o1.o1.o2.c1" endconversation="true" />
+                              <ReputationAction targettype="Faction" identifier="clowns" increase="6" />
+                              <SetDataAction identifier="pathofthebikehorn" value="4" />
+                            </Option>
+                            <Option text="EventText.pathofthebikehorn3.o2.o1.o1.o3">
+                              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn3.o2.o1.o1.o3.c1" endconversation="true" />
+                              <ReputationAction targettype="Faction" identifier="clowns" increase="1" />
+                              <SetDataAction identifier="pathofthebikehorn" value="4" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Success>
+      </CheckDataAction>
+      <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+    </ScriptedEvent>
+    <!-- Path of the Bike Horn 4 -->
+    <ScriptedEvent identifier="pathofthebikehorn4">
+      <CheckDataAction identifier="pathofthebikehorn" condition="eq 4">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>
+          <TagAction criteria="player" tag="player" />
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="jestmaster" targettag="jestmaster" spawnlocation="Outpost" targetmoduletags="clownmodule" />
+          <Label name="beginning" />
+          <TriggerAction target1tag="player" target2tag="jestmaster" applytotarget1="triggerer_player" waitforinteraction="true" />
+          <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="true" />
+          <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn4.c1" eventsprite="Jestmaster">
+            <Option text="EventText.pathofthebikehorn4.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn4.o1.c1">
+                <Option text="EventText.pathofthebikehorn4.o1.o1">
+                  <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn4.o1.o1.c1">
+                    <Option text="EventText.pathofthebikehorn4.o1.o1.o1">
+                      <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn4.o1.o1.o1.c1">
+                        <Option text="EventText.pathofthebikehorn4.o1.o1.o1.o1">
+                          <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn4.o1.o1.o1.o1.c1">
+                            <Option text="EventText.pathofthebikehorn4.o1.o1.o1.o1.o1">
+                              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn4.o1.o1.o1.o1.o1.c1">
+                                <Option text="EventText.pathofthebikehorn4.o1.o1.o1.o1.o1.o1">
+                                  <Label name="takemission" />
+                                  <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn4.o1.o1.o1.o1.o1.o1.c1" endconversation="true" />
+                                  <ReputationAction targettype="Faction" identifier="clowns" increase="1" />
+                                  <SetDataAction identifier="pathofthebikehorn" value="5" />
+                                  <SpawnAction itemidentifier="clownexosuit" targetinventory="triggerer_player" targettag="clownexosuit" />
+                                  <SpawnAction itemidentifier="fuelrod" targetinventory="clownexosuit" />
+                                  <SpawnAction itemidentifier="oxygentank" targetinventory="clownexosuit" />
+                                  <MissionAction missionidentifier="gotoclownhaven" locationtype="City" requiredfaction="clowns" minlocationdistance="1" CreateLocationIfNotFound="true" />
+                                </Option>
+                                <Option text="EventText.pathofthebikehorn4.o1.o1.o1.o1.o1.o2" endconversation="true">
+                                  <Label name="thinkaboutthis" />
+                                  <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+                                  <TriggerAction target1tag="player" target2tag="jestmaster" applytotarget1="triggerer_player" waitforinteraction="true" />
+                                  <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="true" />
+                                  <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn4.o1.o1.o1.o1.o1.o2.c1" eventsprite="Jestmaster">
+                                    <Option text="EventText.pathofthebikehorn4.o1.o1.o1.o1.o1.o2.o1">
+                                      <GoTo name="takemission" />
+                                    </Option>
+                                    <Option text="EventText.pathofthebikehorn4.o1.o1.o1.o1.o1.o2.o2" endconversation="true">
+                                      <GoTo name="thinkaboutthis" />
+                                    </Option>
+                                  </ConversationAction>
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.pathofthebikehorn4.o2" endconversation="true">
+              <GoTo name="beginning" />
+            </Option>
+          </ConversationAction>
+        </Success>
+      </CheckDataAction>
+      <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="clownhaven1">
+      <SetDataAction identifier="clownhaven_peopleannoyed" operation="Set" value="1" />
+      <CheckDataAction identifier="pathofthebikehorn" condition="eq 5">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>
+          <TagAction criteria="player" tag="player" />
+          <Label name="beginning" />
+          <WaitAction time="5" />
+          <CheckItemAction targettag="player" itemidentifiers="clownexosuit" applytagtotarget="funbringer">
+            <Success>
+              <!-- do nothing and allow the event to continue-->
+            </Success>
+            <Failure>
+              <GoTo name="beginning" />
+            </Failure>
+          </CheckItemAction>
+          <WaitAction time="1" />
+          <ConversationAction text="EventText.clownhaven1.c1" eventsprite="Infiltration2" />
+          <Label name="state1" />
+          <WaitAction time="1" />
+          <CheckDataAction identifier="clownhaven_peopleannoyed" condition="gt 1">
+            <Failure>
+              <Goto name="state1" />
+            </Failure>
+            <Success>
+              <ConversationAction text="EventText.clownhaven1.c1.c1" eventsprite="Infiltration2" />
+            </Success>
+          </CheckDataAction>
+          <!-- commoners flee -->
+          <Label name="state2" />
+          <CombatAction combatmode="retreat" npctag="commoner" enemytag="funbringer" isinstigator="false" guardreaction="arrest" witnessreaction="retreat" />
+          <WaitAction time="5" />
+          <CheckDataAction identifier="clownhaven_peopleannoyed" condition="gt 10">
+            <Failure>
+              <Goto name="state2" />
+            </Failure>
+            <Success>
+              <ConversationAction text="EventText.clownhaven1.c1.c2" eventsprite="Infiltration2" />
+            </Success>
+          </CheckDataAction>
+          <ReputationAction targettype="Faction" identifier="clowns" increase="2" />
+          <!-- clowns in the outpost start following the player -->
+          <Label name="state3" />
+          <NPCFollowAction npctag="clown" targettag="funbringer" maxtargets="1000" follow="true" />
+          <CombatAction combatmode="retreat" npctag="commoner" enemytag="funbringer" isinstigator="false" guardreaction="arrest" witnessreaction="retreat" />
+          <WaitAction time="5" />
+          <CheckDataAction identifier="clownhaven_peopleannoyed" condition="gt 20">
+            <Failure>
+              <Goto name="state3" />
+            </Failure>
+            <Success>
+              <ConversationAction text="EventText.clownhaven1.c1.c3" eventsprite="Infiltration2" />
+            </Success>
+          </CheckDataAction>
+          <!-- security tries to arrest the player -->
+          <Label name="state4" />
+          <CombatAction combatmode="arrest" npctag="securitynpc" enemytag="funbringer" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+          <WaitAction time="5" />
+          <CheckDataAction identifier="clownhaven_peopleannoyed" condition="gt 35">
+            <Failure>
+              <Goto name="state4" />
+            </Failure>
+            <Success>
+              <ConversationAction text="EventText.clownhaven1.c1.c4" eventsprite="NoticeBoard" />
+            </Success>
+          </CheckDataAction>
+          <!-- security tries to kill the player -->
+          <Label name="state5" />
+          <WaitAction time="5" />
+          <CombatAction combatmode="offensive" npctag="securitynpc" enemytag="funbringer" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+          <CheckDataAction identifier="clownhaven_peopleannoyed" condition="gte 40">
+            <Failure>
+              <Goto name="state5" />
+            </Failure>
+            <Success />
+          </CheckDataAction>
+          <WaitAction time="10" />
+          <NPCFollowAction npctag="securitynpc" targettag="outpostmanager" follow="true" />
+          <NPCFollowAction npctag="commonner" targettag="outpostmanager" follow="true" />
+          <ConversationAction text="EventText.clownhaven1.c1.c5" eventsprite="NoticeBoard" />
+          <ModifyLocationAction faction="Clowns" name="location.clownhaven" />
+          <SetDataAction identifier="pathofthebikehorn" value="6" />
+          <ReputationAction targettype="Faction" identifier="clowns" increase="10" />
+          <ReputationAction targettype="Faction" identifier="huskcult" increase="-5" />
+        </Success>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <ScriptedEvent identifier="clownhaven_progress">
+      <CheckDataAction identifier="pathofthebikehorn" condition="eq 5">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>          
+          <CheckMissionAction MissionIdentifier="gotoclownhaven" Type="Current">
+            <Failure>
+              <!-- do nothing -->
+            </Failure>
+            <Success>
+              <MissionStateAction missionidentifier="gotoclownhaven" operation="Add" value="1" />
+              <SetDataAction identifier="clownhaven_peopleannoyed" operation="Add" value="1" />
+            </Success>
+          </CheckMissionAction>
+        </Success>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!-- Path of the Bike Horn 5 -->
+    <ScriptedEvent identifier="pathofthebikehorn5">
+      <!-- check for state 6: state 5 for the clownhaven event -->
+      <CheckDataAction identifier="pathofthebikehorn" condition="gte 6">
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+        <Success>
+          <TagAction criteria="player" tag="player" />
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="jestmaster" targettag="jestmaster" spawnlocation="Outpost" targetmoduletags="clownmodule" />
+          <CheckDataAction identifier="pathofthebikehorn" condition="eq 6">
+            <Failure>
+              <!-- do nothing -->
+            </Failure>
+            <Success>
+              <TriggerAction target1tag="player" target2tag="jestmaster" applytotarget1="triggerer_player" waitforinteraction="true" />
+              <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="true" />              
+              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn5.c1" eventsprite="Jestmaster">
+                <Option text="EventText.pathofthebikehorn5.o1">
+                  <ReputationAction targettype="Faction" identifier="clowns" increase="5" />
+                  <ReputationAction targettype="Faction" identifier="huskcult" increase="-2" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn5.o1.c1">
+                    <Option text="EventText.pathofthebikehorn5.o1.o1">
+                      <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn5.o1.o1.c1">
+                        <Option text="EventText.pathofthebikehorn5.o1.o1.o1">
+                          <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn5.o1.o1.o1.c1">
+                            <Option text="EventText.pathofthebikehorn5.o1.o1.o1.o1">
+                              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn5.o1.o1.o1.o1.c1" endconversation="true" />
+                              <SetDataAction identifier="pathofthebikehorn" value="7" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>              
+            </Success>
+          </CheckDataAction>
+          <Label name="moreadvicepls" />
+          <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="false" />
+          <TriggerAction target1tag="player" target2tag="jestmaster" applytotarget1="triggerer_player" waitforinteraction="true" />
+          <NPCFollowAction npctag="jestmaster" targettag="triggerer_player" follow="true" />
+          <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn5.c1.c1" eventsprite="Jestmaster">
+            <Option text="EventText.pathofthebikehorn5.c1.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.pathofthebikehorn5.c1.o1.c1">
+                <Option text="EventText.pathofthebikehorn5.c1.o1.o1" endconversation="true">
+                  <Goto name="moreadvicepls" />
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Success>
+      </CheckDataAction>
+    </ScriptedEvent>
+  </EventPrefabs>
+</RandomEvents>

--- a/OutpostEvents.xml
+++ b/OutpostEvents.xml
@@ -1785,7 +1785,7 @@
     </ScriptedEvent>
     <!--A man and his raptor-->
     <!--PART 1-->
-    <ScriptedEvent identifier="manandhisraptor1" commonness="50">
+    <ScriptedEvent identifier="manandhisraptor1" commonness="50" requiredDestinationTypes="outpost,city,research,military,mine">
       <CheckDataAction identifier="manandhisraptor_missionreceived" condition="eq true">
         <Success>
           <!--Don't repeat-->
@@ -1909,7 +1909,7 @@
     </ScriptedEvent>
 
     <!-- radiation escapee -->
-    <ScriptedEvent identifier="radiationescapee" commonness="50">
+    <ScriptedEvent identifier="radiationescapee" commonness="50" requiredDestinationTypes="outpost,city,research,military,mine">
       <CheckDataAction identifier="radiationescapee_missionreceived" condition="eq true">
         <Success>
           <!--Don't repeat-->
@@ -1954,7 +1954,7 @@
       </CheckDataAction>
     </ScriptedEvent>
     <!-- researcher escort -->
-    <ScriptedEvent identifier="researcherescort" commonness="50">
+    <ScriptedEvent identifier="researcherescort" commonness="50" requiredDestinationTypes="outpost,city,research,military,mine">
       <CheckDataAction identifier="researcherescort_missionreceived" condition="eq true">
         <Success>
           <!--Don't repeat-->

--- a/OutpostEvents.xml
+++ b/OutpostEvents.xml
@@ -2896,7 +2896,7 @@
       <ConversationAction text="EventText.missionevent_killmonster.c1" speakertag="missionnpc" endeventifinterrupted="false" dialogtype="Small"/>
       <MissionAction missiontag="killmonster_set1" />
     </ScriptedEvent>
-    <ScriptedEvent identifier="missionevent_cargo" commonness="100">
+    <ScriptedEvent identifier="missionevent_cargo" commonness="100" requiredDestinationTypes="outpost,city,research,military,mine">
       <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="missionnpc" spawnlocation="Outpost" spawnpointtype="Path" />
       <ConversationAction text="EventText.missionevent_cargo.c1" speakertag="missionnpc" endeventifinterrupted="false" dialogtype="Small"/>
       <MissionAction missiontag="cargo" />
@@ -2906,7 +2906,7 @@
       <ConversationAction text="EventText.missionevent_salvage.c1" speakertag="missionnpc" endeventifinterrupted="false" dialogtype="Small" />
       <MissionAction missiontag="salvage" />
     </ScriptedEvent>
-    <ScriptedEvent identifier="missionevent_clownoutbreak" commonness="40">
+    <ScriptedEvent identifier="missionevent_clownoutbreak" commonness="40" requiredDestinationTypes="outpost,city,research,military,mine">
       <TagAction criteria="player" tag="player" />
       <TagAction criteria="itemidentifier:opdeco_hrflyers" tag="potentialflyers" submarinetype="outpost" />
       <TriggerAction target1tag="potentialflyers" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true"/>
@@ -2923,49 +2923,49 @@
       </ConversationAction>
     </ScriptedEvent>
     <!--MANAGER MISSIONS-->
-    <ScriptedEvent identifier="missionevent_cargo1" commonness="125">
+    <ScriptedEvent identifier="missionevent_cargo1" commonness="125" requiredDestinationTypes="outpost,city,research,military,mine">
       <NPCWaitAction npctag="outpostmanager" wait="true" />
       <ConversationAction text="EventText.missionevent_cargo1.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
       <MissionAction missiontag="cargomaterials" />
       <NPCWaitAction npctag="outpostmanager" wait="false" />
     </ScriptedEvent>
-    <ScriptedEvent identifier="missionevent_cargo2" commonness="50">
+    <ScriptedEvent identifier="missionevent_cargo2" commonness="50" requiredDestinationTypes="outpost,city,research,military,mine">
       <NPCWaitAction npctag="outpostmanager" wait="true" />
       <ConversationAction text="EventText.missionevent_cargo2.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
       <MissionAction missiontag="cargoexplosive" />
       <NPCWaitAction npctag="outpostmanager" wait="false" />
     </ScriptedEvent>
-    <ScriptedEvent identifier="missionevent_cargo3" commonness="100">
+    <ScriptedEvent identifier="missionevent_cargo3" commonness="100" requiredDestinationTypes="outpost,city,research,military,mine">
       <NPCWaitAction npctag="outpostmanager" wait="true" />
       <ConversationAction text="EventText.missionevent_cargo3.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
       <MissionAction missiontag="cargoresearch" />
       <NPCWaitAction npctag="outpostmanager" wait="false" />
     </ScriptedEvent>
-    <ScriptedEvent identifier="missionevent_cargoany" commonness="100">
+    <ScriptedEvent identifier="missionevent_cargoany" commonness="100" requiredDestinationTypes="outpost,city,research,military,mine">
       <NPCWaitAction npctag="outpostmanager" wait="true" />
       <ConversationAction text="EventText.missionevent_cargo1.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
       <MissionAction missiontag="cargo" />
       <NPCWaitAction npctag="outpostmanager" wait="false" />
     </ScriptedEvent>
-    <ScriptedEvent identifier="missionevent_cargo_difficult" commonness="75">
+    <ScriptedEvent identifier="missionevent_cargo_difficult" commonness="75" requiredDestinationTypes="outpost,city,research,military,mine">
       <NPCWaitAction npctag="outpostmanager" wait="true" />
       <ConversationAction text="EventText.missionevent_cargo_difficult.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
       <MissionAction missiontag="cargodifficult" />
       <NPCWaitAction npctag="outpostmanager" wait="false" />
     </ScriptedEvent>
-    <ScriptedEvent identifier="missionevent_cargoweaponscoalition" commonness="100">
+    <ScriptedEvent identifier="missionevent_cargoweaponscoalition" commonness="100" requiredDestinationTypes="outpost,city,research,military,mine">
       <NPCWaitAction npctag="outpostmanager" wait="true" />
       <ConversationAction text="EventText.missionevent_cargoweaponscoalition.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
       <MissionAction missiontag="cargoweaponscoalition" />
       <NPCWaitAction npctag="outpostmanager" wait="false" />
     </ScriptedEvent>
-    <ScriptedEvent identifier="missionevent_cargoexplosiveseparatists" commonness="100">
+    <ScriptedEvent identifier="missionevent_cargoexplosiveseparatists" commonness="100" requiredDestinationTypes="outpost,city,research,military,mine">
       <NPCWaitAction npctag="outpostmanager" wait="true" />
       <ConversationAction text="EventText.missionevent_cargocompoundn.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
       <MissionAction missiontag="cargoexplosiveseparatists" />
       <NPCWaitAction npctag="outpostmanager" wait="false" />
     </ScriptedEvent>
-    <ScriptedEvent identifier="missionevent_cargoexplosiveseparatistsvolatile" commonness="100">
+    <ScriptedEvent identifier="missionevent_cargoexplosiveseparatistsvolatile" commonness="100" requiredDestinationTypes="outpost,city,research,military,mine">
       <NPCWaitAction npctag="outpostmanager" wait="true" />
       <ConversationAction text="EventText.missionevent_cargocompoundn.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
       <MissionAction missiontag="cargoexplosiveseparatistsvolatile" />
@@ -3127,49 +3127,49 @@
       <MissionAction missiontag="collectminerals_set4" />
       <NPCWaitAction npctag="outpostmanager" wait="false" />
     </ScriptedEvent>
-    <ScriptedEvent identifier="missionevent_escort1coalition" commonness="100">
+    <ScriptedEvent identifier="missionevent_escort1coalition" commonness="100" requiredDestinationTypes="outpost,city,research,military,mine">
       <NPCWaitAction npctag="outpostmanager" wait="true" />
       <ConversationAction text="EventText.missionevent_escort1.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
       <MissionAction missiontag="escortcommonerscoalition" />
       <NPCWaitAction npctag="outpostmanager" wait="false" />
     </ScriptedEvent>
-    <ScriptedEvent identifier="missionevent_escort2coalition" commonness="80">
+    <ScriptedEvent identifier="missionevent_escort2coalition" commonness="80" requiredDestinationTypes="outpost,city,research,military,mine">
       <NPCWaitAction npctag="outpostmanager" wait="true" />
       <ConversationAction text="EventText.missionevent_escort2.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
       <MissionAction missiontag="escortVIPcoalition" />
       <NPCWaitAction npctag="outpostmanager" wait="false" />
     </ScriptedEvent>
-    <ScriptedEvent identifier="missionevent_escort3coalition" commonness="60">
+    <ScriptedEvent identifier="missionevent_escort3coalition" commonness="60" requiredDestinationTypes="outpost,city,research,military,mine">
       <NPCWaitAction npctag="outpostmanager" wait="true" />
       <ConversationAction text="EventText.missionevent_escort3.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
       <MissionAction missiontag="escortprisonerscoalition" />
       <NPCWaitAction npctag="outpostmanager" wait="false" />
     </ScriptedEvent>
-    <ScriptedEvent identifier="missionevent_escort4coalition" commonness="60">
+    <ScriptedEvent identifier="missionevent_escort4coalition" commonness="60" requiredDestinationTypes="outpost,city,research,military,mine">
       <NPCWaitAction npctag="outpostmanager" wait="true" />
       <ConversationAction text="EventText.missionevent_escort4.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
       <MissionAction missiontag="escortterroristscoalition" />
     </ScriptedEvent>
 
-    <ScriptedEvent identifier="missionevent_escort1separatists" commonness="100">
+    <ScriptedEvent identifier="missionevent_escort1separatists" commonness="100" requiredDestinationTypes="outpost,city,research,military,mine">
       <NPCWaitAction npctag="outpostmanager" wait="true" />
       <ConversationAction text="EventText.missionevent_escort1separatists.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
       <MissionAction missiontag="escortcommonersseparatists" />
       <NPCWaitAction npctag="outpostmanager" wait="false" />
     </ScriptedEvent>
-    <ScriptedEvent identifier="missionevent_escort2separatists" commonness="80">
+    <ScriptedEvent identifier="missionevent_escort2separatists" commonness="80" requiredDestinationTypes="outpost,city,research,military,mine">
       <NPCWaitAction npctag="outpostmanager" wait="true" />
       <ConversationAction text="EventText.missionevent_escort2separatists.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
       <MissionAction missiontag="escortVIPseparatists" />
       <NPCWaitAction npctag="outpostmanager" wait="false" />
     </ScriptedEvent>
-    <ScriptedEvent identifier="missionevent_escort3separatists" commonness="60">
+    <ScriptedEvent identifier="missionevent_escort3separatists" commonness="60" requiredDestinationTypes="outpost,city,research,military,mine">
       <NPCWaitAction npctag="outpostmanager" wait="true" />
       <ConversationAction text="EventText.missionevent_escort3separatists.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
       <MissionAction missiontag="escortprisonersseparatists" />
       <NPCWaitAction npctag="outpostmanager" wait="false" />
     </ScriptedEvent>
-    <ScriptedEvent identifier="missionevent_escort4separatists" commonness="60">
+    <ScriptedEvent identifier="missionevent_escort4separatists" commonness="60" requiredDestinationTypes="outpost,city,research,military,mine">
       <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 30">
         <Success>
           <NPCWaitAction npctag="outpostmanager" wait="true" />

--- a/OutpostEvents.xml
+++ b/OutpostEvents.xml
@@ -1,0 +1,3673 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Randomevents>
+  
+  <!-- Define flavor sprites that appear top left of the message box here, identifier is required -->
+  <EventSprites>
+    <Sprite identifier="gambler" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="559,6,165,240" origin="0.5,0.5"/>
+    <Sprite identifier="cultist" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="37,507,182,249" origin="0.5,0.5"/>
+    <Sprite identifier="mediator" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="267,5,225,242" origin="0.5,0.5"/>
+    <Sprite identifier="huskinvite" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="555,775,182,248" origin="0.5,0.5"/>
+    <Sprite identifier="map" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="259,521,249,240" origin="0.5,0.5"/>
+    <Sprite identifier="vent" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="507,0,249,252" origin="0.5,0.5"/>
+    <Sprite identifier="brokenterminal" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="768,0,244,251" origin="0.5,0.5"/>    
+    <Sprite identifier="ambush" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="261,542,248,174" origin="0.5,0.5"/>
+    <Sprite identifier="trashcan" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="771,15,244,241" origin="0.5,0.5"/>
+    <Sprite identifier="clown" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="544,259,182,249" origin="0.5,0.5"/>
+    <Sprite identifier="unconscious" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="770,321,241,152" origin="0.5,0.5"/>
+    <Sprite identifier="noticeboard" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="263,523,243,231" origin="0.5,0.5"/>
+    <Sprite identifier="ventinside" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="510,520,248,242" origin="0.5,0.5"/>
+    <Sprite identifier="redbluebottles" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="549,516,182,248" origin="0.5,0.5"/>
+    <Sprite identifier="redyellowbottles" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="764,520,243,232" origin="0.5,0.5"/>
+    <Sprite identifier="dorm" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="267,269,231,237" origin="0.5,0.5"/>
+    <Sprite identifier="cleaner" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="34,1,182,242" origin="0.5,0.5"/>
+    <Sprite identifier="note" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="808,768,182,247" origin="0.5,0.5"/>
+    <Sprite identifier="noteopened" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="812,514,182,247" origin="0.5,0.5"/>
+    <Sprite identifier="group" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="37,772,182,247" origin="0.5,0.5"/>
+    <Sprite identifier="mechanic" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="553,775,182,248" origin="0.5,0.5"/>
+    <Sprite identifier="crowd" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="1,293,248,174" origin="0.5,0.5"/>
+    <Sprite identifier="clownambush" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="519,280,241,219" origin="0.5,0.5"/>
+    <Sprite identifier="office" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="34,256,182,248" origin="0.5,0.5"/>
+    <Sprite identifier="mines" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="760,772,246,245" origin="0.5,0.5"/>
+    <Sprite identifier="oldman" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="28,516,202,249" origin="0.5,0.5"/>
+    <Sprite identifier="security" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="294,775,182,248" origin="0.5,0.5"/>
+    <Sprite identifier="captain" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="34,0,182,251" origin="0.5,0.5"/>
+    <Sprite identifier="officeinside" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="766,264,245,230" origin="0.5,0.5"/>
+    <Sprite identifier="JacovSubra1" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="0,0,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="JacovSubra2" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="256,0,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="JacovSubra3" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="512,0,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="JacovSubra4" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="768,0,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Infiltration1" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="0,256,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Infiltration2" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="256,256,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Terrorism1" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="512,256,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Terrorism2" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="768,256,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Stuckinthemiddle1" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="0,512,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Censorship1" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="256,512,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="BadVibration1" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="512,512,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="BadVibration2" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="768,512,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="BombScare1" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="0,768,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="BombScare2" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="256,768,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Stowaway1A" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="512,768,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Stowaway1B" texture="Content/Map/Outposts/Art/Event_pic3.png" sourcerect="768,768,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Stowaway2" texture="Content/Map/Outposts/Art/Event_pic4.png" sourcerect="0,0,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="ShockJock" texture="Content/Map/Outposts/Art/Event_pic4.png" sourcerect="256,0,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="HeartOfGold" texture="Content/Map/Outposts/Art/Event_pic4.png" sourcerect="512,0,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="ManAndHisRaptor" texture="Content/Map/Outposts/Art/Event_pic4.png" sourcerect="768,0,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Receptiondude" texture="Content/Map/Outposts/Art/Event_pic4.png" sourcerect="0,256,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Instructor" texture="Content/Map/Outposts/Art/Event_pic4.png" sourcerect="256,256,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Ancient1" texture="Content/Map/Outposts/Art/Event_pic4.png" sourcerect="512,256,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Ancient2" texture="Content/Map/Outposts/Art/Event_pic4.png" sourcerect="768,256,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="engineer" texture="Content/Map/Outposts/Art/Event_pic4.png" sourcerect="0,512,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Separatists" texture="Content/Map/Outposts/Art/Event_pic4.png" sourcerect="256,512,256,256" origin="0.5,0.5"/> 
+    <Sprite identifier="Coalition" texture="Content/Map/Outposts/Art/Event_pic2.png" sourcerect="256,0,256,256" origin="0.5,0.5"/> 
+    <Sprite identifier="Ecclesiast" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="256,256,256,256" origin="0.5,0.5"/>
+    <Sprite identifier="Jestmaster" texture="Content/Map/Outposts/Art/Event_pic1.png" sourcerect="256,768,256,256" origin="0.5,0.5"/>
+  </EventSprites>
+
+
+
+  <!-- Events defined in <EventPrefabs> can only be triggered via a console command or with a TriggerEventAction -->
+  <EventPrefabs>
+    <!-- test event -->
+    <ScriptedEvent identifier="testevent">
+      <ConversationAction text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." eventsprite="cultist">
+        <Option text="Next">
+          <ConversationAction text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." eventsprite="huskinvite">
+            <Option text="Next">
+              <ConversationAction text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." eventsprite="cultist">
+                <Option text="Next">
+                  <ConversationAction text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." eventsprite="mediator" closedialog="true" />
+                </Option>
+                <Option text="End" endconversation="true">
+                  <TagAction criteria="player" tag="player"/>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="End"/>
+          </ConversationAction>
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+
+    <!-- No longer used in the vanilla content -->
+    <ScriptedEvent identifier="forcebeaconmission" requirebeaconstation="True">
+      <MissionAction missiontag="specialbeaconmission" />
+    </ScriptedEvent>
+
+    <!--"Giving directions"-->
+    <ScriptedEvent identifier="givingdirections" commonness="100">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="captain" targettag="givingdirections_captain" spawnlocation="Outpost" spawnpointtype="Path" targetmoduletags="crewmodule" />
+      <TagAction criteria="player" tag="player" />
+      <TriggerAction target1tag="givingdirections_captain" target2tag="player" applytotarget2="triggerer_player" radius="100" waitforinteraction="true"/>
+      <NPCWaitAction npctag="givingdirections_captain" wait="true" />
+      <ConversationAction targettag="triggerer_player" text="EventText.givingdirections.c1" eventsprite="captain">
+        <Option text="EventText.givingdirections.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.givingdirections.o1.c1">
+            <Option text="EventText.givingdirections.o1.o1">
+              <SkillCheckAction requiredskill="Helm" requiredlevel="50" targettag="triggerer_player">
+                <Success>
+                  <GiveSkillEXPAction skill="helm" amount="5" targettag="triggerer_player" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.givingdirections.o1.o1.c1">
+                    <Option text="EventText.givingdirections.o1.o1.o1" />
+                  </ConversationAction>
+                </Success>
+                <Failure>
+                  <ConversationAction targettag="triggerer_player" text="EventText.givingdirections.o1.o1.c2">
+                    <Option text="EventText.givingdirections.o1.o1.o2" />
+                  </ConversationAction>
+                </Failure>
+              </SkillCheckAction>
+            </Option>
+            <Option text="EventText.givingdirections.o1.o2" />
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.givingdirections.o2">
+          <RNGAction chance="0.15">
+            <Success>
+              <ConversationAction targettag="triggerer_player" text="EventText.givingdirections.o2.c1">
+                <Option text="EventText.givingdirections.o2.o1" endconversation="true">
+                  <SpawnAction itemidentifier="revolver" targettag="prizerevolver" targetinventory="triggerer_player" />
+                  <SpawnAction itemidentifier="revolverround" targetinventory="prizerevolver" />
+                  <SpawnAction itemidentifier="revolverround" targetinventory="prizerevolver" />
+                  <SpawnAction itemidentifier="revolverround" targetinventory="prizerevolver" />
+                </Option>
+              </ConversationAction>
+            </Success>
+            <Failure>
+              <ConversationAction targettag="triggerer_player" text="EventText.givingdirections.o2.c2">
+                <Option text="EventText.givingdirections.o2.o2" />
+              </ConversationAction>
+              <CombatAction combatmode="Offensive" npctag="givingdirections_captain" enemytag="triggerer_player" isinstigator="false" guardreaction="none" witnessreaction="retreat"/>
+            </Failure>
+          </RNGAction>
+        </Option>
+        <Option text="EventText.givingdirections.o3" />
+      </ConversationAction>
+      <NPCWaitAction npctag="givingdirections_captain" wait="false" />
+    </ScriptedEvent>
+    <!--"A sound in the vent"
+    TODO:
+    -follow-up event?-->
+    <ScriptedEvent identifier="soundinthevent" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemtag:mudraptorspawnvent" tag="mudraptorspawnvent" SubmarineType="Outpost" chooserandom="true" />
+      <TriggerAction target1tag="mudraptorspawnvent" target2tag="player" applytotarget1="looseventspawnpoint" applytotarget2="triggerer_player" radius="150"/>
+      <SpawnAction itemidentifier="loosevent" spawnlocation="Outpost" SpawnPointTag="looseventspawnpoint" TargetTag="selectedmudraptorspawnvent" offset="0"/>
+      <StatusEffectAction targettag="selectedmudraptorspawnvent">
+        <StatusEffect target="This" spritecolor="0,0,0,0" spritedepth="0.89" setvalue="true">
+          <Sound file="Content/Sounds/Damage/Creak4.ogg" range="400" volume="3" frequencymultiplier="2" />
+        </StatusEffect>
+      </StatusEffectAction>
+      <ConversationAction targettag="triggerer_player" text="EventText.soundinthevent.c1" eventsprite="vent"/>
+      <Label name="UseitemOnVent" />
+      <TriggerAction target1tag="selectedmudraptorspawnvent" target2tag="player" radius="80" waitforinteraction="true"/>
+      <ConversationAction targettag="triggerer_player" text="eventtext.soundinthevent.whatdoyoudo" eventsprite="vent">
+        <!-- use a screwdriver -->
+        <Option text="EventText.soundinthevent.o1">
+          <CheckItemAction targettag="triggerer_player" itemtags="screwdriveritem">
+            <Success>
+              <SkillCheckAction targettag="triggerer_player" requiredskill="Mechanical" requiredlevel="60">
+                <Success>
+                  <GiveSkillEXPAction skill="mechanical" amount="5" targettag="triggerer_player" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.soundinthevent.o1.c1" />
+                  <MoneyAction amount="1000" />
+                </Success>
+                <Failure>
+                  <AfflictionAction affliction="lacerations" strength="15" limbtype="LeftHand" targettag="triggerer_player" />
+                  <StatusEffectAction targettag="selectedmudraptorspawnvent">
+                    <StatusEffect target="This">
+                      <Explosion range="200.0" stun="0.2" force="5.0" flames="false" flash="false" shockwave="false" sparks="false" underwaterbubble="false" />
+                      <Sound file="Content/Sounds/Damage/StructureCrunch2.ogg" range="500" />
+                    </StatusEffect>
+                  </StatusEffectAction>
+                  <ConversationAction targettag="triggerer_player" text="EventText.soundinthevent.o1.c2" />
+                </Failure>
+              </SkillCheckAction>
+            </Success>
+            <Failure>
+              <ConversationAction targettag="triggerer_player" text="eventtext.soundinthevent.getscrewdriver" />
+              <Goto name="UseitemOnVent" />
+            </Failure>
+          </CheckItemAction>
+        </Option>
+        <!-- shine a flashlight -->
+        <Option text="EventText.soundinthevent.o2">
+          <CheckItemAction targettag="triggerer_player" itemidentifiers="flashlight" RequireEquipped="true">
+            <Success>
+              <SkillCheckAction targettag="triggerer_player" requiredskill="weapons" requiredlevel="70">
+                <Success>
+                  <ConversationAction targettag="triggerer_player" text="EventText.soundinthevent.o2.c1" eventsprite="ambush"/>
+                  <WaitAction time="1.5" />
+                  <SpawnAction speciesname="Mudraptor_hatchling" spawnlocation="Outpost" spawnpointtag="looseventspawnpoint" />
+                  <StatusEffectAction targettag="selectedmudraptorspawnvent">
+                    <StatusEffect target="This">
+                      <Explosion range="200.0" stun="0.5" force="5.0" flash="false" flames="false" shockwave="false" sparks="false" underwaterbubble="false" />
+                      <Sound file="Content/Items/Door/DoorBreak1.ogg" range="500" />
+                    </StatusEffect>
+                  </StatusEffectAction>
+                </Success>
+                <Failure>
+                  <ConversationAction targettag="triggerer_player" text="EventText.soundinthevent.o2.c2" eventsprite="ambush"/>
+                  <WaitAction time="1.5" />
+                  <StatusEffectAction targettag="selectedmudraptorspawnvent">
+                    <StatusEffect target="This">
+                      <Explosion range="200.0" stun="0.5" force="5.0" flash="false" flames="false" shockwave="false" sparks="false" underwaterbubble="false" />
+                      <Sound file="Content/Items/Door/DoorBreak1.ogg" range="500" />
+                    </StatusEffect>
+                  </StatusEffectAction>
+                  <SpawnAction speciesname="Mudraptor_hatchling" spawnlocation="Outpost" spawnpointtag="looseventspawnpoint" />
+                  <SpawnAction speciesname="Mudraptor_hatchling" spawnlocation="Outpost" spawnpointtag="looseventspawnpoint" />
+                  <SpawnAction speciesname="Mudraptor_hatchling" spawnlocation="Outpost" spawnpointtag="looseventspawnpoint" />
+                </Failure>
+              </SkillCheckAction>
+            </Success>
+            <Failure>
+              <ConversationAction targettag="triggerer_player" text="eventtext.soundinthevent.getflashlight" />
+              <Goto name="UseitemOnVent" />
+            </Failure>
+          </CheckItemAction>
+        </Option>
+        <Option text="EventText.soundinthevent.o3">
+          <RNGAction chance="0.33">
+            <Success>
+              <ConversationAction targettag="triggerer_player" text="EventText.soundinthevent.o3.c1">
+                <Option text="EventText.soundinthevent.o3.o1" />
+              </ConversationAction>
+            </Success>
+            <Failure>
+              <SkillCheckAction requiredskill="Helm" requiredlevel="70" targettag="triggerer_player">
+                <Success>
+                  <GiveSkillEXPAction skill="helm" amount="5" targettag="triggerer_player" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.soundinthevent.o3.c2">
+                    <Option text="EventText.soundinthevent.o3.o2" />
+                  </ConversationAction>
+                </Success>
+                <Failure>
+                  <ConversationAction targettag="triggerer_player" text="EventText.soundinthevent.o3.c3">
+                    <Option text="EventText.soundinthevent.o3.o3" />
+                  </ConversationAction>
+                </Failure>
+              </SkillCheckAction>
+            </Failure>
+          </RNGAction>
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Impromptu engineering"-->
+    <ScriptedEvent identifier="impromptuengineering" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <!--<TagAction criteria="itemidentifier:opdeco_computer" tag="potentialresearchterminal" submarinetype="outpost" />-->
+      <!--<TagAction criteria="itemidentifier:opdeco_desk" tag="potentialresearchterminal" submarinetype="outpost" />-->
+      <TagAction criteria="itemidentifier:op_researchtable" tag="potentialresearchterminal" submarinetype="outpost" />
+      <TagAction criteria="itemidentifier:op_researchterminal" tag="potentialresearchterminal" submarinetype="outpost" />
+      <TriggerAction target1tag="potentialresearchterminal" target2tag="player" applytotarget1="selectedresearchterminal" applytotarget2="triggerer_player" radius="150" waitforinteraction="true" />
+      <StatusEffectAction targettag="selectedresearchterminal">
+        <StatusEffect  target="This" indestructible="false" condition="0" setvalue="true" />
+      </StatusEffectAction>
+      <ConversationAction targettag="triggerer_player" text="EventText.impromptuengineering.c1" eventsprite="brokenterminal">
+        <Option text="EventText.impromptuengineering.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.impromptuengineering.o1.c1">
+            <Option text="EventText.impromptuengineering.o1.o1">
+              <SkillCheckAction targettag="triggerer_player" requiredskill="Mechanical" requiredlevel="40">
+                <Success>
+                  <GiveSkillEXPAction skill="mechanical" amount="5" targettag="triggerer_player" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.impromptuengineering.o1.o1.c1">
+                    <Option text="EventText.impromptuengineering.o1.o1.o1" endconversation="true">
+                      <SpawnAction itemidentifier="redwire" targetinventory="triggerer_player" />
+                      <SpawnAction itemidentifier="copper" targetinventory="triggerer_player" />
+                      <SpawnAction itemidentifier="fpgacircuit" targetinventory="triggerer_player" />
+                    </Option>
+                  </ConversationAction>
+                </Success>
+                <Failure>
+                  <ConversationAction targettag="triggerer_player" text="EventText.impromptuengineering.o1.o1.c2">
+                    <Option text="EventText.impromptuengineering.o1.o1.o2" endconversation="true">
+                      <SpawnAction itemidentifier="redwire" targetinventory="triggerer_player" />
+                    </Option>
+                  </ConversationAction>
+                </Failure>
+              </SkillCheckAction>
+            </Option>
+            <Option text="EventText.impromptuengineering.o1.o2">
+              <SkillCheckAction targettag="triggerer_player" requiredskill="electrical" requiredlevel="50">
+                <Success>
+                  <StatusEffectAction targettag="selectedresearchterminal">
+                    <StatusEffect  target="This" condition="100" indestructible="true" setvalue="true" />
+                  </StatusEffectAction>
+                  <ConversationAction targettag="triggerer_player" text="EventText.impromptuengineering.o1.o2.c1">
+                    <Option text="EventText.impromptuengineering.o1.o2.o1">
+                      <SpawnAction itemidentifier="coilgunammobox" spawnlocation="MainSub" />
+                      <SpawnAction itemidentifier="coilgunammobox" spawnlocation="MainSub" />
+                      <ConversationAction targettag="triggerer_player" text="EventText.impromptuengineering.o1.o2.o1.c1">
+                        <Option text="EventText.impromptuengineering.o1.o2.o1.o1" />
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.impromptuengineering.o1.o2.o2">
+                      <ConversationAction targettag="triggerer_player" text="EventText.impromptuengineering.o1.o2.o2.c1">
+                        <Option text="EventText.impromptuengineering.o1.o2.o2.o1" endconversation="true">
+                          <GiveSkillEXPAction skill="electrical" amount="5" targettag="triggerer_player" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Success>
+                <Failure>
+                  <ConversationAction targettag="triggerer_player" text="EventText.impromptuengineering.o1.o2.c2">
+                    <Option text="EventText.impromptuengineering.o1.o2.o3" endconversation="true">
+                      <AfflictionAction targettag="triggerer_player" affliction="burn" strength="15" limbtype="lefthand" />
+                      <StatusEffectAction targettag="triggerer_player">
+                        <StatusEffect target="This" targetlimbs="LeftHand,RightHand">
+                          <Sound file="Content/Sounds/Damage/Electrocution1.ogg" range="1000" />
+                          <Explosion range="100.0" force="1.0" flames="false" shockwave="false" sparks="true" underwaterbubble="false" />
+                          <Affliction identifier="stun" strength="4" />
+                          <Affliction identifier="burn" strength="5" />
+                        </StatusEffect>
+                      </StatusEffectAction>
+                    </Option>
+                  </ConversationAction>
+                </Failure>
+              </SkillCheckAction>
+            </Option>
+            <Option text="EventText.impromptuengineering.o1.o3"></Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.impromptuengineering.o2" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Good samaritan"-->
+    <ScriptedEvent identifier="goodsamaritan" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="patient" spawnlocation="Outpost" spawnpointtype="Path" />
+      <AfflictionAction targettag="patient" affliction="opiateoverdose" strength="0.4" MultiplyByMaxVitality="true" />
+      <!-- stun to force the character unconscious regardless of any vitality multipliers -->
+      <AfflictionAction targettag="patient" affliction="stun" strength="1.0" MultiplyByMaxVitality="true" />
+      <GodModeAction targettag="patient" enabled="true" />
+      <StatusEffectAction targettag="patient">
+        <StatusEffect target="This" UseHealthWindow="false" />
+      </StatusEffectAction>
+      <TriggerAction target1tag="patient" target2tag="player" applytotarget2="triggerer_player" disableiftargetincapacitated="false" radius="150" waitforinteraction="true"/>      
+      <ConversationAction targettag="triggerer_player" text="EventText.goodsamaritan.c1" eventsprite="unconscious">
+        <Option text="EventText.goodsamaritan.o1">
+          <SkillCheckAction targettag="triggerer_player" requiredskill="Medical" requiredlevel="30">
+            <Success>              
+              <ConversationAction targettag="triggerer_player" text="EventText.goodsamaritan.o1.c1">
+                <Option text="EventText.goodsamaritan.o1.o1">
+                  <CheckItemAction targettag="triggerer_player" itemidentifiers="antinarc">
+                    <Success>
+                      <RemoveItemAction targettag="triggerer_player" itemidentifiers="antinarc" />
+                      <ConversationAction targettag="triggerer_player" text="EventText.goodsamaritan.o1.o1.c1" />
+                      <ReputationAction targettype="Location" increase="2" />
+                      <GodModeAction targettag="patient" enabled="false" />
+                      <AfflictionAction targettag="patient" affliction="opiateoverdose" strength="-0.66" MultiplyByMaxVitality="true" />
+                    </Success>
+                    <Failure>
+                      <ConversationAction targettag="triggerer_player" text="EventText.goodsamaritan.o1.o1.c2" />
+                      <ReputationAction targettype="Location" increase="2" />
+                      <GodModeAction targettag="patient" enabled="false" />
+                    </Failure>
+                  </CheckItemAction>
+                </Option>
+                <Option text="EventText.goodsamaritan.o1.o2">
+                  <ConversationAction targettag="triggerer_player" text="EventText.goodsamaritan.o1.o2.c1">
+                    <Option text="EventText.goodsamaritan.o1.o2.o1" />
+                  </ConversationAction>
+                  <GiveSkillEXPAction targettag="triggerer_player" skill="Medical" amount="5" />
+                  <GodModeAction targettag="patient" enabled="false" />
+                </Option>
+              </ConversationAction>
+            </Success>
+            <Failure>
+              <ConversationAction targettag="triggerer_player" text="EventText.goodsamaritan.o1.c2">
+                <Option text="EventText.goodsamaritan.o1.o3" />
+              </ConversationAction>
+              <GodModeAction targettag="patient" enabled="false" />
+              <AfflictionAction targettag="patient" affliction="opiateoverdose" strength="0.66" MultiplyByMaxVitality="true" />
+              <AfflictionAction targettag="patient" affliction="oxygenlow" strength="1.0" MultiplyByMaxVitality="true" />
+            </Failure>
+          </SkillCheckAction>
+        </Option>
+        <Option text="EventText.goodsamaritan.o2" endconversation="true">
+          <ConversationAction targettag="triggerer_player" text="EventText.goodsamaritan.o2.c1" />
+          <ReputationAction targettype="Location" increase="-2" />
+          <MoneyAction amount="14" targettag="player" />
+          <GodModeAction targettag="patient" enabled="false" />
+          <AfflictionAction targettag="patient" affliction="opiateoverdose" strength="0.66" MultiplyByMaxVitality="true" />
+        </Option>
+        <Option text="EventText.goodsamaritan.o3" endconversation="true">
+          <GodModeAction targettag="patient" enabled="false" />
+          <AfflictionAction targettag="patient" affliction="opiateoverdose" strength="0.66" MultiplyByMaxVitality="true" />
+          <AfflictionAction targettag="patient" affliction="oxygenlow" strength="1.0" MultiplyByMaxVitality="true" />
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Propaganda"-->
+    <ScriptedEvent identifier="propaganda" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemidentifier:opdeco_hrflyers" tag="potentialflyers" submarinetype="outpost" chooserandom="true" />
+      <TriggerAction target1tag="potentialflyers" target2tag="player" applytotarget2="triggerer_player" radius="250" waitforinteraction="true"/>
+      <ConversationAction targettag="triggerer_player" text="EventText.propaganda.c1" eventsprite="noticeboard">
+        <Option text="EventText.propaganda.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.propaganda.o1.c1">
+            <Option text="EventText.propaganda.o1.o1">
+              <RNGAction chance="0.66">
+                <Success>
+                  <SpawnAction itemidentifier="op_sepgraffiti" spawnlocation="Outpost" SpawnPointTag="potentialflyers" TargetTag="separatistgraffiti" offset="0"/>
+                  <StatusEffectAction targettag="separatistgraffiti">
+                    <StatusEffect target="This" duration="0.5" spritecolor="255,255,255,150" spritedepth="0.89" setvalue="true">
+                      <Sound file="Content/Items/MechanicalRepairFail.ogg" range="800" volume="0.8" loop="true" frequencymultiplier="2"  />
+                      <ParticleEmitter particle="dustcloud" particleamount="5" velocitymin="50" velocitymax="100" anglemin="0" anglemax="360" scalemin="0.15" scalemax="0.25" Spread="50" distancemin="-50" distancemax="50" colormultiplier="255,255,255,255" />
+                    </StatusEffect>
+                  </StatusEffectAction>
+                  <WaitAction time="0.5" />
+                  <ReputationAction targettype="Faction" identifier="separatists" increase="3" />
+                  <ReputationAction targettype="Faction" identifier="coalition" increase="-2" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.propaganda.o1.o1.c1">
+                    <Option text="EventText.propaganda.o1.o1.o1" />
+                  </ConversationAction>
+                </Success>
+                <Failure>
+                  <SpawnAction itemidentifier="banditprop13" spawnlocation="Outpost" SpawnPointTag="potentialflyers" TargetTag="uglygraffiti1" offset="0"/>
+                  <SpawnAction itemidentifier="banditprop16" spawnlocation="Outpost" SpawnPointTag="potentialflyers" TargetTag="uglygraffiti2" offset="0" />
+                  <StatusEffectAction targettag="uglygraffiti1">
+                    <StatusEffect target="This" duration="0.5" spritecolor="255,50,0,150" spritedepth="0.89" setvalue="true">
+                      <Sound file="Content/Items/MechanicalRepairFail.ogg" range="800" volume="0.8" loop="true" frequencymultiplier="2"  />
+                      <ParticleEmitter particle="dustcloud" particleamount="5" velocitymin="50" velocitymax="100" anglemin="0" anglemax="360" scalemin="0.15" scalemax="0.25" Spread="50" distancemin="-50" distancemax="50" colormultiplier="255,255,255,255" />
+                    </StatusEffect>
+                  </StatusEffectAction>
+                  <StatusEffectAction targettag="uglygraffiti2">
+                    <StatusEffect target="This" spritecolor="255,50,0,150" spritedepth="0.89" setvalue="true"/>
+                  </StatusEffectAction>
+                  <WaitAction time="0.5" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.propaganda.o1.o2.c1">
+                    <Option text="EventText.propaganda.o1.o2.o1" />
+                  </ConversationAction>
+                </Failure>
+              </RNGAction>
+            </Option>
+            <Option text="EventText.propaganda.o1.o2" />
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.propaganda.o2" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Goblin cooking"-->
+    <ScriptedEvent identifier="goblincooking1" commonness="50">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemtag:mudraptorspawnvent" tag="psychosisvent" />
+      <TriggerAction target1tag="psychosisvent" target2tag="player" applytotarget1="selectedpsychosisvent" applytotarget2="triggerer_player" radius="150" />
+      <ConversationAction targettag="triggerer_player" text="EventText.goblincooking1.c1" eventsprite="officeinside">
+        <Option text="EventText.goblincooking1.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.goblincooking1.o1.c1">
+            <Option text="EventText.goblincooking1.o1.o1">
+              <AfflictionAction targettag="triggerer_player" affliction="psychosis" strength="5" />
+              <ConversationAction targettag="triggerer_player" text="EventText.goblincooking1.o1.o1.c1" eventsprite="vent">
+                <Option text="EventText.goblincooking1.o1.o1.o1">
+                  <AfflictionAction targettag="triggerer_player" affliction="psychosis" strength="25" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.goblincooking1.o1.o1.o1.c1" fadetoblack="true" eventsprite="ventinside">
+                    <Option text="EventText.goblincooking1.o1.o1.o1.o1">
+                      <ConversationAction targettag="triggerer_player" text="EventText.goblincooking1.o1.o1.o1.o1.c1" fadetoblack="true">
+                        <Option text="EventText.goblincooking1.o1.o1.o1.o1.o1">
+                          <AfflictionAction targettag="triggerer_player" affliction="stun" strength="2" />
+                          <AfflictionAction targettag="triggerer_player" affliction="psychosis" strength="25" />
+                          <ConversationAction targettag="triggerer_player" text="EventText.goblincooking1.o1.o1.o1.o1.o1.c1" />
+                          <MoneyAction amount="-500" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.goblincooking1.o1.o1.o1.o2" fadetoblack="true">
+                      <AfflictionAction targettag="triggerer_player" affliction="psychosis" strength="25" />
+                      <ConversationAction targettag="triggerer_player" text="EventText.goblincooking1.o1.o1.o1.o2.c1">
+                        <Option text="EventText.goblincooking1.o1.o1.o1.o2.o1" />
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.goblincooking1.o1.o1.o2">
+                  <ConversationAction targettag="triggerer_player" text="EventText.goblincooking1.o1.o1.o2.c1">
+                    <Option text="EventText.goblincooking1.o1.o1.o2.o1" />
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.goblincooking1.o1.o2" />
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.goblincooking1.o2" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Crawler outbreak"-->
+    <ScriptedEvent identifier="crawleroutbreak" commonness="250">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemtag:containmentdoor" tag="containmentdoorevent" SubmarineType="Outpost" ContinueIfNoTargetsFound="false"  />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="researcher" targettag="panickedresearcher" spawnlocation="Outpost" targetmoduletags="researchmodule" SpawnPointTag="research" />
+      <!-- make npc run towards you as you enter research module  -->
+      <TriggerAction target1tag="player" targetmoduletype="researchmodule" radius="100" applytotarget1="triggerer_player" />
+      <NPCFollowAction npctag="panickedresearcher" targettag="triggerer_player" follow="True" />
+      <TriggerAction target1tag="panickedresearcher" target2tag="triggerer_player" radius="150" waitforinteraction="false"/>
+      <!-- spawn crawlers and break down containment door -->
+      <SpawnAction speciesname="crawler" spawnlocation="Outpost" targetmoduletags="researchmodule" SpawnPointTag="testsubject" spawnpointtype="enemy" RequireSpawnPointTag="true" />
+      <SpawnAction speciesname="crawler" spawnlocation="Outpost" targetmoduletags="researchmodule" SpawnPointTag="testsubject" spawnpointtype="enemy" RequireSpawnPointTag="true" />
+      <SpawnAction speciesname="crawler" spawnlocation="Outpost" targetmoduletags="researchmodule" SpawnPointTag="testsubject" spawnpointtype="enemy" RequireSpawnPointTag="true" />
+      <WaitAction time="0.5" />
+      <StatusEffectAction targettag="containmentdoorevent">
+        <StatusEffect target="This" indestructible="false" condition="0" setvalue="true" />
+        <Sound file="Content/Items/Door/Doorbreak1.ogg" range="800" volume="1" />
+      </StatusEffectAction>
+      <ConversationAction targettag="triggerer_player" text="EventText.crawleroutbreak.c1" eventsprite="ambush"/>
+      <!-- make researcher run out of module after conversation -->
+      <TagAction criteria="hullname:airlock" tag="airlock" submarinetype="Outpost" />
+      <NPCFollowAction npctag="panickedresearcher" targettag="airlock" follow="true" />
+    </ScriptedEvent>
+    <!--"Taste test"-->
+    <ScriptedEvent identifier="tastetest" commonness="150">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemidentifier:opdeco_trashcan" tag="potentialtrashcan" submarinetype="outpost" />
+      <TriggerAction target1tag="potentialtrashcan" target2tag="player" applytotarget1="selectedtrashcan" applytotarget2="triggerer_player" radius="100" waitforinteraction="true"/>
+      <ConversationAction text="EventText.tastetest.c1" targettag="triggerer_player" eventsprite="redbluebottles">
+        <Option text="EventText.tastetest.o1">
+          <SkillCheckAction requiredskill="Medical" requiredlevel="40" targettag="triggerer_player">
+            <Success>
+              <GiveSkillEXPAction skill="medical" amount="5" targettag="triggerer_player" />
+              <ConversationAction targettag="triggerer_player" text="EventText.tastetest.o1.c1">
+                <Option text="EventText.tastetest.o1.o1">
+                  <ConversationAction targettag="triggerer_player" text="EventText.tastetest.o1.o1.c1">
+                    <Option text="EventText.tastetest.o1.o1.o1" endconversation="true">
+                      <WaitAction time="20" />
+                      <AfflictionAction targettag="triggerer_player" affliction="internaldamage" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="lacerations" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="blunttrauma" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="bitewounds" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="gunshotwound" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="organdamage" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="explosiondamage" strength="-50" />
+                      <ConversationAction targettag="triggerer_player" text="EventText.tastetest.o1.o1.o1.c1">
+                        <Option text="EventText.tastetest.o1.o1.o1.o1" endconversation="true">
+                          <TriggerAction target1tag="selectedtrashcan" target2tag="triggerer_player" radius="100" />
+                          <ConversationAction targettag="triggerer_player" text="EventText.tastetest.o1.o1.o1.o1.c1" eventsprite="redyellowbottles"/>
+                          <SpawnAction itemidentifier="hyperzine" targetinventory="triggerer_player" />
+                          <SpawnAction itemidentifier="steroids" targetinventory="triggerer_player" />
+                          <SpawnAction itemidentifier="sulphuricacid" targetinventory="triggerer_player" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.tastetest.o1.o2" endconversation="true" />
+              </ConversationAction>
+            </Success>
+            <Failure>
+              <ConversationAction targettag="triggerer_player" text="EventText.tastetest.o1.c2">
+                <Option text="EventText.tastetest.o1.o3">
+                  <ConversationAction targettag="triggerer_player" text="EventText.tastetest.o1.o3.c1">
+                    <Option text="EventText.tastetest.o1.o3.o1" endconversation="true">
+                      <WaitAction time="20" />
+                      <AfflictionAction targettag="triggerer_player" affliction="internaldamage" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="lacerations" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="blunttrauma" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="bitewounds" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="gunshotwound" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="organdamage" strength="-50" />
+                      <AfflictionAction targettag="triggerer_player" affliction="explosiondamage" strength="-50" />
+                      <ConversationAction targettag="triggerer_player" text="EventText.tastetest.o1.o3.o1.c1" eventsprite="redbluebottles">
+                        <Option text="EventText.tastetest.o1.o3.o1.o1" endconversation="true">
+                          <TriggerAction target1tag="selectedtrashcan" target2tag="triggerer_player" radius="100" />
+                          <ConversationAction targettag="triggerer_player" text="EventText.tastetest.o1.o3.o1.o1.c1" />
+                          <SpawnAction itemidentifier="hyperzine" targetinventory="triggerer_player" />
+                          <SpawnAction itemidentifier="steroids" targetinventory="triggerer_player" />
+                          <SpawnAction itemidentifier="sulphuricacid" targetinventory="triggerer_player" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.tastetest.o1.o4">
+                  <AfflictionAction targettag="triggerer_player" affliction="organdamage" limbtype="torso" strength="50" />
+                  <AfflictionAction targettag="triggerer_player" affliction="stun" strength="6" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.tastetest.o1.o4.c1">
+                    <Option text="EventText.tastetest.o1.o4.o1" />
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.tastetest.o1.o5" />
+              </ConversationAction>
+            </Failure>
+          </SkillCheckAction>
+        </Option>
+        <Option text="EventText.tastetest.o2" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Outbreak"-->
+    <ScriptedEvent identifier="outbreak" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="infectednpc" spawnlocation="Outpost" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="outbreaknpc" spawnlocation="Outpost" />
+      <TriggerAction target1tag="outbreaknpc" target2tag="player" applytotarget2="triggerer_player" radius="250" waitforinteraction="true"/>
+      <AfflictionAction targettag="infectednpc" affliction="huskinfection" strength="40" />
+      <ConversationAction targettag="triggerer_player" text="EventText.outbreak.c1" eventsprite="cultist">
+        <Option text="EventText.outbreak.o1" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Mike the Idiot 1"-->
+    <ScriptedEvent identifier="miketheidiot1" commonness="25">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemtag:chair" tag="chair" RequiredModuleTag="CrewModule" />
+      <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="miketheidiot" targettag="mike" TargetModuleTags="CrewModule" />
+      <NPCOperateItemAction npctag="mike" targettag="chair" Operate="true" />
+      <TriggerAction target1tag="player" target2tag="mike" applytotarget1="triggerer_player" waitforinteraction="true"/>
+      <ConversationAction targettag="triggerer_player" text="EventText.miketheidiot1.c1" eventsprite="dorm">
+        <Option text="EventText.miketheidiot1.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.miketheidiot1.o1.c1">
+            <Option text="EventText.miketheidiot1.o1.o1">
+              <CheckMoneyAction Amount="5">
+                <Success>
+                  <MoneyAction amount="-5" />
+                  <SetDataAction identifier="timesmikefound" value="1" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.miketheidiot1.o1.o1.c1">
+                    <Option text="EventText.miketheidiot1.o1.o1.o1">
+                      <ConversationAction text="EventText.miketheidiot1.o1.o1.o1.c1">
+                        <Option text="EventText.miketheidiot1.o1.o1.o1.o1" endconversation="true" />
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.miketheidiot1.o1.o1.o2">
+                      <ConversationAction targettag="triggerer_player" text="EventText.miketheidiot1.o1.o1.o2.c1">
+                        <Option text="EventText.miketheidiot1.o1.o1.o2.o1" endconversation="true" />
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.miketheidiot1.o1.o1.o3">
+                      <ConversationAction targettag="triggerer_player" text="EventText.miketheidiot1.o1.o1.o3.c1">
+                        <Option text="EventText.miketheidiot1.o1.o1.o3.o1" endconversation="true" />
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Success>
+                <Failure>
+                  <ConversationAction targettag="triggerer_player" text="eventtext.miketheidiot.nomoney"/>                  
+                </Failure>
+              </CheckMoneyAction>
+            </Option>
+            <Option text="EventText.miketheidiot1.o1.o2" endconversation="true" />
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.miketheidiot1.o2" endconversation="true" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Mike the Idiot 2"-->
+    <ScriptedEvent identifier="miketheidiot2" commonness="25">
+      <CheckDataAction identifier="timesmikefound" condition="eq 1">
+        <Success>
+          <TagAction criteria="player" tag="player" />
+          <TagAction criteria="itemtag:chair" tag="chair" RequiredModuleTag="CrewModule" />
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="miketheidiot" targettag="mike" TargetModuleTags="CrewModule" />
+          <NPCOperateItemAction npctag="mike" targettag="chair" Operate="true" />
+          <TriggerAction target1tag="player" target2tag="mike" applytotarget1="triggerer_player" waitforinteraction="true"/>
+          <NPCWaitAction npctag="mike" wait="true" />
+          <ConversationAction targettag="triggerer_player" text="EventText.miketheidiot2.c1" eventsprite="cleaner">
+            <Option text="EventText.miketheidiot2.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.miketheidiot2.o1.c1">
+                <Option text="EventText.miketheidiot2.o1.o1">
+                  <CheckMoneyAction Amount="5">
+                    <Success>
+                      <MoneyAction amount="-5" />
+                      <SetDataAction identifier="timesmikefound" value="2" />
+                      <ConversationAction targettag="triggerer_player" text="EventText.miketheidiot2.o1.o1.c1">
+                        <Option text="EventText.miketheidiot2.o1.o1.o1">
+                          <ConversationAction targettag="triggerer_player" text="EventText.miketheidiot2.o1.o1.o1.c1">
+                            <Option text="EventText.miketheidiot2.o1.o1.o1.o1" endconversation="true" />
+                          </ConversationAction>
+                        </Option>
+                        <Option text="EventText.miketheidiot2.o1.o1.o2">
+                          <ConversationAction targettag="triggerer_player" text="EventText.miketheidiot2.o1.o1.o2.c1">
+                            <Option text="EventText.miketheidiot2.o1.o1.o2.o1" endconversation="true" />
+                          </ConversationAction>
+                        </Option>
+                        <Option text="EventText.miketheidiot2.o1.o1.o3">
+                          <ConversationAction targettag="triggerer_player" text="EventText.miketheidiot2.o1.o1.o3.c1">
+                            <Option text="EventText.miketheidiot2.o1.o1.o3.o1" endconversation="true" />
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Success>
+                    <Failure>
+                      <ConversationAction targettag="triggerer_player" text="eventtext.miketheidiot.nomoney"/>
+                    </Failure>
+                  </CheckMoneyAction>                  
+                </Option>
+                <Option text="EventText.miketheidiot2.o1.o2" endconversation="true" />
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.miketheidiot2.o2" endconversation="true" />
+          </ConversationAction>
+          <NPCWaitAction npctag="mike" wait="false" />
+        </Success>
+        <Failure>
+          <!--Do nothing-->
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--"Firefighting"-->
+    <ScriptedEvent identifier="firefighting" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemidentifier:opdeco_trashcan" tag="potentialtrashcan" submarinetype="outpost" chooserandom="true" />
+      <!-- trash can smokes until either extinguished or catches on fire via options. sets conditon to 0 to make it stop -->
+      <StatusEffectAction targettag="potentialtrashcan">
+        <StatusEffect target="This" duration="999" interval="1" checkconditionalalways="true" >
+          <Conditional condition="gt 1" />
+          <ParticleEmitter particle="swirlysmoke" particlespersecond="3" velocitymin="25" velocitymax="50" anglemin="70" anglemax="110" scalemin="0.5" scalemax="1" distancemin="20" distancemax="20" colormultiplier="255,255,255,255" drawontop="true" />
+        </StatusEffect>
+      </StatusEffectAction>
+      <TriggerAction target1tag="potentialtrashcan" target2tag="player" applytotarget1="selectedtrashcan" applytotarget2="triggerer_player" radius="100" waitforinteraction="true"/>
+      <ConversationAction targettag="triggerer_player" text="EventText.firefighting.c1" eventsprite="trashcan">
+        <Option text="EventText.firefighting.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.firefighting.o1.c1">
+            <Option text="EventText.firefighting.o1.o1">
+              <AfflictionAction targettag="triggerer_player" affliction="burn" strength="15" limbtype="rightarm" />
+              <ConversationAction targettag="triggerer_player" text="EventText.firefighting.o1.o1.c1" />
+              <!-- more burns, but you get a cigar. -->
+              <SpawnAction itemidentifier="cigar" TargetTag="burntcigar" targetinventory="triggerer_player" />
+              <StatusEffectAction targettag="potentialtrashcan">
+                <StatusEffect target="This" condition="0" setvalue="true" />
+              </StatusEffectAction>
+              <StatusEffectAction targettag="burntcigar">
+                <StatusEffect target="This" condition="62" setvalue="true" />
+              </StatusEffectAction>
+            </Option>
+            <Option text="EventText.firefighting.o1.o2" endconversation="true">
+              <!-- causes a fire after 30 seconds -->
+              <Label name="waitforfire" />
+              <WaitAction time="30" />
+              <FireAction size="10" targettag="selectedtrashcan" />
+              <StatusEffectAction targettag="potentialtrashcan">
+                <StatusEffect target="This" condition="0" setvalue="true" />
+              </StatusEffectAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.firefighting.o2" endconversation="true">
+          <Goto name="waitforfire" />
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Sleight of Hand"-->
+    <ScriptedEvent identifier="sleightofhand" commonness="100">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="gambler" spawnlocation="Outpost" targetmoduletags="crewmodule" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="gambler" spawnlocation="Outpost" targetmoduletags="crewmodule" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="securitynpc[faction]" targettag="gamblingsecurity" spawnlocation="Outpost" targetmoduletags="crewmodule" />
+      <!--<NPCFollowAction npctag="gambler" targettag="gamblingsecurity" follow="true" />
+      <NPCFollowAction npctag="gamblingsecurity" targettag="gambler" follow="true" />-->
+      <TagAction criteria="player" tag="player" />
+      <TriggerAction target1tag="gambler" target2tag="player" applytotarget2="triggerer_player" radius="100" waitforinteraction="true"/>
+      <ConversationAction targettag="triggerer_player" text="EventText.sleightofhand.c1" eventsprite="gambler">
+        <Option text="EventText.sleightofhand.o1">
+          <RNGAction chance="0.125">
+            <Success>
+              <ConversationAction targettag="triggerer_player" text="EventText.sleightofhand.o1.c1"/>
+              <SpawnAction itemidentifier="alientrinket1" targetinventory="triggerer_player" />
+            </Success>
+            <Failure>
+              <ConversationAction targettag="triggerer_player" text="EventText.sleightofhand.o1.c2"></ConversationAction>
+              <MoneyAction amount="-500" />
+            </Failure>
+          </RNGAction>
+        </Option>
+        <Option text="EventText.sleightofhand.o2">
+          <RNGAction chance="0.25">
+            <Success>
+              <ConversationAction targettag="triggerer_player" text="EventText.sleightofhand.o2.c1"/>
+              <SpawnAction itemidentifier="alientrinket1" targetinventory="triggerer_player" />
+            </Success>
+            <Failure>
+              <ConversationAction targettag="triggerer_player" text="EventText.sleightofhand.o2.c2" />
+              <SpawnAction itemidentifier="alientrinket1" targetinventory="triggerer_player" />
+              <CombatAction combatmode="defensive" npctag="gamblingsecurity" enemytag="triggerer_player" isinstigator="false" guardreaction="arrest" witnessreaction="none" />
+              <ReputationAction targettype="Location" increase="-2" />
+            </Failure>
+          </RNGAction>
+        </Option>
+        <Option text="EventText.sleightofhand.o3" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Foreshadowing"-->
+    <!--NOTE: disabled in event lists-->
+    <ScriptedEvent identifier="foreshadowing" commonness="25">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="bot" tag="potentialnotegiver" />
+      <TriggerAction target1tag="potentialnotegiver" target2tag="player" applytotarget1="notegiver" applytotarget2="triggerer_player" radius="100" waitforinteraction="false"/>
+      <ConversationAction targettag="triggerer_player" text="EventText.foreshadowing.c1" eventsprite="note">
+        <Option text="EventText.foreshadowing.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.foreshadowing.o1.c1" eventsprite="noteopened"></ConversationAction>
+        </Option>
+        <Option text="EventText.foreshadowing.o2" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Engineers are special"-->
+    <ScriptedEvent identifier="Engineers_are_special" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="humanprefabidentifier:reactoroperator" tag="repairnpc" />
+      <TriggerAction target1tag="repairnpc" target2tag="player" applytotarget2="triggerer_player" radius="250" waitforinteraction="true"/>
+      <NPCWaitAction npctag="repairnpc" wait="true" />
+      <ConversationAction targettag="triggerer_player" text="EventText.Engineers_are_special.c1" eventsprite="mechanic" continueconversation="true" _npos="2839.201,261.54736" />
+      <SkillCheckAction targettag="triggerer_player" requiredskill="mechanical" requiredlevel="50" _npos="3262.4575,261.54736">
+        <Success>
+          <ConversationAction targettag="triggerer_player" text="EventText.Engineers_are_special.c1.c1" continueconversation="true" _npos="3700.167,125.27942">
+            <Option text="EventText.Engineers_are_special.c1.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.Engineers_are_special.c1.o1.c1" _npos="4287.3125,-70.810974" />
+            </Option>
+            <Option text="EventText.Engineers_are_special.c1.o2">
+              <RNGAction chance="0.6" _npos="4285.822,189.16768">
+                <Success>
+                  <ConversationAction targettag="triggerer_player" text="EventText.Engineers_are_special.c1.o2.c1" _npos="4714.9326,97.9465" />
+                  <ReputationAction targettype="Location" increase="2" />
+                  <GiveSkillEXPAction skill="mechanical" amount="5" targettag="triggerer_player" />
+                  <SetPriceMultiplierAction multiplier="0.85" operation="Multiply" targetmultiplier="Mechanical"/>
+                </Success>
+                <Failure>
+                  <ConversationAction targettag="triggerer_player" text="EventText.Engineers_are_special.c1.o2.c2" _npos="4714.8335,315.59344" />
+                </Failure>
+              </RNGAction>
+            </Option>
+          </ConversationAction>
+        </Success>
+        <Failure>
+          <ConversationAction targettag="triggerer_player" text="EventText.Engineers_are_special.c1.c2" _npos="3700.1667,325.55194" />
+        </Failure>
+      </SkillCheckAction>
+      <NPCWaitAction npctag="repairnpc" wait="false" />
+    </ScriptedEvent>
+    <!--"Mediator"-->
+    <ScriptedEvent identifier="mediator" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="troublemaker1" spawnlocation="Outpost" spawnpointtype="Path" lootingisstealing="false"/>
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="troublemaker2" spawnlocation="Outpost" spawnpointtype="Path" lootingisstealing="false"/>
+      <!-- make sure the npcs have something to fight with -->
+      <SpawnAction itemidentifier="wrench" targetinventory="troublemaker1" />
+      <SpawnAction itemidentifier="wrench" targetinventory="troublemaker2" />
+      <NPCFollowAction npctag="troublemaker1" targettag="troublemaker2" follow="true" />
+      <NPCFollowAction npctag="troublemaker2" targettag="troublemaker1" follow="true" />
+      <TriggerAction target1tag="troublemaker1" target2tag="player" applytotarget2="triggerer_player" radius="250" waitforinteraction="true"/>
+      <ConversationAction targettag="triggerer_player" text="EventText.mediator.c1" eventsprite="mediator">
+        <Option text="EventText.mediator.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.mediator.o1.c1">
+            <Option text="EventText.mediator.o1.o1">
+              <SkillCheckAction targettag="triggerer_player" requiredskill="Helm" requiredlevel="70">
+                <Success>
+                  <GiveSkillEXPAction skill="helm" amount="5" targettag="triggerer_player" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.mediator.o1.o1.c1" />
+                  <ReputationAction targettype="Location" increase="1" />
+                  <NPCFollowAction npctag="troublemaker1" targettag="troublemaker2" follow="false" />
+                  <NPCFollowAction npctag="troublemaker2" targettag="troublemaker1" follow="false" />
+                </Success>
+                <Failure>
+                  <ConversationAction targettag="triggerer_player" text="EventText.mediator.o1.o1.c2" />
+                  <ReputationAction targettype="Location" increase="-2" />
+                </Failure>
+              </SkillCheckAction>
+            </Option>
+            <Option text="EventText.mediator.o1.o2">
+              <SkillCheckAction targettag="triggerer_player" requiredskill="weapons" requiredlevel="50">
+                <Success>
+                  <GiveSkillEXPAction skill="weapons" amount="5" targettag="triggerer_player" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.mediator.o1.o2.c1" />
+                  <ReputationAction targettype="Location" increase="2" />
+                  <NPCFollowAction npctag="troublemaker1" targettag="troublemaker2" follow="false" />
+                  <NPCFollowAction npctag="troublemaker2" targettag="troublemaker1" follow="false" />
+                </Success>
+                <Failure>
+                  <ConversationAction targettag="triggerer_player" text="EventText.mediator.o1.o2.c2">
+                    <Option text="EventText.mediator.o1.o2.o1">
+                      <ConversationAction targettag="triggerer_player" text="EventText.mediator.o1.o2.o1.c1">
+                        <Option text="EventText.mediator.o1.o2.o1.o1">
+                          <ConversationAction targettag="triggerer_player" text="EventText.mediator.o1.o2.o1.o1.c1" />
+                          <CombatAction combatmode="Offensive" npctag="troublemaker1" enemytag="triggerer_player" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+                          <CombatAction combatmode="Offensive" npctag="troublemaker2" enemytag="triggerer_player" isinstigator="true" guardreaction="arrest" witnessreaction="retreat" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Failure>
+              </SkillCheckAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.mediator.o2">
+          <ConversationAction targettag="triggerer_player" text="EventText.mediator.o2.c1" />
+          <ReputationAction targettype="Location" increase="-2" />
+          <CombatAction combatmode="Offensive" npctag="troublemaker1" enemytag="troublemaker2" isinstigator="false" guardreaction="arrest" witnessreaction="retreat" />
+          <CombatAction combatmode="Offensive" npctag="troublemaker2" enemytag="troublemaker1" isinstigator="false" guardreaction="arrest" witnessreaction="retreat" />
+        </Option>
+        <Option text="EventText.mediator.o3" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"Black market"-->
+    <ScriptedEvent identifier="blackmarket" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="smuggler" spawnlocation="Outpost" spawnpointtype="Path" />
+      <TriggerAction target1tag="smuggler" target2tag="player" applytotarget2="triggerer_player" radius="250" waitforinteraction="true"/>
+      <NPCFollowAction npctag="smuggler" targettag="triggerer_player" follow="true" />
+      <ConversationAction targettag="triggerer_player" text="EventText.blackmarket.c1" eventsprite="cultist">
+        <Option text="EventText.blackmarket.o1">
+          <RNGAction chance="0.5">
+            <Success>
+              <ConversationAction targettag="triggerer_player" text="EventText.blackmarket.o1.c1" continueconversation="true" />
+              <ConversationAction targettag="triggerer_player" text="EventText.blackmarket.o1.c1.c1">
+                <Option text="EventText.blackmarket.o1.c1.o1">
+                  <CheckMoneyAction amount="1000">
+                    <Success>
+                      <MoneyAction amount="-1000" />
+                      <RNGAction chance="0.33">
+                        <Success>
+                          <ConversationAction targettag="triggerer_player" text="EventText.blackmarket.o1.c1.o1.c1" />
+                          <SpawnAction itemidentifier="alienpistol" targettag="boughtpistol" targetinventory="triggerer_player" />
+                          <SpawnAction itemidentifier="alienpowercell" targetinventory="boughtpistol" />
+                        </Success>
+                        <Failure>
+                          <ConversationAction targettag="triggerer_player" text="EventText.blackmarket.o1.c1.o1.c2" />
+                        </Failure>
+                      </RNGAction>                      
+                    </Success>
+                    <Failure>
+                      <ConversationAction targettag="triggerer_player" text="eventtext.blackmarket.nomoney" />
+                    </Failure>
+                  </CheckMoneyAction>
+                </Option>
+                <Option text="EventText.blackmarket.o1.c1.o2" />
+              </ConversationAction>
+            </Success>
+            <Failure>
+              <ConversationAction targettag="triggerer_player" text="EventText.blackmarket.o1.c2" />
+              <ConversationAction targettag="triggerer_player" text="EventText.blackmarket.o1.c2.c2">                
+                <Option text="EventText.blackmarket.o1.c2.o1">
+                  <CheckMoneyAction amount="500">
+                    <Success>
+                      <MoneyAction amount="-500" />
+                      <RNGAction chance="0.33">
+                        <Success>
+                          <ConversationAction targettag="triggerer_player" text="EventText.blackmarket.o1.c2.o1.c1" />
+                          <SpawnAction itemidentifier="smallmudraptoregg" targetinventory="triggerer_player" />
+                        </Success>
+                        <Failure>
+                          <ConversationAction targettag="triggerer_player" text="EventText.blackmarket.o1.c2.o1.c2" />
+                          <SpawnAction itemidentifier="huskeggsbasic" targetinventory="triggerer_player" />
+                        </Failure>
+                      </RNGAction>                      
+                    </Success>
+                    <Failure>
+                      <ConversationAction targettag="triggerer_player" text="eventtext.blackmarket.nomoney" />
+                    </Failure>                    
+                  </CheckMoneyAction>
+                </Option>
+                <Option text="EventText.blackmarket.o1.c2.o2" />
+              </ConversationAction>
+            </Failure>
+          </RNGAction>
+        </Option>
+        <Option text="EventText.blackmarket.o2" />
+      </ConversationAction>
+      <NPCFollowAction npctag="smuggler" targettag="triggerer_player" follow="false" />
+    </ScriptedEvent>
+    <!--"Fan club"-->
+    <ScriptedEvent identifier="fanclub" commonness="75">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="fan" spawnlocation="Outpost" targetmoduletags="airlock" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="fan" spawnlocation="Outpost" targetmoduletags="airlock" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="fan" spawnlocation="Outpost" targetmoduletags="airlock" />
+      <TriggerAction target1tag="fan" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true"/>
+      <NPCFollowAction npctag="fan" targettag="triggerer_player" follow="true" />
+      <ConversationAction targettag="triggerer_player" text="EventText.fanclub.c1" eventsprite="crowd">
+        <Option text="EventText.fanclub.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.fanclub.o1.c1" />
+          <ReputationAction targettype="Location" increase="2" />
+          <NPCFollowAction npctag="fan" targettag="triggerer_player" follow="false" />
+        </Option>
+        <Option text="EventText.fanclub.o2" endconversation="true">
+          <WaitAction time="10" />
+          <NPCFollowAction npctag="fan" targettag="triggerer_player" follow="false" />
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--"At Wit's End"-->
+    <ScriptedEvent identifier="atwitsend" commonness="70">
+      <CheckDataAction identifier="atwitsend_complete" condition="eq true">
+        <Success>
+          <!--Don't repeat event-->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player" />
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="artiedolittle" targettag="artie" spawnlocation="Outpost" targetmoduletags="airlock" />
+          <TriggerAction target1tag="artie" target2tag="player" applytotarget2="triggerer_player" waitforinteraction="true" />
+          <NPCFollowAction npctag="artie" targettag="triggerer_player" follow="true" />
+          <ConversationAction targettag="triggerer_player" speakertag="artie" text="EventText.atwitsend.c1" eventsprite="crowd">
+            <Option text="EventText.atwitsend.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.atwitsend.o1.c1">
+                <Option text="EventText.atwitsend.o1.o1">
+                  <ConversationAction targettag="triggerer_player" text="EventText.atwitsend.o1.o1.c1" />
+                  <NPCChangeTeamAction npctag="artie" teamid="Team1" addtocrew="true" />
+                  <NPCFollowAction npctag="artie" targettag="triggerer_player" follow="false" />
+                </Option>
+                <Option text="EventText.atwitsend.o1.o2">
+                  <ConversationAction targettag="triggerer_player" text="EventText.atwitsend.o1.o2.c1" />
+                  <NPCFollowAction npctag="artie" targettag="triggerer_player" follow="false" />
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.atwitsend.o2">
+              <ConversationAction targettag="triggerer_player" text="EventText.atwitsend.o2.c1" />
+              <NPCFollowAction npctag="artie" targettag="triggerer_player" follow="false" />
+            </Option>
+          </ConversationAction>
+          <SetDataAction identifier="atwitsend_complete" value="true"/>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    
+    <!--"Consultant"
+      TODO: correct mine module tag-->
+    <ScriptedEvent identifier="consultant" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="mineowner" spawnlocation="Outpost" targetmoduletags="adminmodule" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="miner" targettag="foreman" spawnlocation="Outpost" targetmoduletags="tempmine" />
+      <TriggerAction target1tag="mineowner" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true"/>
+      <NPCWaitAction npctag="mineowner" wait="true" />
+      <ConversationAction targettag="triggerer_player" text="EventText.consultant.c1" eventsprite="office">
+        <Option text="EventText.consultant.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.c1">
+            <Option text="EventText.consultant.o1.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1" />
+              <TriggerAction target1tag="foreman" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true"/>
+              <NPCWaitAction npctag="foreman" wait="true" />
+              <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.c1" eventsprite="mines">
+                <Option text="EventText.consultant.o1.o1.c1.o1">
+                  <SkillCheckAction requiredskill="Helm" requiredlevel="60" targettag="triggerer_player">
+                    <Success>
+                      <GiveSkillEXPAction skill="helm" amount="5" targettag="triggerer_player" />
+                      <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o1.c1" />
+                      <MoneyAction amount="2000" />
+                    </Success>
+                    <Failure>
+                      <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o1.c2" />
+                    </Failure>
+                  </SkillCheckAction>
+                </Option>
+                <Option text="EventText.consultant.o1.o1.c1.o2">
+                  <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o2.c1">
+                    <Option text="EventText.consultant.o1.o1.c1.o2.o1">
+                      <SkillCheckAction requiredskill="Medical" requiredlevel="50" targettag="triggerer_player">
+                        <Success>
+                          <GiveSkillEXPAction skill="medical" amount="5" targettag="triggerer_player" />
+                          <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o2.o1.c1" />
+                          <MoneyAction amount="2000" />
+                        </Success>
+                        <Failure>
+                          <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o2.o1.c2" />
+                        </Failure>
+                      </SkillCheckAction>
+                    </Option>
+                    <Option text="EventText.consultant.o1.o1.c1.o2.o2">
+                      <SkillCheckAction requiredskill="Helm" requiredlevel="60" targettag="triggerer_player">
+                        <Success>
+                          <GiveSkillEXPAction skill="helm" amount="5" targettag="triggerer_player" />
+                          <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o2.o2.c1" />
+                          <MoneyAction amount="2000" />
+                        </Success>
+                        <Failure>
+                          <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o2.o2.c2" />
+                        </Failure>
+                      </SkillCheckAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.consultant.o1.o1.c1.o3">
+                  <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o3.c1">
+                    <Option text="EventText.consultant.o1.o1.c1.o3.o1">
+                      <SkillCheckAction requiredskill="Medical" requiredlevel="50" targettag="triggerer_player">
+                        <Success>
+                          <GiveSkillEXPAction skill="medical" amount="5" targettag="triggerer_player" />
+                          <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o3.o1.c1" />
+                          <MoneyAction amount="2000" />
+                        </Success>
+                        <Failure>
+                          <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o3.o1.c2" />
+                        </Failure>
+                      </SkillCheckAction>
+                    </Option>
+                    <Option text="EventText.consultant.o1.o1.c1.o3.o2">
+                      <SkillCheckAction requiredskill="Helm" requiredlevel="60" targettag="triggerer_player">
+                        <Success>
+                          <GiveSkillEXPAction skill="helm" amount="5" targettag="triggerer_player" />
+                          <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o3.o2.c1" />
+                          <MoneyAction amount="2000" />
+                        </Success>
+                        <Failure>
+                          <ConversationAction targettag="triggerer_player" text="EventText.consultant.o1.o1.c1.o3.o2.c2" />
+                        </Failure>
+                      </SkillCheckAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+              <NPCWaitAction npctag="foreman" wait="false" />
+            </Option>
+            <Option text="EventText.consultant.o1.o2" />
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.consultant.o2" />
+      </ConversationAction>
+      <NPCWaitAction npctag="mineowner" wait="false" />
+    </ScriptedEvent>
+    <!--Big brother-->
+    <ScriptedEvent identifier="bigbrother" commonness="150">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="securitynpc[faction]" targettag="securitychief" spawnlocation="Outpost" targetmoduletags="adminmodule" />
+      <NPCWaitAction npctag="securitychief" wait="true" />
+      <WaitAction time="5" />
+      <ConversationAction text="EventText.bigbrother.c1" dialogtype="Small" eventsprite="officeinside"/>
+      <TriggerAction target1tag="player" target2tag="securitychief" radius="150" applytotarget1="triggerer_player"/>
+      <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1" speakertag="securitychief" eventsprite="officeinside" waitforinteraction="true">
+        <Option text="EventText.bigbrother.c1.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.o1.c1">
+            <Option text="EventText.bigbrother.c1.o1.o1">
+              <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.o1.o1.c1">
+                <Option text="EventText.bigbrother.c1.o1.o1.o1">
+                  <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.o1.o1.o1.c1" />
+                </Option>
+                <Option text="EventText.bigbrother.c1.o1.o1.o2" endconversation="true">
+                  <GoTo name="end" />
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.bigbrother.c1.o2" endconversation="true">
+          <GoTo name="end" />
+        </Option>
+      </ConversationAction>
+      <NPCWaitAction npctag="securitychief" wait="false" />
+      <TriggerAction target1tag="triggerer_player" targetmoduletype="seccrewmodule" radius="10" applytotarget1="triggerer_player" />
+      <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.c1" eventsprite="dorm">
+        <Option text="EventText.bigbrother.c1.c1.o1">
+          <RNGAction chance="0.2">
+            <Success>
+              <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o1.c1" dialogtype="Small" />
+              <ConversationAction text="EventText.bigbrother.c1.c1.o1.c1.c1" speakertag="securitychief" dialogtype="Small"/>
+              <MoneyAction amount="2000" />
+            </Success>
+            <Failure>
+              <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="securitynpc[faction]" targettag="guard" spawnlocation="Outpost" spawnpointtag="triggerer_player" />
+              <NPCWaitAction npctag="guard" wait="true" />
+              <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o1.c2" eventsprite="security">
+                <Option text="EventText.bigbrother.c1.c1.o1.o1">
+                  <SkillCheckAction requiredskill="weapons" requiredlevel="40" targettag="triggerer_player">
+                    <Success>
+                      <GiveSkillEXPAction skill="weapons" amount="5" targettag="triggerer_player" />
+                      <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o1.o1.c1" dialogtype="Small" />
+                      <ConversationAction text="EventText.bigbrother.c1.c1.o1.o1.c1.c1" speakertag="securitychief" dialogtype="Small" />
+                      <MoneyAction amount="2000" />
+                    </Success>
+                    <Failure>
+                      <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o1.o1.c2"/>
+                      <WaitAction time="20" />
+                      <TriggerAction target1tag="triggerer_player" target2tag="guard" radius="250" />
+                      <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o1.o1.c2.c2" eventsprite="security" dialogtype="Small"/>
+                      <WaitAction time="10" />
+                      <CombatAction combatmode="Offensive" npctag="guard" enemytag="triggerer_player" isinstigator="false" guardreaction="arrest" witnessreaction="retreat" />
+                    </Failure>
+                  </SkillCheckAction>
+                </Option>
+                <Option text="EventText.bigbrother.c1.c1.o1.o2">
+                  <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o1.o2.c1" eventsprite="security" />
+                  <WaitAction time="20" />
+                  <TriggerAction target1tag="triggerer_player" target2tag="guard" radius="250" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o1.o2.c1.c1" eventsprite="security" dialogtype="Small"/>
+                  <WaitAction time="10" />
+                  <CombatAction combatmode="Offensive" npctag="guard" enemytag="triggerer_player" isinstigator="false" guardreaction="arrest" witnessreaction="retreat" />
+                </Option>
+              </ConversationAction>
+              <NPCWaitAction npctag="guard" wait="false" />
+            </Failure>
+          </RNGAction>
+        </Option>
+        <Option text="EventText.bigbrother.c1.c1.o2">
+          <SkillCheckAction requiredskill="Electrical" requiredlevel="30" targettag="triggerer_player">
+            <Success>
+              <GiveSkillEXPAction skill="electrical" amount="5" targettag="triggerer_player" />
+              <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o2.c1" dialogtype="Small" />
+              <ConversationAction text="EventText.bigbrother.c1.c1.o2.c1.c1" speakertag="securitychief" dialogtype="Small" />
+              <MoneyAction amount="2000" />
+            </Success>
+            <Failure>
+              <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="securitynpc[faction]" targettag="guard" spawnlocation="Outpost" spawnpointtag="triggerer_player" />
+              <NPCWaitAction npctag="guard" wait="true" />
+              <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o2.c2" eventsprite="security">
+                <Option text="EventText.bigbrother.c1.c1.o2.o1">
+                  <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o2.o1.c1" dialogtype="Small" />
+                  <ConversationAction text="EventText.bigbrother.c1.c1.o2.o1.c1.c1" speakertag="securitychief" dialogtype="Small" />
+                  <MoneyAction amount="2000" />
+                </Option>
+                <Option text="EventText.bigbrother.c1.c1.o2.o2">
+                  <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o2.o2.c1" />
+                  <WaitAction time="20" />
+                  <TriggerAction target1tag="triggerer_player" target2tag="guard" radius="250" />
+                  <ConversationAction targettag="triggerer_player" text="EventText.bigbrother.c1.c1.o2.o2.c1.c1" eventsprite="security" dialogtype="Small"/>
+                  <WaitAction time="10" />
+                  <CombatAction combatmode="Offensive" npctag="guard" enemytag="triggerer_player" isinstigator="false" guardreaction="arrest" witnessreaction="retreat" />
+                </Option>
+              </ConversationAction>
+              <NPCWaitAction npctag="guard" wait="false" />
+            </Failure>
+          </SkillCheckAction>
+        </Option>
+      </ConversationAction>
+      <Label name="end"/>
+    </ScriptedEvent> 
+    <!--Stowaway 1-->
+    <ScriptedEvent identifier="stowaway1" commonness="50">
+      <TagAction criteria="player" tag="player"/>
+      <SpawnAction itemidentifier="metalcrate" targettag="stowawaytoolbox" spawnlocation="MainSub" ignorebyai="true" />
+      <Label name="stowawayreturn"/>
+      <TriggerAction target1tag="stowawaytoolbox" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true"/>
+      <ConversationAction text="EventText.stowaway1.c1" dialogtype="Regular" eventsprite="Stowaway1A" targettag="triggerer_player">
+        <Option text="EventText.stowaway1.o1">
+          <ConversationAction text="EventText.stowaway1.o1.c1" dialogtype="Regular" targettag="triggerer_player" eventsprite="Stowaway1A">
+            <Option text="EventText.stowaway1.o1.o1">
+              <ConversationAction text="EventText.stowaway1.o1.o1.c1" dialogtype="Regular" targettag="triggerer_player">
+                <Option text="EventText.stowaway1.o1.o1.o1">
+                  <ConversationAction text="EventText.stowaway1.o1.o1.o1.c1" dialogtype="Regular" targettag="triggerer_player">
+                    <Option text="EventText.stowaway1.o1.o1.o1.o1">
+                      <RNGAction chance="0.66">
+                        <Success>
+                          <ConversationAction text="EventText.stowaway1.o1.o1.o1.o1.c1" dialogtype="Regular" targettag="triggerer_player" eventsprite="Stowaway1B"/>
+                          <SpawnAction speciesname="Crawler_hatchling" spawnpointtag="triggerer_player" />
+                        </Success>
+                        <Failure>
+                          <ConversationAction text="EventText.stowaway1.o1.o1.o1.o1.c2" dialogtype="Regular" targettag="triggerer_player" eventsprite="Stowaway1B"/>
+                          <RNGAction chance="0.5">
+                            <Success>
+                              <SpawnAction speciesname="psilotoad" spawnpointtag="triggerer_player" />
+                            </Success>
+                            <Failure>
+                              <SpawnAction speciesname="orangeboy" spawnpointtag="triggerer_player" />
+                            </Failure>
+                          </RNGAction>  
+                        </Failure>
+                      </RNGAction>
+                    </Option>
+                    <Option text="EventText.generic.walkaway" endconversation="true">
+                      <!--Return-->
+                      <GoTo name="stowawayreturn" />
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.generic.walkaway" endconversation="true">
+                  <!--Return-->
+                  <GoTo name="stowawayreturn" />
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.generic.walkaway" endconversation="true">
+          <!--Return-->
+          <GoTo name="stowawayreturn" />
+        </Option>
+      </ConversationAction>
+      <OnRoundEndAction>
+        <RemoveItemAction targettag="stowawaytoolbox" />
+      </OnRoundEndAction>
+    </ScriptedEvent>
+    <!--Stowaway 2-->
+    <ScriptedEvent identifier="stowaway2" commonness="50">
+      <CheckDataAction identifier="stowaway2_complete" condition="eq true">
+        <Success>
+          <!--Don't repeat event-->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player"/>
+          <TagAction criteria="itemidentifier:steelcabinet" tag="potentialcabinet" submarinetype="player" />
+          <TagAction criteria="itemidentifier:mediumwindowedsteelcabinet" tag="potentialcabinet" submarinetype="player"/>
+          <TagAction criteria="itemidentifier:mediumsteelcabinet" tag="potentialcabinet" submarinetype="player" />
+          <!--disabled return label for now-->
+          <Label name="stowawayreturn"/>
+          <TriggerAction target1tag="potentialcabinet" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true"/>
+          <ConversationAction text="EventText.stowaway2.c1" dialogtype="Regular" targettag="triggerer_player" eventsprite="Stowaway2">
+            <Option text="EventText.stowaway2.o1">
+              <!--disabled clown part for now-->
+              <CheckReputationAction targettype="faction" identifier="clowns" condition="gte 200">
+                <Success>
+                  <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="clownmessenger" targettag="messenger" spawnpointtag="triggerer_player"/>
+                  <ConversationAction text="EventText.stowaway2.o1.c1" dialogtype="Regular" targettag="triggerer_player">
+                    <Option text="EventText.stowaway2.o1.o1">
+                      <ConversationAction text="EventText.stowaway2.o1.o1.c1" dialogtype="Regular" targettag="triggerer_player"/>
+                      <MissionAction missiontag="salvageclownwreck" minlocationdistance="2" unlockfurtheronmap="true"/>
+                    </Option>
+                  </ConversationAction>
+                </Success>
+                <Failure>
+                  <ConversationAction text="EventText.stowaway2.o1.c2" dialogtype="Regular" targettag="triggerer_player">
+                    <Option text="EventText.stowaway2.o1.o2">
+                      <ConversationAction text="EventText.stowaway2.o1.o2.c1" dialogtype="Regular" targettag="triggerer_player">
+                        <Option text="EventText.stowaway2.o1.o2.o1">
+                          <ConversationAction text="EventText.stowaway2.o1.o2.o1.c1" dialogtype="Regular" targettag="triggerer_player">
+                            <Option text="EventText.stowaway2.o1.o2.o1.o1">
+                              <ConversationAction text="EventText.stowaway2.o1.o2.o1.o1.c1" dialogtype="Regular" targettag="triggerer_player">
+                                <Option text="EventText.stowaway2.o1.o2.o1.o1.o1">
+                                  <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="stowaway" spawnpointtag="triggerer_player" targettag="stowaway"/>
+                                  <ConversationAction text="EventText.stowaway2.o1.o2.o1.o1.o1.c1" dialogtype="Regular" targettag="triggerer_player"/>
+                                  <MissionAction missiontag="escortstowaway" />
+                                </Option>
+                                <Option text="EventText.stowaway2.o1.o2.o1.o1.o2">
+                                  <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="stowaway" spawnpointtag="triggerer_player" targettag="stowaway"/>
+                                  <ConversationAction text="EventText.stowaway2.o1.o2.o1.o1.o1.c1" dialogtype="Regular" targettag="triggerer_player"/>
+                                  <MissionAction missiontag="escortstowaway" />
+                                </Option>
+                                <Option text="EventText.stowaway2.o1.o2.o1.o1.o3">
+                                  <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="stowaway" spawnpointtag="triggerer_player" targettag="stowaway"/>
+                                  <ConversationAction text="EventText.stowaway2.o1.o2.o1.o1.o3.c1" dialogtype="Regular" targettag="triggerer_player"/>
+                                  <NPCChangeTeamAction npctag="stowaway" teamid="Team1" addtocrew="true" />
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                        <Option text="EventText.stowaway2.o1.o2.o2" endconversation="true">
+                          <GoTo name="stowawayreturn" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.stowaway2.o1.o2.o1">
+                      <ConversationAction text="EventText.stowaway2.o1.o2.o1.c1" dialogtype="Regular" targettag="triggerer_player">
+                        <Option text="EventText.stowaway2.o1.o2.o1.o1">
+                          <ConversationAction text="EventText.stowaway2.o1.o2.o1.o1.c1" dialogtype="Regular" targettag="triggerer_player">
+                            <Option text="EventText.stowaway2.o1.o2.o1.o1.o1">
+                              <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="stowaway" spawnpointtag="triggerer_player" targettag="stowaway"/>
+                              <ConversationAction text="EventText.stowaway2.o1.o2.o1.o1.o1.c1" dialogtype="Regular" targettag="triggerer_player"/>
+                              <MissionAction missiontag="escortstowaway" />
+                            </Option>
+                            <Option text="EventText.stowaway2.o1.o2.o1.o1.o2">
+                              <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="stowaway" spawnpointtag="triggerer_player" targettag="stowaway"/>
+                              <ConversationAction text="EventText.stowaway2.o1.o2.o1.o1.o1.c1" dialogtype="Regular" targettag="triggerer_player"/>
+                              <MissionAction missiontag="escortstowaway" />
+                            </Option>
+                            <Option text="EventText.stowaway2.o1.o2.o1.o1.o3">
+                              <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="stowaway" spawnpointtag="triggerer_player" targettag="stowaway"/>
+                              <ConversationAction text="EventText.stowaway2.o1.o2.o1.o1.o3.c1" dialogtype="Regular" targettag="triggerer_player"/>
+                              <NPCChangeTeamAction npctag="stowaway" teamid="Team1" addtocrew="true" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.stowaway2.o1.o2.o2" endconversation="true">
+                      <GoTo name="stowawayreturn" />
+                    </Option>
+                  </ConversationAction>
+                </Failure>
+              </CheckReputationAction>
+            </Option>
+            <Option text="EventText.generic.walkaway" endconversation="true">
+              <GoTo name="stowawayreturn" />
+            </Option>
+          </ConversationAction>
+          <SetDataAction identifier="stowaway2_complete" value="true"/>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--Shock jock-->
+    <ScriptedEvent identifier="shockjock" commonness="50">
+      <CheckDataAction identifier="shockjock_complete" condition="eq true">
+        <Success>
+          <!--Don't repeat this event if the continuation event is complete-->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player"/>
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="passerby" spawnlocation="outpost"/>
+          <TriggerAction target1tag="player" target2tag="passerby" applytotarget1="triggerer_player" radius="150" waitforinteraction="false"/>
+          <ConversationAction text="EventText.shockjock.c1" targettag="triggerer_player" dialogtype="Regular" eventsprite="ShockJock">
+            <Option text="EventText.shockjock.o1">
+              <RNGAction chance="0.66">
+                <Success>
+                  <RNGAction chance="0.5">
+                    <Success>
+                      <ConversationAction text="EventText.shockjock.o1.c1" targettag="triggerer_player" dialogtype="Regular">
+                        <Option text="EventText.generic.continue">
+                          <ConversationAction text="EventText.shockjock.o1.o1.c1" targettag="triggerer_player" dialogtype="Regular">
+                            <Option text="EventText.generic.continue">
+                              <ConversationAction text="EventText.shockjock.signoff" targettag="triggerer_player" dialogtype="Regular" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Success>
+                    <Failure>
+                      <ConversationAction text="EventText.shockjock.o1.c2" targettag="triggerer_player" dialogtype="Regular">
+                        <Option text="EventText.generic.continue">
+                          <ConversationAction text="EventText.shockjock.o1.o2.c1" targettag="triggerer_player" dialogtype="Regular">
+                            <Option text="EventText.generic.continue">
+                              <ConversationAction text="EventText.shockjock.signoff" targettag="triggerer_player" dialogtype="Regular" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Failure>
+                  </RNGAction>
+                </Success>
+                <Failure>
+                  <ConversationAction text="EventText.shockjock.o1.c3" targettag="triggerer_player" dialogtype="Regular">
+                    <Option text="EventText.generic.continue">
+                      <ConversationAction text="EventText.shockjock.o1.o3.c1" targettag="triggerer_player" dialogtype="Regular">
+                        <Option text="EventText.generic.continue">
+                          <ConversationAction text="EventText.shockjock.signoff" targettag="triggerer_player" dialogtype="Regular" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Failure>
+              </RNGAction>
+              <ConversationAction text="EventText.shockjock.o1.c4" targettag="triggerer_player" dialogtype="Regular">
+                <Option text="EventText.shockjock.o1.o4">
+                  <ConversationAction text="EventText.shockjock.o1.o4.c1" targettag="triggerer_player" dialogtype="Regular" />
+                  <SetDataAction identifier="heardbroadcast" value="true" />
+                </Option>
+                <Option text="EventText.generic.walkaway" endconversation="true">
+                  <!--END-->
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.generic.ignore" endconversation="true">
+              <!--END-->
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--Shock jock continuation-->
+    <ScriptedEvent identifier="shockjock2" commonness="50">
+      <TagAction criteria="player" tag="player"/>
+      <CheckDataAction identifier="shockjock_complete" condition="eq true">
+        <Success>
+          <!--Don't repeat event-->
+        </Success>
+        <Failure>
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="shockjock" targettag="okelly" spawnpointtag="saferoom" spawnlocation="beaconstation" requirespawnpointtag="true"/>
+          <SpawnAction speciesname="orangeboy" spawnpointtag="saferoom" targettag="maurice" spawnlocation="beaconstation" requirespawnpointtag="true"/>
+          <SpawnAction itemidentifier="petnametag" targetinventory="maurice" targettag="mauricenametag"/>
+          <StatusEffectAction targettag="mauricenametag">
+            <StatusEffect target="This" writtenname="Maurice"/>
+          </StatusEffectAction>
+          <TriggerAction target1tag="player" target2tag="okelly" applytotarget1="triggerer_player" radius="200" />
+          <CombatAction combatmode="Offensive" npctag="okelly" enemytag="triggerer_player" isinstigator="true" guardreaction="none" witnessreaction="retreat"/>
+          <SetDataAction identifier="shockjock_complete" value="true"/>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--Assassination of Jacov Subra-->
+    <!--PART 1-->
+    <ScriptedEvent identifier="assassinationofjacovsubra1" commonness="50">
+      <CheckDataAction identifier="waytoascension" condition="gt 3">
+        <Success>
+          <!-- Don't give the assassination mission after joining the Church of Husk -->
+        </Success>
+        <Failure>
+          <CheckDataAction identifier="subraevent_state" condition="gt 0">
+            <Success>
+              <!--Don't repeat event-->
+            </Success>
+            <Failure>
+              <TagAction criteria="player" tag="player"/>
+              <TagAction criteria="itemidentifier:steelcabinet" tag="potentialcabinet" submarinetype="outpost" />
+              <TagAction criteria="itemidentifier:mediumwindowedsteelcabinet" tag="potentialcabinet" submarinetype="outpost"/>
+              <TagAction criteria="itemidentifier:mediumsteelcabinet" tag="potentialcabinet" submarinetype="outpost" />
+              <SpawnAction itemidentifier="idcard" spawnlocation="outpost" targettag="subraid" targetinventory="potentialcabinet" ignorebyai="true" />
+              <!--<TriggerAction target1tag="potentialcabinet" target2tag="player" applytotarget1="selectedcabinet" applytotarget2="triggerer_player" radius="50" />-->
+              <TriggerAction target1tag="subraid" target2tag="player" applytotarget1="selectedcabinet" applytotarget2="triggerer_player" radius="50" waitforinteraction="true"/>
+              <SetDataAction identifier="subraevent_state" value="1"/>
+              <ConversationAction text="EventText.assassinationofjacovsubra1.c1" dialogtype="Regular" targettag="triggerer_player" eventsprite="JacovSubra1">
+                <Option text="EventText.assassinationofjacovsubra1.o1">
+                  <ConversationAction text="EventText.assassinationofjacovsubra1.o1.c1" targettag="triggerer_player"/>
+                </Option>
+                <Option text="EventText.assassinationofjacovsubra1.o2">
+                  <!--Do nothing for now-->
+                </Option>
+              </ConversationAction>
+            </Failure>
+          </CheckDataAction>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--PART 2-->
+    <ScriptedEvent identifier="assassinationofjacovsubra2" commonness="0">
+      <CheckDataAction identifier="subraevent_state" condition="eq 1">
+        <Success>
+          <TagAction criteria="player" tag="player"/>
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="workeronbreak" spawnpointtype="Path" spawnlocation="Outpost" targetmoduletags="airlock"/>
+          <TriggerAction target1tag="workeronbreak" target2tag="player" applytotarget2="triggerer_player" radius="500" waitforinteraction="true"/>
+          <NPCWaitAction npctag="workeronbreak" wait="true" />
+          <ConversationAction text="EventText.assassinationofjacovsubra2.c1" targettag="triggerer_player">
+            <Option text="EventText.assassinationofjacovsubra2.o1">
+              <ConversationAction text="EventText.assassinationofjacovsubra2.o1.c1" targettag="triggerer_player" eventsprite="JacovSubra2">
+                <Option text="EventText.generic.continue">
+                  <ConversationAction text="EventText.assassinationofjacovsubra2.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.assassinationofjacovsubra2.o1.o1.o1">
+                      <ConversationAction text="EventText.assassinationofjacovsubra2.o1.o1.o1.c1" targettag="triggerer_player"/>
+                      <SetDataAction identifier="subraevent_state" value="2"/>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option >
+            <Option text="EventText.assassinationofjacovsubra2.o2">
+              <ConversationAction text="EventText.assassinationofjacovsubra2.o1.o1.c1" targettag="triggerer_player" eventsprite="JacovSubra2">
+                <Option text="EventText.assassinationofjacovsubra2.o1.o1.o1">
+                  <ConversationAction text="EventText.assassinationofjacovsubra2.o1.o1.o1.c1" targettag="triggerer_player"/>
+                  <SetDataAction identifier="subraevent_state" value="2"/>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.assassinationofjacovsubra2.o3">
+              <!--Rude, but set data anyway.-->
+              <SetDataAction identifier="subraevent_state" value="2"/>
+            </Option>
+          </ConversationAction>
+          <NPCWaitAction npctag="workeronbreak" wait="false" />
+        </Success>
+        <Failure>
+          <!--Do nothing before the ID card is found-->
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--PART 3-->
+    <!--TODO:
+    -trigger interact-->
+    <ScriptedEvent identifier="assassinationofjacovsubra3" commonness="0">
+      <CheckDataAction identifier="waytoascension" condition="gt 3">
+        <Success>
+          <!-- Don't progress the assassination mission after joining the Church of Husk -->
+        </Success>
+        <Failure>
+          <CheckDataAction identifier="subraevent_state" condition="eq 2">
+            <Success>
+              <TagAction criteria="player" tag="player"/>
+              <TagAction criteria="itemidentifier:opdeco_hrflyers" tag="potentialflyers" submarinetype="outpost" />
+              <TriggerAction target1tag="potentialflyers" target2tag="player" applytotarget2="triggerer_player" radius="100" waitforinteraction="true"/>
+              <ConversationAction text="EventText.assassinationofjacovsubra3.c1" targettag="triggerer_player" eventsprite="JacovSubra3">
+                <Option text="EventText.assassinationofjacovsubra3.o1" endconversation="true">
+                  <MissionAction missionidentifier="gotosubra" locationtype="Abandoned" unlockfurtheronmap="true"/>
+                </Option >
+              </ConversationAction>
+            </Success>
+            <Failure>
+              <!--Do nothing-->
+            </Failure>
+          </CheckDataAction>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--PART 4-->
+    <ScriptedEvent identifier="assassinationofjacovsubra4" commonness="0">
+      <CheckDataAction identifier="waytoascension" condition="gt 3">
+        <Success>
+          <!-- Don't progress the assassination mission after joining the Church of Husk -->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player"/>
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="jacovsubra" targettag="jacovsubra" spawnlocation="Outpost"/>
+          <TriggerAction target1tag="player" target2tag="jacovsubra" applytotarget1="triggerer_player" waitforinteraction="true"/>
+          <NPCWaitAction npctag="jacovsubra" wait="true" />
+          <ConversationAction text="EventText.assassinationofjacovsubra4.c1" targettag="triggerer_player" eventsprite="JacovSubra4">
+            <Option text="EventText.assassinationofjacovsubra4.o1">
+              <ConversationAction text="EventText.assassinationofjacovsubra4.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.assassinationofjacovsubra4.o1.o1">
+                  <ConversationAction text="EventText.assassinationofjacovsubra4.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.assassinationofjacovsubra4.o1.o1.o1">
+                      <ConversationAction text="EventText.assassinationofjacovsubra4.o1.o1.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.assassinationofjacovsubra4.deal">
+                          <ConversationAction text="EventText.assassinationofjacovsubra4.neversaw" targettag="triggerer_player"/>
+                          <MoneyAction amount="3000" />
+                        </Option>
+                        <Option text="EventText.assassinationofjacovsubra4.nodeal">
+                          <ConversationAction text="EventText.assassinationofjacovsubra4.run" targettag="triggerer_player"/>
+                          <CombatAction combatmode="retreat" npctag="jacovsubra" enemytag="triggerer_player" isinstigator="true" guardreaction="none" witnessreaction="retreat"/>
+                          <SetDataAction identifier="subraevent_state" value="3"/>
+                          <!--END-->
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.assassinationofjacovsubra4.o1.o1.o2">
+                      <ConversationAction text="EventText.assassinationofjacovsubra4.o1.o1.o2.c1" targettag="triggerer_player">
+                        <Option text="EventText.assassinationofjacovsubra4.o1.o1.o2.o1" endconversation="true">
+                          <CombatAction combatmode="retreat" npctag="jacovsubra" enemytag="triggerer_player" isinstigator="true" guardreaction="none" witnessreaction="retreat"/>
+                          <SetDataAction identifier="subraevent_state" value="3"/>
+                          <!--END-->
+                        </Option>
+                        <Option text="EventText.assassinationofjacovsubra4.o1.o1.o2.o2">
+                          <ConversationAction text="EventText.assassinationofjacovsubra4.o1.o1.o2.o2.c1" targettag="triggerer_player"/>
+                          <MissionAction missionidentifier="subraescort"/>
+                          <NPCFollowAction npctag="jacovsubra" targettag="triggerer_player" follow="true" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.assassinationofjacovsubra4.o1.o2">
+                  <ConversationAction text="EventText.assassinationofjacovsubra4.o1.o2.c1" targettag="triggerer_player">
+                    <Option text="EventText.assassinationofjacovsubra4.deal">
+                      <ConversationAction text="EventText.assassinationofjacovsubra4.neversaw" targettag="triggerer_player"/>
+                      <MoneyAction amount="3000" />
+                    </Option>
+                    <Option text="EventText.assassinationofjacovsubra4.nodeal">
+                      <ConversationAction text="EventText.assassinationofjacovsubra4.run" targettag="triggerer_player"/>
+                      <CombatAction combatmode="retreat" npctag="jacovsubra" enemytag="triggerer_player" isinstigator="true" guardreaction="none" witnessreaction="retreat"/>
+                      <SetDataAction identifier="subraevent_state" value="3"/>
+                      <!--END-->
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.assassinationofjacovsubra4.o2" endconversation="true">
+              <CombatAction combatmode="retreat" npctag="jacovsubra" enemytag="triggerer_player" isinstigator="true" guardreaction="none" witnessreaction="retreat"/>
+              <SetDataAction identifier="subraevent_state" value="3"/>
+              <!--END-->
+            </Option>
+          </ConversationAction>
+          <NPCWaitAction npctag="jacovsubra" wait="false" />
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--Bad vibrations-->
+    <!--PART 1-->
+    <ScriptedEvent identifier="badvibrations1" commonness="50">
+      <CheckDataAction identifier="badvibrations_missionreceived" condition="eq true">
+        <Success>
+          <!--Don't repeat-->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player"/>
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="artifactvictim" targettag="victim" spawnlocation="Outpost" />
+          <NPCWaitAction npctag="artifactvictim" wait="true" />
+          <TriggerAction target1tag="player" target2tag="victim" applytotarget1="triggerer_player" waitforinteraction="true"/>
+          <ConversationAction text="EventText.badvibrations1.c1" targettag="triggerer_player" eventsprite="BadVibration1">
+            <Option text="EventText.badvibrations1.o1">
+              <ConversationAction text="EventText.badvibrations1.o1.c1" targettag="triggerer_player" eventsprite="BadVibration2">
+                <Option text="EventText.badvibrations1.o1.o1">
+                  <ConversationAction text="EventText.badvibrations1.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.badvibrations1.o1.o1.o1">
+                      <ConversationAction text="EventText.badvibrations1.o1.o1.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.badvibrations1.stepback">
+                          <ConversationAction text="EventText.badvibrations1.raving" targettag="triggerer_player"/>
+                          <MissionAction missionidentifier="badvibrationsartifactruins"/>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.badvibrations1.stepback">
+                      <ConversationAction text="EventText.badvibrations1.raving" targettag="triggerer_player"/>
+                      <MissionAction missionidentifier="badvibrationsartifactruins"/>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.badvibrations1.notmyproblem">
+                  <!--END-->
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.badvibrations1.notmyproblem">
+              <!--END-->
+            </Option>
+          </ConversationAction>
+          <SetDataAction identifier="badvibrations_missionreceived" value="true"/>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--PART 2-->
+    <ScriptedEvent identifier="badvibrations2" commonness="0">
+      <TagAction criteria="player" tag="player"/>
+      <TagAction criteria="itemidentifier:psychosisartifact_event" tag="artifact"/>
+      <TriggerAction target1tag="player" target2tag="artifact" applytotarget1="triggerer_player" waitforinteraction="true"/>
+      <AfflictionAction affliction="psychosis" strength="10" targettag="triggerer_player" />
+      <ConversationAction text="EventText.badvibrations2.c1" targettag="triggerer_player">
+        <Option text="EventText.badvibrations2.o1">
+          <AfflictionAction affliction="psychosis" strength="20" targettag="triggerer_player" />
+          <ConversationAction text="EventText.badvibrations2.o1.c1" targettag="triggerer_player">
+            <Option text="EventText.badvibrations2.o1.o1">
+              <AfflictionAction affliction="psychosis" strength="30" targettag="triggerer_player" />
+              <ConversationAction text="EventText.badvibrations2.o1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.badvibrations2.o1.o1.o1">
+                  <ConversationAction text="EventText.badvibrations2.o1.o1.o1.c1" targettag="triggerer_player" fadetoblack="true"/>
+                  <AfflictionAction affliction="paralysis" strength="1000" targettag="triggerer_player" />
+                  <!--END-->
+                </Option>
+                <Option text="EventText.badvibrations2.inspect">
+                  <AfflictionAction affliction="psychosis" strength="-100" targettag="triggerer_player" />
+                  <SetDataAction identifier="badvibrations_state" value="1" />
+                  <ConversationAction text="EventText.badvibrations2.protrusion" targettag="triggerer_player"/>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.badvibrations2.inspect">
+              <AfflictionAction affliction="psychosis" strength="-100" targettag="triggerer_player" />
+              <SetDataAction identifier="badvibrations_state" value="1" />
+              <ConversationAction text="EventText.badvibrations2.protrusion" targettag="triggerer_player"/>
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.badvibrations2.inspect">
+          <AfflictionAction affliction="psychosis" strength="-100" targettag="triggerer_player" />
+          <SetDataAction identifier="badvibrations_state" value="1" />
+          <ConversationAction text="EventText.badvibrations2.protrusion" targettag="triggerer_player"/>
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--PART 3-->
+    <ScriptedEvent identifier="badvibrations3" commonness="0">
+      <CheckDataAction identifier="badvibrations_state" condition="eq 1">
+        <Success>
+          <TagAction criteria="player" tag="player"/>
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="artifactvictim" targettag="artifactvictim" spawnlocation="Outpost" />
+          <NPCWaitAction npctag="artifactvictim" wait="true" />
+          <TriggerAction target1tag="player" target2tag="artifactvictim" applytotarget1="triggerer_player" waitforinteraction="true"/>
+          <ConversationAction text="EventText.badvibrations3.c1" targettag="triggerer_player">
+            <Option text="EventText.badvibrations3.o1">
+              <ConversationAction text="EventText.badvibrations3.gotbetter" targettag="triggerer_player">
+                <Option text="EventText.badvibrations3.welcome">
+                  <ConversationAction text="EventText.badvibrations3.anotherthing" targettag="triggerer_player">
+                    <Option text="EventText.badvibrations3.merrier">
+                      <ConversationAction text="EventText.badvibrations3.seeyouonboard" targettag="triggerer_player"/>
+                      <NPCChangeTeamAction npctag="artifactvictim" teamid="Team1" addtocrew="true" />
+                      <SetDataAction identifier="badvibrations_state" value="2" />
+                      <!--END-->
+                    </Option>
+                    <Option text="EventText.badvibrations3.full">
+                      <ConversationAction text="EventText.badvibrations3.hangout" targettag="triggerer_player"/>
+                      <SetDataAction identifier="badvibrations_state" value="2" />
+                      <!--END-->
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.badvibrations3.reward">
+                  <ConversationAction text="EventText.badvibrations3.scrounge" targettag="triggerer_player"/>
+                  <MoneyAction amount="350" />
+                  <SetDataAction identifier="badvibrations_state" value="2" />
+                  <!--END-->
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.badvibrations3.o2">
+              <ConversationAction text="EventText.badvibrations3.o2.c1" targettag="triggerer_player">
+                <Option text="EventText.badvibrations3.o2.o1">
+                  <ConversationAction text="EventText.badvibrations3.gotbetter" targettag="triggerer_player">
+                    <Option text="EventText.badvibrations3.welcome">
+                      <ConversationAction text="EventText.badvibrations3.anotherthing" targettag="triggerer_player">
+                        <Option text="EventText.badvibrations3.merrier">
+                          <ConversationAction text="EventText.badvibrations3.seeyouonboard" targettag="triggerer_player"/>
+                          <NPCChangeTeamAction npctag="artifactvictim" teamid="Team1" addtocrew="true" />
+                          <SetDataAction identifier="badvibrations_state" value="2" />
+                          <!--END-->
+                        </Option>
+                        <Option text="EventText.badvibrations3.full">
+                          <ConversationAction text="EventText.badvibrations3.hangout" targettag="triggerer_player"/>
+                          <SetDataAction identifier="badvibrations_state" value="2" />
+                          <!--END-->
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.badvibrations3.reward">
+                      <ConversationAction text="EventText.badvibrations3.scrounge" targettag="triggerer_player"/>
+                      <MoneyAction amount="350" />
+                      <SetDataAction identifier="badvibrations_state" value="2" />
+                      <!--END-->
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Success>
+        <Failure>
+          <!--Do nothing-->
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--A man and his raptor-->
+    <!--PART 1-->
+    <ScriptedEvent identifier="manandhisraptor1" commonness="50">
+      <CheckDataAction identifier="manandhisraptor_missionreceived" condition="eq true">
+        <Success>
+          <!--Don't repeat-->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player"/>
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="raptorowner" targettag="raptorowner" spawnlocation="Outpost" />
+          <NPCWaitAction npctag="raptorowner" wait="true" />
+          <TriggerAction target1tag="player" target2tag="raptorowner" applytotarget1="triggerer_player" waitforinteraction="true"/>
+          <ConversationAction text="EventText.manandhisraptor1.c1" targettag="triggerer_player" eventsprite="ManAndHisRaptor">
+            <Option text="EventText.manandhisraptor1.o1">
+              <ConversationAction text="EventText.manandhisraptor1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.manandhisraptor1.o1.o1">
+                  <ConversationAction text="EventText.manandhisraptor1.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.manandhisraptor1.takeonboard">
+                      <MissionAction missionidentifier="raptorescort"/>
+                      <MoneyAction amount="1000" />
+                      <ConversationAction text="EventText.manandhisraptor1.great" targettag="triggerer_player"/>
+                    </Option>
+                    <Option text="EventText.generic.refuse">
+                      <!--END-->
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.manandhisraptor1.takeonboard">
+                  <MissionAction missionidentifier="raptorescort"/>
+                  <ConversationAction text="EventText.manandhisraptor1.great" targettag="triggerer_player"/>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.manandhisraptor1.o2">
+              <!--END-->
+            </Option>
+          </ConversationAction>
+          <SetDataAction identifier="manandhisraptor_missionreceived" value="true"/>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--PART 2-->
+    <ScriptedEvent identifier="manandhisraptor2" commonness="0">
+      <TagAction criteria="player" tag="player"/>
+      <TagAction criteria="humanprefabidentifier:raptorowner" tag="raptorowner"/>
+      <TriggerAction target1tag="player" target2tag="raptorowner" applytotarget1="triggerer_player" waitforinteraction="true"/>
+      <ConversationAction text="EventText.manandhisraptor2.c1" targettag="triggerer_player">
+        <Option text="EventText.manandhisraptor2.o1">
+          <SpawnAction speciesname="mudraptor_passive" spawnpointtag="raptorowner" targettag="rex"/>
+          <SpawnAction itemidentifier="petnametag" targetinventory="rex" targettag="rexnametag"/>
+          <StatusEffectAction targettag="rexnametag">
+            <StatusEffect target="This" writtenname="Rex"/>
+          </StatusEffectAction>
+          <ConversationAction text="EventText.manandhisraptor2.o1.c1" targettag="triggerer_player"/>
+        </Option>
+      </ConversationAction>
+      <ConversationAction text="EventText.manandhisraptor2.c1.c1" speakertag="rex" endeventifinterrupted="false" dialogtype="Small" />
+    </ScriptedEvent>
+    <!--Heart of gold-->
+    <ScriptedEvent identifier="heartofgold" commonness="50">
+      <CheckDataAction identifier="heartofgold_complete" condition="eq true">
+        <Success>
+          <!--Don't repeat-->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player"/>
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="drugdealer" targettag="drugdealer" spawnlocation="outpost"/>
+          <NPCWaitAction npctag="drugdealer" wait="true" />
+          <TriggerAction target1tag="player" target2tag="drugdealer" applytotarget1="triggerer_player" waitforinteraction="true"/>
+          <ConversationAction text="EventText.heartofgold.c1" targettag="triggerer_player" eventsprite="HeartOfGold">
+            <Option text="EventText.heartofgold.o1">
+              <ConversationAction text="EventText.heartofgold.o1.c1" targettag="triggerer_player"/>
+              <CombatAction combatmode="Offensive" npctag="drugdealer" enemytag="triggerer_player" isinstigator="false" guardreaction="none" witnessreaction="retreat"/>
+              <!--END-->
+            </Option>
+            <Option text="EventText.heartofgold.o2">
+              <ConversationAction text="EventText.heartofgold.o2.c1" targettag="triggerer_player">
+                <Option text="EventText.heartofgold.goodluck">
+                  <ConversationAction text="EventText.heartofgold.wait" targettag="triggerer_player">
+                    <Option text="EventText.heartofgold.okay">
+                      <ConversationAction text="EventText.heartofgold.signingbonus" targettag="triggerer_player"/>
+                      <NPCChangeTeamAction npctag="drugdealer" teamid="Team1" addtocrew="true" />
+                      <!--END-->
+                    </Option>
+                    <Option text="EventText.generic.refuse">
+                      <ConversationAction text="EventText.heartofgold.whatamigonnado" targettag="triggerer_player">
+                        <Option text="EventText.heartofgold.onyourown">
+                          <!--END-->
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.heartofgold.o2.o2">
+                  <ConversationAction text="EventText.heartofgold.o2.o2.c1" targettag="triggerer_player">
+                    <Option text="EventText.heartofgold.o2.o2.o1">
+                      <ConversationAction text="EventText.heartofgold.o2.o2.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.heartofgold.goodluck">
+                          <ConversationAction text="EventText.heartofgold.wait" targettag="triggerer_player">
+                            <Option text="EventText.heartofgold.okay">
+                              <ConversationAction text="EventText.heartofgold.signingbonus" targettag="triggerer_player"/>
+                              <NPCChangeTeamAction npctag="drugdealer" teamid="Team1" addtocrew="true" />
+                              <!--END-->
+                            </Option>
+                            <Option text="EventText.generic.refuse">
+                              <ConversationAction text="EventText.heartofgold.whatamigonnado" targettag="triggerer_player">
+                                <Option text="EventText.heartofgold.onyourown">
+                                  <!--END-->
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+          <SetDataAction identifier="heartofgold_complete" value="true"/>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+
+    <!-- radiation escapee -->
+    <ScriptedEvent identifier="radiationescapee" commonness="50">
+      <CheckDataAction identifier="radiationescapee_missionreceived" condition="eq true">
+        <Success>
+          <!--Don't repeat-->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player"/>
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="radiationescapee" targettag="radiationescapee" spawnlocation="Outpost" />
+          <TriggerAction target1tag="radiationescapee" target2tag="player" applytotarget2="triggerer_player" radius="500" waitforinteraction="false"/>
+          <NPCFollowAction npctag="radiationescapee" targettag="triggerer_player" follow="true" />
+          <TriggerAction target1tag="radiationescapee" target2tag="player" applytotarget2="triggerer_player" radius="100" waitforinteraction="false"/>
+          <ConversationAction text="EventText.radiationescapee.c1" targettag="triggerer_player" eventsprite="ManAndHisRaptor">
+            <Option text="EventText.radiationescapee.o1">
+              <ConversationAction text="EventText.radiationescapee.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.radiationescapee.o1.o1">                  
+                  <ConversationAction text="EventText.radiationescapee.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="eventtext.manandhisraptor1.takeonboard">
+                      <MissionAction missionidentifier="radiationescapeeescort" unlockfurtheronmap="true"/>
+                      <ConversationAction text="EventText.radiationescapee.great" targettag="triggerer_player"/>
+                    </Option>
+                    <Option text="EventText.generic.refuse">
+                      <!--END-->
+                    </Option>
+                  </ConversationAction>                  
+                </Option>
+                <Option text="EventText.radiationescapee.o1.o2">
+                  <ConversationAction text="EventText.radiationescapee.o1.o2.c1" targettag="triggerer_player">
+                    <Option text="EventText.manandhisraptor1.takeonboard">
+                      <MissionAction missionidentifier="radiationescapeeescort" unlockfurtheronmap="true"/>
+                      <ConversationAction text="EventText.radiationescapee.great" targettag="triggerer_player"/>
+                    </Option>
+                    <Option text="EventText.generic.refuse">
+                      <!--END-->
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+          <SetDataAction identifier="radiationescapee_missionreceived" value="true"/>
+          <NPCFollowAction npctag="radiationescapee" targettag="triggerer_player" follow="false" />
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!-- researcher escort -->
+    <ScriptedEvent identifier="researcherescort" commonness="50">
+      <CheckDataAction identifier="researcherescort_missionreceived" condition="eq true">
+        <Success>
+          <!--Don't repeat-->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player"/>
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="eyeresearcher" targettag="eyeresearcher" spawnlocation="Outpost" />
+          <TriggerAction target1tag="player" target2tag="eyeresearcher" applytotarget1="triggerer_player" waitforinteraction="true"/>
+          <ConversationAction text="EventText.researcherescort.c1" targettag="triggerer_player" eventsprite="BombScare1">
+            <Option text="EventText.researcherescort.o1">
+              <ConversationAction text="EventText.researcherescort.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.researcherescort.o1.o1">
+                  <ConversationAction text="EventText.researcherescort.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.researcherescort.o1.o1.o1">
+                      <ConversationAction text="EventText.researcherescort.o1.o1.o1.c1" targettag="triggerer_player">
+                        <Option text="eventtext.manandhisraptor1.takeonboard">
+                          <MissionAction missionidentifier="researcherescort" unlockfurtheronmap="true"/>
+                          <ConversationAction text="EventText.researcherescort.great" targettag="triggerer_player"/>
+                          <SetDataAction identifier="researcherescort_missionreceived" value="true"/>
+                        </Option>
+                        <Option text="EventText.generic.refuse">
+                          <!--END-->
+                        </Option>
+                      </ConversationAction>
+                    </Option>                    
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!-- returner -->
+    <ScriptedEvent identifier="returner" commonness="50">
+      <CheckDataAction identifier="returner" condition="eq true">
+        <Success>
+          <!--Don't repeat-->
+        </Success>
+        <Failure>
+          <TagAction criteria="player" tag="player"/>
+          <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="returner" spawnlocation="Outpost" />
+          <TriggerAction target1tag="player" target2tag="returner" applytotarget1="triggerer_player" radius="150" waitforinteraction="false"/>
+          <ConversationAction text="EventText.returner.c1" targettag="triggerer_player" eventsprite="BadVibration2">
+            <Option text="EventText.returner.o1">
+              <ConversationAction text="EventText.returner.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.returner.o1.o1">
+                  <ConversationAction text="EventText.returner.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.returner.o1.o1.o1">
+                      <ConversationAction text="EventText.returner.o1.o1.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.returner.o1.o1.o1.o1">
+                          <ConversationAction text="EventText.returner.o1.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+          <SetDataAction identifier="returner" value="true"/>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+    <!--Captive souls-->
+    <ScriptedEvent identifier="captivesouls" commonness="50">
+      <TagAction criteria="player" tag="player" />
+      <!-- needs a containment tank preplaced or event will not trigger. hopefully in research module -->
+      <TagAction criteria="itemidentifier:op_researchcontainmenttank3" tag="captivesoulstank" SubmarineType="Outpost" chooserandom="true" ContinueIfNoTargetsFound="false" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="researcher" targettag="captivesouls_scientist" targetmoduletags="airlock" spawnlocation="Outpost" />
+      <NPCWaitAction npctag="captivesouls_scientist" wait="true" />
+      <Label name="beginning" />
+      <ClearTagAction tag="triggerer_player" />
+      <!-- scientist conversation -->
+      <TriggerAction target1tag="player" target2tag="captivesouls_scientist" applytotarget1="triggerer_player" waitforinteraction="true" />
+      <ConversationAction text="EventText.captivesouls.c1" targettag="triggerer_player" eventsprite="mediator">
+        <Option text="EventText.captivesouls.o1">
+          <ConversationAction text="EventText.captivesouls.o1.c1" targettag="triggerer_player">
+            <Option text="EventText.generic.continue">
+              <ConversationAction text="EventText.captivesouls.o1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.generic.continue">
+                  <ConversationAction text="EventText.captivesouls.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" >
+                    <Option text="EventText.generic.continue">
+                      <ConversationAction text="EventText.captivesouls.o1.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" />
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.generic.ignore" endconversation="true">
+          <!--END-->
+          <GoTo name="beginning" />
+        </Option>
+      </ConversationAction>
+      <!--Interact with containment tank-->
+      <TriggerAction target1tag="triggerer_player" target2tag="captivesoulstank" waitforinteraction="true" />
+      <ConversationAction text="EventText.captivesouls.c1.c1" targettag="triggerer_player">
+        <Option text="EventText.captivesouls.c1.o1">
+          <ConversationAction text="EventText.captivesouls.c1.o1.c1" targettag="triggerer_player">
+            <Option text="EventText.captivesouls.c1.o1.o1">
+              <ConversationAction text="EventText.captivesouls.c1.o1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.captivesouls.c1.o1.o1.o1">
+                  <ConversationAction text="EventText.captivesouls.c1.o1.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.captivesouls.c1.o1.o1.o1.o1">
+                      <ConversationAction text="EventText.captivesouls.c1.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                        <!-- break the glass and spawn the crawler -->
+                        <Option text="EventText.captivesouls.c1.o1.o1.o1.o1.o1" endconversation="true" >
+                          <StatusEffectAction targettag="captivesoulstank">
+                            <StatusEffect target="This">
+                              <SpawnItem identifier="banditprop7" spawnposition="This" Offset="0,-10"/>
+                              <Sound file="Content/Sounds/Damage/GlassImpact2.ogg" range="500" />
+                              <ParticleEmitter particle="watersplash" particleamount="10" velocitymin="0" velocitymax="50" anglemin="240" anglemax="300" scalemin="1" scalemax="2"  />
+                            </StatusEffect>
+                          </StatusEffectAction>
+                          <SpawnAction speciesname="crawler_hatchling" spawnlocation="Outpost" targetmoduletags="researchmodule" SpawnPointTag="captivesoulstank" TargetTag="crawlerhybrid" />
+                          <StatusEffectAction targettag="crawlerhybrid">
+                            <StatusEffect target="This" disabledeltatime="true" >
+                              <!-- stun to prevent crazy ragdolling when it spawns -->
+                              <Affliction identifier="stun" strength="1" />
+                              <Affliction identifier="nausea" strength="100" />
+                            </StatusEffect>
+                            <StatusEffect target="This" delay="2" duration="10">
+                              <!-- dies after a few seconds from organ failure -->
+                              <Affliction identifier="organdamage" strength="3" />
+                            </StatusEffect>
+                          </StatusEffectAction>
+                          <!-- 5 seconds after breaking glass, interact with the tank again to grab the curio -->
+                          <WaitAction time="5" />
+                          <TriggerAction target1tag="triggerer_player" target2tag="captivesoulstank" waitforinteraction="true" />
+                          <ConversationAction text="EventText.captivesouls.c1.o1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                            <Option text="EventText.captivesouls.c1.o1.o1.o1.o1.o1.o1.o1">
+                              <ConversationAction text="EventText.captivesouls.c1.o1.o1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" />
+                              <SpawnAction itemidentifier="alientrinket1" targetinventory="triggerer_player" TargetTag="trinket" />                    
+                              <StatusEffectAction targettag="trinket">
+                                <!-- mark as stolen -->
+                                <StatusEffect target="This" SpawnedInCurrentOutpost="true" AllowStealing="false" />
+                              </StatusEffectAction>                              
+                            </Option>
+                            <Option text="EventText.captivesouls.c1.o1.o1.o1.o1.o1.o1.o2">
+                              <ConversationAction text="EventText.captivesouls.c1.o1.o1.o1.o1.o1.o1.o2.c1" targettag="triggerer_player" endconversation="true" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                        <Option text="EventText.captivesouls.c1.o1.o1.o1.o1.o2">
+                          <ConversationAction text="EventText.captivesouls.c1.o1.o1.o1.o1.o2.c1" targettag="triggerer_player" endconversation="true" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.captivesouls.c1.o1.o2">
+              <!--END-->
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.captivesouls.c1.o2">
+          <!--END-->
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+
+    <!--Explosive Mishap-->
+    <ScriptedEvent identifier="explosivemishap" commonness="50">
+      <TagAction criteria="player" tag="player" />
+      <SpawnAction itemidentifier="ancientweapon" targettag="mishapweapon" spawnlocation="Outpost" targetmoduletags="researchmodule" SpawnPointTag="research" ignorebyai="true" />
+      <SpawnAction itemidentifier="aliencircuitry" SpawnPointTag="mishapweapon" amount="3" offset="120" />
+      <StatusEffectAction targettag="mishapweapon">
+        <StatusEffect target="This" noninteractable="true" setvalue="true" />
+      </StatusEffectAction>
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="researcher" targettag="exploder1" spawnlocation="Outpost" targetmoduletags="researchmodule" SpawnPointTag="mishapweapon" AllowInPlayerView="false" ignorebyai="true"  />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="researcher" targettag="exploder2" spawnlocation="Outpost" targetmoduletags="researchmodule" SpawnPointTag="exploder1" AllowInPlayerView="false" offset="50" />
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="securitynpc[faction]" targettag="securitymishap" spawnlocation="Outpost" targetmoduletags="airlock"  />
+      <NPCWaitAction npctag="securitymishap" wait="true" />
+      <NPCWaitAction npctag="exploder1" wait="true" />
+      <NPCFollowAction npctag="exploder2" targettag="exploder1" follow="true" />
+      <!-- proximity trigger -->
+      <TriggerAction target1tag="player" target2tag="mishapweapon" applytotarget1="triggerer_player" radius="350"/>
+      <ConversationAction text="EventText.explosivemishap.c1" targettag="triggerer_player" eventsprite="Stowaway2">
+        <Option text="EventText.explosivemishap.o1">
+          <ConversationAction text="EventText.explosivemishap.o1.c1" targettag="triggerer_player">
+            <Option text="EventText.generic.continue">
+              <ConversationAction text="EventText.explosivemishap.o1.o1.c1" targettag="triggerer_player" ContinueAutomatically="true" />
+              <!-- explosions ahoy -->
+              <StatusEffectAction targettag="mishapweapon">
+                <StatusEffect target="This" duration="2" spritecolor="255,255,255,255" noninteractable="false" spawnedincurrentoutpost="true" allowstealing="false" setvalue="true">
+                  <sound file="Content/Items/Weapons/WEAPONS_laserGunShot1.ogg" range="1000" frequencymultiplier="0.5" />
+                  <ParticleEmitter particle="electricshock" particlespersecond="2" velocitymin="0" velocitymax="0" anglemin="0" anglemax="360" scalemin="0.15" scalemax="0.25" Spread="0" distancemin="0" distancemax="0" colormultiplier="255,255,255,255" />
+                  <ParticleEmitter particle="plasmaspark" particleamount="2" velocitymin="100" velocitymax="300" anglemin="20" anglemax="160" scalemin="0.5" scalemax="1" Spread="50" distancemin="0" distancemax="100" colormultiplier="255,255,255,255" />
+                </StatusEffect>
+                <StatusEffect target="This" delay="2">
+                  <Explosion range="800.0" structuredamage="0" itemdamage="200" force="5" severlimbsprobability="0" debris="true" decal="explosion" decalsize="0.5">
+                    <Affliction identifier="stun" strength="4" />
+                  </Explosion>
+                  <Sound file="Content/Sounds/Damage/StructureCrunch2.ogg" range="800" volume="2" />
+                </StatusEffect>
+              </StatusEffectAction>
+              <StatusEffectAction targettag="exploder1">
+                <StatusEffect target="This" delay="2">
+                  <Explosion range="200.0" structuredamage="0" itemdamage="200" force="5" severlimbsprobability="1" debris="true" decal="explosion" decalsize="0.5">
+                    <Affliction identifier="explosiondamage" strength="100" />
+                    <Affliction identifier="bleeding" strength="50" />
+                    <Affliction identifier="stun" strength="5" />
+                  </Explosion>
+                  <sound file="Content/Items/Weapons/ExplosionMedium1.ogg" range="1000" volume="1" />
+                </StatusEffect>
+              </StatusEffectAction>
+                <!-- make sure the characters die -->              
+              <AfflictionAction targettag="exploder1" affliction="explosiondamage" strength="10000" />
+              <AfflictionAction targettag="exploder2" affliction="explosiondamage" strength="10000" />
+              <!-- security hurries to the module -->
+              <NPCFollowAction npctag="securitymishap" targettag="exploder1" follow="True" />
+              <ConversationAction text="EventText.explosivemishap.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" />
+              <TriggerAction target1tag="player" target2tag="mishapweapon" applytotarget1="lootermishap" radius="50" waitforinteraction="true"/>
+              <ConversationAction text="EventText.explosivemishap.o1.o1.o1.o1.c1" targettag="lootermishap">
+                <Option text="EventText.explosivemishap.o1.o1.o1.o1.o1">
+                  <ConversationAction text="EventText.explosivemishap.o1.o1.o1.o1.o1.c1" targettag="lootermishap" ContinueConversation="true" >
+                    <Option text="EventText.explosivemishap.o1.o1.o1.o1.o1.o1">
+                      <ConversationAction text="EventText.explosivemishap.o1.o1.o1.o1.o1.o1.c1" targettag="lootermishap">
+                        <Option text="EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1">
+                          <!-- remove the weapon from the floor and spawn it in inventory -->
+                          <StatusEffectAction targettag="mishapweapon">
+                            <StatusEffect target="This">
+                              <Remove />
+                            </StatusEffect>
+                          </StatusEffectAction>
+                          <SpawnAction itemidentifier="ancientweapon" targettag="mishapweaponlooted" targetinventory="lootermishap" />
+                          <StatusEffectAction targettag="mishapweaponlooted">
+                            <StatusEffect target="This" spawnedincurrentoutpost="true" allowstealing="false" setvalue="true"/>
+                          </StatusEffectAction>
+                          <RNGAction chance="0.25">
+                            <Success>
+                              <SpawnAction itemidentifier="alienpowercell" targetinventory="mishapweaponlooted" />
+                              <ConversationAction targettag="lootermishap" text="EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1.c1" endconversation="true"/>
+                            </Success>
+                            <Failure>
+                              <ConversationAction targettag="lootermishap" text="EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1.c2" endconversation="true" />
+                            </Failure>
+                          </RNGAction>
+                          <!-- trigger the guard if you get near it -->
+                          <TriggerAction target1tag="lootermishap" target2tag="securitymishap" radius="100" waitforinteraction="false" />
+                          <NPCFollowAction npctag="securitymishap" targettag="lootermishap" follow="true" />
+                          <ConversationAction text="EventText.explosivemishap.securitycheck" targettag="lootermishap" eventsprite="security" >
+                            <Option text="EventText.explosivemishap.didntseeanything">
+                              <!-- if you have the weapon on you, guard arrests you -->
+                              <CheckItemAction targettag="lootermishap" itemtags="mishapweaponlooted">
+                                <Success>
+                                  <ConversationAction text="EventText.explosivemishap.noticedweapon" targettag="lootermishap" eventsprite="security" endconversation="true" />
+                                  <CombatAction combatmode="Arrest" npctag="securitymishap" enemytag="lootermishap" isinstigator="true" guardreaction="none" witnessreaction="retreat" />
+                                </Success>
+                                <Failure>
+                                  <ConversationAction text="EventText.explosivemishap.noweapon" targettag="lootermishap" eventsprite="security" endconversation="true" />
+                                  <NPCFollowAction npctag="securitymishap" targettag="lootermishap" follow="false" />
+                                </Failure>
+                              </CheckItemAction>
+                            </Option>
+                            <Option text="EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1.o2">
+                              <StatusEffectAction targettag="mishapweaponlooted">
+                                <StatusEffect target="This">
+                                  <Remove />
+                                </StatusEffect>
+                              </StatusEffectAction>
+                              <ConversationAction targettag="lootermishap" text="EventText.explosivemishap.o1.o1.o1.o1.o1.o1.o1.o2.c1" endconversation="true" />
+                              <ReputationAction targettype="Location" increase="3" />
+                              <NPCWaitAction npctag="securitymishap" wait="true" />
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.explosivemishap.o1.o1.o1.o1.o2">
+                  <!--END-->
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.generic.ignore" endconversation="true">
+          <!--END-->
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+
+    <!--Occupational Hazards-->
+    <ScriptedEvent identifier="occupationalhazards" commonness="50">
+      <TagAction criteria="player" tag="player" />
+      <Label name="beginning" />
+      <ClearTagAction tag="triggerer_player" />
+      <TriggerAction target1tag="player" targetmoduletype="crewmodule" applytotarget1="triggerer_player" />
+      <ConversationAction text="EventText.occupationalhazards.c1" targettag="triggerer_player" eventsprite="engineer">
+        <Option text="EventText.occupationalhazards.o1">
+          <ConversationAction text="EventText.occupationalhazards.o1.c1" targettag="triggerer_player">
+            <Option text="EventText.occupationalhazards.o1.o1">
+              <ConversationAction text="EventText.occupationalhazards.o1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.occupationalhazards.o1.o1.o1">
+                  <ConversationAction text="EventText.occupationalhazards.o1.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.occupationalhazards.o1.o1.o1.o1">
+                      <ConversationAction text="EventText.occupationalhazards.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.occupationalhazards.o1.o1.o1.o1.o1">
+                          <ConversationAction text="EventText.occupationalhazards.o1.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                            <Option text="EventText.occupationalhazards.o1.o1.o1.o1.o1.o1">
+                              <ConversationAction text="EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                                <Option text="EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1">
+                                  <ConversationAction text="EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                                    <Option text="EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1">
+                                      <ConversationAction text="EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" />
+                                      <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="raptorvictim" targettag="occupationalhazards_miner" spawnlocation="Outpost" spawnpointtype="Path" targetmoduletags="minemodule" />
+                                      <SpawnAction itemidentifier="smallmudraptoregg" spawnlocation="Outpost" targetmoduletags="minemodule"/>
+                                      <SpawnAction itemidentifier="smallmudraptoregg" spawnlocation="Outpost" targetmoduletags="minemodule"/>
+                                      <AfflictionAction targettag="occupationalhazards_miner" affliction="bitewounds" strength="1000" />
+                                      <TriggerAction target1tag="occupationalhazards_miner" target2tag="triggerer_player" radius="100" disableiftargetincapacitated="false"/>
+                                      <ConversationAction text="EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1.c1.c1" targettag="triggerer_player" eventsprite="unconscious">
+                                        <Option text="EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1.c1.o1">
+                                          <ConversationAction text="EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1.c1.o1.c1" targettag="triggerer_player" endconversation="true"/>
+                                          <MoneyAction amount="904" />
+                                        </Option>
+                                        <Option text="EventText.occupationalhazards.o1.o1.o1.o1.o1.o1.o1.o1.c1.o2"/>
+                                      </ConversationAction>
+                                    </Option>
+                                  </ConversationAction>
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.generic.ignore" endconversation="true">
+          <!--END-->
+          <GoTo name="beginning" />
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+
+    <!--Hognose-->
+    <ScriptedEvent identifier="hognose" commonness="50">
+      <CheckDataAction identifier="hognose_accepted" condition="eq true">
+        <Success>
+          <!--Do nothing-->
+        </Success>
+        <Failure>
+          <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="hognose" targettag="hognose" spawnlocation="Outpost" spawnpointtype="Path" />
+          <NPCWaitAction npctag="hognose" wait="true" />
+          <TagAction criteria="player" tag="player" />
+          <TriggerAction target1tag="hognose" target2tag="player" applytotarget2="triggerer_player" radius="100" waitforinteraction="true"/>
+          <ConversationAction text="EventText.hognose.c1" targettag="triggerer_player" eventsprite="Stowaway2">
+            <Option text="EventText.hognose.o1">
+              <ConversationAction text="EventText.hognose.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.hognose.o1.o1">
+                  <ConversationAction text="EventText.hognose.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.hognose.o1.o1.o1">
+                      <ConversationAction text="EventText.hognose.o1.o1.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.hognose.o1.o1.o1.o1">
+                          <ConversationAction text="EventText.hognose.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                            <Option text="EventText.hognose.o1.o1.o1.o1.o1">
+                              <ConversationAction text="EventText.hognose.o1.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                                <Option text="EventText.generic.continue">
+                                  <ConversationAction text="EventText.hognose.o1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player">
+                                    <Option text="EventText.hognose.o1.o1.o1.o1.o1.o1.o1">
+                                      <ConversationAction text="EventText.hognose.o1.o1.o1.o1.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" />
+                                      <MissionAction missionidentifier="killmopingjack" />
+                                      <SetDataAction identifier="hognose_accepted" value="true" />
+                                    </Option>
+                                    <Option text="EventText.hognose.o1.o1.o1.o1.o1.o1.o2">
+                                      <!--END-->
+                                    </Option>
+                                  </ConversationAction>
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                    <Option text="EventText.hognose.o1.o1.o2" />
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.hognose.o1.o2">
+                  <!--END-->
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.hognose.o2">
+              <!--END-->
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckDataAction>
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="hognose2" commonness="50">
+      <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="hognose" targettag="hognose" spawnlocation="MainSub" spawnpointtype="Path" allowduplicates="false" />
+      <NPCChangeTeamAction npctag="hognose" teamid="Team1" addtocrew="true" />
+    </ScriptedEvent>
+
+    <!--Prophet of Sierpinsk-->
+    <ScriptedEvent identifier="prophetofsierpinsk" commonness="0">
+      <SpawnAction npcsetidentifier="customnpcs1" npcidentifier="prophetofsierpinsk" targettag="prophet" spawnpointtag="saferoom" spawnlocation="beaconstation" requirespawnpointtag="true" />
+      <TagAction criteria="player" tag="player" />
+      <TriggerAction target1tag="prophet" target2tag="player" applytotarget2="triggerer_player" radius="100" waitforinteraction="true" eventsprite="officeinside" />
+      <ConversationAction text="EventText.prophetofsierpinsk.c1" targettag="triggerer_player">
+        <Option text="EventText.prophetofsierpinsk.o1">
+          <ConversationAction text="EventText.prophetofsierpinsk.o1.c1" targettag="triggerer_player" />
+          <ConversationAction text="EventText.prophetofsierpinsk.o1.c1.c1" targettag="triggerer_player">
+            <Option text="EventText.prophetofsierpinsk.o1.c1.o1">
+              <ConversationAction text="EventText.prophetofsierpinsk.o1.c1.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.prophetofsierpinsk.o1.c1.o1.o1">
+                  <GoTo name="explain" />
+                </Option>
+              </ConversationAction>
+            </Option>
+            <Option text="EventText.prophetofsierpinsk.o1.c1.o2">
+              <ConversationAction text="EventText.prophetofsierpinsk.o1.c1.o2.c1" targettag="triggerer_player">
+                <Option text="EventText.prophetofsierpinsk.o1.c1.o2.o1">
+                  <GoTo name="explain" />
+                </Option>
+              </ConversationAction>
+              <Label name="explain" />
+              <ConversationAction text="EventText.prophetofsierpinsk.o1.c1.o2.c1.c1" targettag="triggerer_player" />
+              <ConversationAction text="EventText.prophetofsierpinsk.o1.c1.o2.c1.c1.c1" targettag="triggerer_player" endconversation="true" />
+            </Option>
+          </ConversationAction>
+        </Option>
+        <Option text="EventText.prophetofsierpinsk.o2">
+          <ConversationAction text="EventText.prophetofsierpinsk.o2.c1" targettag="triggerer_player">
+            <Option text="EventText.prophetofsierpinsk.o2.o1">
+              <ConversationAction text="EventText.prophetofsierpinsk.o2.o1.c1" targettag="triggerer_player">
+                <Option text="EventText.prophetofsierpinsk.o2.o1.o1">
+                  <ConversationAction text="EventText.prophetofsierpinsk.o2.o1.o1.c1" targettag="triggerer_player">
+                    <Option text="EventText.prophetofsierpinsk.o2.o1.o1.o1">
+                      <ConversationAction text="EventText.prophetofsierpinsk.o2.o1.o1.o1.c1" targettag="triggerer_player">
+                        <Option text="EventText.prophetofsierpinsk.o2.o1.o1.o1.o1">
+                          <ConversationAction text="EventText.prophetofsierpinsk.o2.o1.o1.o1.o1.c1" targettag="triggerer_player" endconversation="true" />
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+
+    <!--"Alien writing 1"-->
+    <ScriptedEvent identifier="alienwriting1" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemtag:alienwriting1" tag="alienwriting1" />
+      <Label name="writingstart" />
+      <TriggerAction target1tag="alienwriting1" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true"/>
+      <CheckItemAction targettag="triggerer_player" itemidentifiers="alientranslator">
+        <Success>
+          <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.start">
+            <Option text="eventtext.alienwriting.listen">
+              <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.writingstart"/>
+              <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.1_1"/>
+            </Option>
+            <Option text="eventtext.alienwriting.dontlisten" endconversation="true">
+              <GoTo name="writingstart" />
+            </Option>
+          </ConversationAction>
+          <GoTo name="writingstart" />
+        </Success>
+        <Failure>
+          <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.start_alt" endconversation="true"/>
+          <GoTo name="writingstart" />
+        </Failure>
+      </CheckItemAction>
+    </ScriptedEvent>
+    
+    <!--"Alien writing 2"-->
+    <ScriptedEvent identifier="alienwriting2" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemtag:alienwriting2" tag="alienwriting2" />
+      <Label name="writingstart" />
+      <TriggerAction target1tag="alienwriting2" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true"/>
+      <CheckItemAction targettag="triggerer_player" itemidentifiers="alientranslator">
+        <Success>
+          <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.start">
+            <Option text="eventtext.alienwriting.listen">
+              <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.writingstart"/>
+              <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.2_1"/>
+            </Option>
+            <Option text="eventtext.alienwriting.dontlisten" endconversation="true">
+              <GoTo name="writingstart" />
+            </Option>
+          </ConversationAction>
+          <GoTo name="writingstart" />
+        </Success>
+        <Failure>
+          <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.start_alt" endconversation="true"/>
+          <GoTo name="writingstart" />
+        </Failure>
+      </CheckItemAction>
+    </ScriptedEvent>
+
+    <!--"Alien writing 3"-->
+    <ScriptedEvent identifier="alienwriting3" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemtag:alienwriting3" tag="alienwriting3" />
+      <Label name="writingstart" />
+      <TriggerAction target1tag="alienwriting3" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true"/>
+      <CheckItemAction targettag="triggerer_player" itemidentifiers="alientranslator">
+        <Success>
+          <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.start">
+            <Option text="eventtext.alienwriting.listen">
+              <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.writingstart"/>
+              <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.3_1"/>
+            </Option>
+            <Option text="eventtext.alienwriting.dontlisten" endconversation="true">
+              <GoTo name="writingstart" />
+            </Option>
+          </ConversationAction>
+          <GoTo name="writingstart" />
+        </Success>
+        <Failure>
+          <ConversationAction targettag="triggerer_player" text="eventtext.alienwriting.start_alt" endconversation="true"/>
+          <GoTo name="writingstart" />
+        </Failure>
+      </CheckItemAction>
+    </ScriptedEvent>
+
+    <!--"Ancient encounter"-->
+    <ScriptedEvent identifier="ancientencounter" commonness="100">
+      <WaitAction time="10" />
+      <ConversationAction text="EventText.ancientencounter.c1" eventsprite="Ancient1">
+        <Option text="EventText.ancientencounter.o1">
+          <ConversationAction text="EventText.ancientencounter.o1.c1" eventsprite="Ancient2">
+            <Option text="EventText.ancientencounter.o1.o1">
+              <ConversationAction text="EventText.ancientencounter.o1.o1.c1" eventsprite="Ancient2">
+                <Option text="EventText.ancientencounter.o1.o1.o1">
+                  <ConversationAction text="EventText.ancientencounter.o1.o1.o1.c1" eventsprite="Ancient2">
+                    <Option text="EventText.ancientencounter.o1.o1.o1.o1">
+                      <ConversationAction text="EventText.ancientencounter.o1.o1.o1.o1.c1" eventsprite="Ancient2">
+                        <Option text="EventText.ancientencounter.o1.o1.o1.o1.o1">
+                          <ConversationAction text="EventText.ancientencounter.o1.o1.o1.o1.o1.c1" eventsprite="Ancient2">
+                            <Option text="EventText.ancientencounter.o1.o1.o1.o1.o1.o1">
+                              <ConversationAction text="EventText.ancientencounter.o1.o1.o1.o1.o1.o1.c1" eventsprite="Ancient2">
+                                <Option text="EventText.ancientencounter.o1.o1.o1.o1.o1.o1.o1" endconversation="true" />
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+                <Option text="EventText.ancientencounter.o1.o1.o2">
+                  <ConversationAction text="EventText.ancientencounter.o1.o1.o2.c1" eventsprite="Ancient2">
+                    <Option text="EventText.ancientencounter.o1.o1.o1">
+                      <ConversationAction text="EventText.ancientencounter.o1.o1.o1.c1" eventsprite="Ancient2">
+                        <Option text="EventText.ancientencounter.o1.o1.o1.o1">
+                          <ConversationAction text="EventText.ancientencounter.o1.o1.o1.o1.c1" eventsprite="Ancient2">
+                            <Option text="EventText.ancientencounter.o1.o1.o1.o1.o1">
+                              <ConversationAction text="EventText.ancientencounter.o1.o1.o1.o1.o1.c1" eventsprite="Ancient2">
+                                <Option text="EventText.ancientencounter.o1.o1.o1.o1.o1.o1">
+                                  <ConversationAction text="EventText.ancientencounter.o1.o1.o1.o1.o1.o1.c1" eventsprite="Ancient2">
+                                    <Option text="EventText.ancientencounter.o1.o1.o1.o1.o1.o1.o1" endconversation="true" />
+                                  </ConversationAction>
+                                </Option>
+                              </ConversationAction>
+                            </Option>
+                          </ConversationAction>
+                        </Option>
+                      </ConversationAction>
+                    </Option>
+                  </ConversationAction>
+                </Option>
+              </ConversationAction>
+            </Option>
+          </ConversationAction>
+        </Option>
+      </ConversationAction>
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="ancientencounterfinal" commonness="0">
+      <ConversationAction text="EventText.ancientencounterfinal" dialogtype="Regular" endconversation="true" eventsprite="Ancient2"/>
+    </ScriptedEvent>
+    
+    <ScriptedEvent identifier="buttonpressed1" commonness="100">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemtag:alienentrancebutton" tag="alienentrancebutton" />
+      <TagAction criteria="itemtag:anomalydoor" tag="door" />
+      <TriggerAction target1tag="alienentrancebutton" target2tag="player" applytotarget2="triggerer_player" radius="500"/>
+      <Label name="retry" />
+      <WaitAction time="1" />
+      <CheckConditionalAction targettag="door" targetitemcomponent="Door" IsOpen="true" >
+        <Success>
+          <ConversationAction text="EventText.buttonpressed1.c1" dialogtype="Regular" endconversation="true"/>
+        </Success>
+        <Failure>
+          <Goto name="retry"/>
+        </Failure>
+      </CheckConditionalAction>
+    </ScriptedEvent>
+
+    <!--"Unlock Path"-->
+    <ScriptedEvent identifier="unlockpathgeneric" commonness="0" unlockpathevent="true">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="watchman" targettag="unlockpathnpc" spawnlocation="Outpost" spawnpointtag="unlockpath" />
+      <CheckReputationAction targettype="faction" identifier="coalition" condition="gte 30">
+        <Success>
+          <ConversationAction text="EventText.unlockpathgeneric.c1" speakertag="unlockpathnpc" dialogtype="Regular"/>
+          <UnlockPathAction />
+        </Success>
+        <Failure>
+          <Label name="retry" />
+          <ConversationAction text="EventText.unlockpathgeneric.c2" speakertag="unlockpathnpc" invokertag="player" dialogtype="Regular" eventsprite="captain">
+            <Option text="EventText.unlockpathgeneric.o1">
+              <CheckMoneyAction amount="2000">
+                <Success>
+                  <MoneyAction amount="-2000" />
+                  <UnlockPathAction />
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathgeneric.o1.c1" eventsprite="captain" />
+                </Success>
+                <Failure>
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathgeneric.nomoney" eventsprite="captain" />
+                  <GoTo name="retry" />
+                </Failure>
+              </CheckMoneyAction>
+            </Option>
+            <Option text="EventText.unlockpathgeneric.o2">
+              <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathgeneric.o2.c1" eventsprite="captain" />
+              <GoTo name="retry" />
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckReputationAction>
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="unlockpathcoldcaverns" commonness="1" unlockpathevent="true" unlockpathtooltip="lockedpathtooltipcoalitionreputation" unlockpathreputation="30" faction="coalition" biome="coldcaverns">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="watchman" targettag="unlockpathnpc" spawnlocation="Outpost" spawnpointtag="unlockpath" />
+      <CheckReputationAction targettype="faction" identifier="coalition" condition="gte 30">
+        <Success>
+          <ConversationAction text="EventText.unlockpathcoldcaverns.c1" speakertag="unlockpathnpc" dialogtype="Regular"/>
+          <UnlockPathAction />
+        </Success>
+        <Failure>
+          <Label name="retry" />
+          <ConversationAction text="EventText.unlockpathcoldcaverns.c2" speakertag="unlockpathnpc" invokertag="player" dialogtype="Regular" eventsprite="captain">
+            <Option text="EventText.unlockpathcoldcaverns.o1">
+              <CheckMoneyAction amount="2000">
+                <Success>
+                  <MoneyAction amount="-2000" />
+                  <UnlockPathAction />
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathcoldcaverns.o1.c1" eventsprite="captain" />
+                </Success>
+                <Failure>
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathcoldcaverns.o1.nomoney" eventsprite="captain" />
+                  <GoTo name="retry" />
+                </Failure>
+              </CheckMoneyAction>
+            </Option>
+            <Option text="EventText.unlockpath.refusebribe">
+              <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathcoldcaverns.o2.c1" eventsprite="captain" />
+              <GoTo name="retry" />
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckReputationAction>
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="unlockpatheuropanridge" commonness="1" unlockpathevent="true" unlockpathtooltip="lockedpathtooltipcoalitionreputation" unlockpathreputation="40" faction="coalition" biome="europanridge">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="watchman" targettag="unlockpathnpc" spawnlocation="Outpost" spawnpointtag="unlockpath" />
+      <CheckReputationAction targettype="faction" identifier="coalition" condition="gte 40">
+        <Success>
+          <ConversationAction text="EventText.unlockpatheuropanridge.c1" speakertag="unlockpathnpc" dialogtype="Regular"/>
+          <UnlockPathAction />
+        </Success>
+        <Failure>
+          <Label name="retry" />
+          <ConversationAction text="EventText.unlockpatheuropanridge.c2" speakertag="unlockpathnpc" invokertag="player" dialogtype="Regular" eventsprite="captain">
+            <Option text="EventText.unlockpatheuropanridge.o1">
+              <CheckMoneyAction amount="4000">
+                <Success>
+                  <MoneyAction amount="-4000" />
+                  <UnlockPathAction />
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpatheuropanridge.o1.c1" eventsprite="captain" />
+                </Success>
+                <Failure>
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpatheuropanridge.o1.nomoney" eventsprite="captain" />
+                  <GoTo name="retry" />
+                </Failure>
+              </CheckMoneyAction>
+            </Option>
+            <Option text="EventText.unlockpath.refusebribe">
+              <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpatheuropanridge.o2.c1" eventsprite="captain" />
+              <GoTo name="retry" />
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckReputationAction>
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="unlockpathaphoticplateau" commonness="1" unlockpathevent="true" unlockpathtooltip="lockedpathtooltipcoalitionreputation" unlockpathreputation="50" faction="coalition" biome="theaphoticplateau">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="watchman" targettag="unlockpathnpc" spawnlocation="Outpost" spawnpointtag="unlockpath" />
+      <CheckReputationAction targettype="faction" identifier="coalition" condition="gte 50">
+        <Success>
+          <ConversationAction text="EventText.unlockpathaphoticplateau.c1" speakertag="unlockpathnpc" dialogtype="Regular"/>
+          <UnlockPathAction />
+        </Success>
+        <Failure>
+          <Label name="retry" />
+          <ConversationAction text="EventText.unlockpathaphoticplateau.c2" speakertag="unlockpathnpc" invokertag="player" dialogtype="Regular" eventsprite="captain">
+            <Option text="EventText.unlockpathaphoticplateau.o1">
+              <CheckMoneyAction amount="8000">
+                <Success>
+                  <MoneyAction amount="-8000" />
+                  <UnlockPathAction />
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathaphoticplateau.o1.c1" eventsprite="captain" />
+                </Success>
+                <Failure>
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathaphoticplateau.o1.nomoney" eventsprite="captain" />
+                  <GoTo name="retry" />
+                </Failure>
+              </CheckMoneyAction>
+            </Option>
+            <Option text="EventText.unlockpath.refusebribe">
+              <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathaphoticplateau.o2.c1" eventsprite="captain" />
+              <GoTo name="retry" />
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckReputationAction>
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="unlockpathgreatsea" commonness="1" unlockpathevent="true" unlockpathtooltip="lockedpathtooltipcoalitionreputation" unlockpathreputation="75" faction="coalition" biome="thegreatsea">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="watchman" targettag="unlockpathnpc" spawnlocation="Outpost" spawnpointtag="unlockpath" />
+      <CheckReputationAction targettype="faction" identifier="coalition" condition="gte 75">
+        <Success>
+          <ConversationAction text="EventText.unlockpathgreatsea.c1" speakertag="unlockpathnpc" dialogtype="Regular" eventsprite="captain"/>
+          <UnlockPathAction />
+        </Success>
+        <Failure>
+          <Label name="retry" />
+          <ConversationAction text="EventText.unlockpathgreatsea.c2" speakertag="unlockpathnpc" invokertag="player" dialogtype="Regular" eventsprite="captain">
+            <Option text="EventText.unlockpathgreatsea.o1">
+              <CheckMoneyAction amount="16000">
+                <Success>
+                  <MoneyAction amount="-16000" />
+                  <UnlockPathAction />
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathgreatsea.o1.c1" eventsprite="captain" />
+                </Success>
+                <Failure>
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathgreatsea.o1.nomoney" eventsprite="captain" />
+                  <GoTo name="retry" />
+                </Failure>
+              </CheckMoneyAction>
+            </Option>
+            <Option text="EventText.unlockpath.refusebribe">
+              <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathgreatsea.o2.c1" eventsprite="captain" />
+              <GoTo name="retry" />
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckReputationAction>
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="unlockpathcoldcavernsseparatists" commonness="1" unlockpathevent="true" unlockpathtooltip="lockedpathtooltipseparatistreputation" unlockpathreputation="30" faction="separatists" biome="coldcaverns">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="watchmanseparatist" targettag="unlockpathnpc" spawnlocation="Outpost" spawnpointtag="unlockpath" />
+      <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 30">
+        <Success>
+          <ConversationAction text="EventText.unlockpathcoldcavernsseparatists.c1" speakertag="unlockpathnpc" dialogtype="Regular"/>
+          <UnlockPathAction />
+        </Success>
+        <Failure>
+          <Label name="retry" />
+          <ConversationAction text="eventtext.unlockpathcoldcavernsseparatists.c2" speakertag="unlockpathnpc" invokertag="player" dialogtype="Regular" eventsprite="captain">
+            <Option text="EventText.unlockpathcoldcaverns.o1">
+              <CheckMoneyAction amount="2000">
+                <Success>
+                  <MoneyAction amount="-2000" />
+                  <UnlockPathAction />
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="eventtext.unlockpathcoldcavernsseparatists.o1.c1" eventsprite="captain" />
+                </Success>
+                <Failure>
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="eventtext.unlockpathcoldcavernsseparatists.o1.nomoney" eventsprite="captain" />
+                  <GoTo name="retry" />
+                </Failure>
+              </CheckMoneyAction>
+            </Option>
+            <Option text="EventText.unlockpath.refusebribe">
+              <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="eventtext.unlockpathcoldcavernsseparatists.o2.c1" eventsprite="captain" />
+              <GoTo name="retry" />
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckReputationAction>
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="unlockpatheuropanridgeseparatists" commonness="1" unlockpathevent="true" unlockpathtooltip="lockedpathtooltipseparatistreputation" unlockpathreputation="40" faction="separatists" biome="europanridge">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="watchmanseparatist" targettag="unlockpathnpc" spawnlocation="Outpost" spawnpointtag="unlockpath" />
+      <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 40">
+        <Success>
+          <ConversationAction text="eventtext.unlockpatheuropanridgeseparatists.c1" speakertag="unlockpathnpc" dialogtype="Regular"/>
+          <UnlockPathAction />
+        </Success>
+        <Failure>
+          <Label name="retry" />
+          <ConversationAction text="EventText.unlockpatheuropanridge.c2" speakertag="unlockpathnpc" invokertag="player" dialogtype="Regular" eventsprite="captain">
+            <Option text="EventText.unlockpatheuropanridge.o1">
+              <CheckMoneyAction amount="4000">
+                <Success>
+                  <MoneyAction amount="-4000" />
+                  <UnlockPathAction />
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpatheuropanridge.o1.c1" eventsprite="captain" />
+                </Success>
+                <Failure>
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpatheuropanridge.o1.nomoney" eventsprite="captain" />
+                  <GoTo name="retry" />
+                </Failure>
+              </CheckMoneyAction>
+            </Option>
+            <Option text="EventText.unlockpath.refusebribe">
+              <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpatheuropanridge.o2.c1" eventsprite="captain" />
+              <GoTo name="retry" />
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckReputationAction>
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="unlockpathaphoticplateauseparatists" commonness="1" unlockpathevent="true" unlockpathtooltip="lockedpathtooltipseparatistreputation" unlockpathreputation="50" faction="separatists" biome="theaphoticplateau">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="watchmanseparatist" targettag="unlockpathnpc" spawnlocation="Outpost" spawnpointtag="unlockpath" />
+      <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 50">
+        <Success>
+          <ConversationAction text="EventText.unlockpathaphoticplateauseparatists.c1" speakertag="unlockpathnpc" dialogtype="Regular"/>
+          <UnlockPathAction />
+        </Success>
+        <Failure>
+          <Label name="retry" />
+          <ConversationAction text="EventText.unlockpathaphoticplateau.c2" speakertag="unlockpathnpc" invokertag="player" dialogtype="Regular" eventsprite="captain">
+            <Option text="EventText.unlockpathaphoticplateau.o1">
+              <CheckMoneyAction amount="8000">
+                <Success>
+                  <MoneyAction amount="-8000" />
+                  <UnlockPathAction />
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="eventtext.unlockpathaphoticplateauseparatists.o1.c1" eventsprite="captain" />
+                </Success>
+                <Failure>
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathaphoticplateau.o1.nomoney" eventsprite="captain" />
+                  <GoTo name="retry" />
+                </Failure>
+              </CheckMoneyAction>
+            </Option>
+            <Option text="EventText.unlockpath.refusebribe">
+              <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathaphoticplateau.o2.c1" eventsprite="captain" />
+              <GoTo name="retry" />
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckReputationAction>
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="unlockpathgreatseaseparatists" commonness="1" unlockpathevent="true" unlockpathtooltip="lockedpathtooltipseparatistreputation" unlockpathreputation="75" faction="separatists" biome="thegreatsea">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="watchmanseparatist" targettag="unlockpathnpc" spawnlocation="Outpost" spawnpointtag="unlockpath" />
+      <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 75">
+        <Success>
+          <ConversationAction text="eventtext.unlockpathgreatseaseparatists.c1" speakertag="unlockpathnpc" dialogtype="Regular" eventsprite="captain"/>
+          <UnlockPathAction />
+        </Success>
+        <Failure>
+          <Label name="retry" />
+          <ConversationAction text="EventText.unlockpathgreatsea.c2" speakertag="unlockpathnpc" invokertag="player" dialogtype="Regular" eventsprite="captain">
+            <Option text="EventText.unlockpathgreatsea.o1">
+              <CheckMoneyAction amount="16000">
+                <Success>
+                  <MoneyAction amount="-16000" />
+                  <UnlockPathAction />
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathgreatsea.o1.c1" eventsprite="captain" />
+                </Success>
+                <Failure>
+                  <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathgreatsea.o1.nomoney" eventsprite="captain" />
+                  <GoTo name="retry" />
+                </Failure>
+              </CheckMoneyAction>
+            </Option>
+            <Option text="EventText.unlockpath.refusebribe">
+              <ConversationAction speakertag="unlockpathnpc" waitforinteraction="false" targettag="player" text="EventText.unlockpathgreatsea.o2.c1" eventsprite="captain" />
+              <GoTo name="retry" />
+            </Option>
+          </ConversationAction>
+        </Failure>
+      </CheckReputationAction>
+    </ScriptedEvent>
+    
+    <!-- LEGACY: This is here (for now) only in order to not break existing saves -->
+    <ScriptedEvent identifier="healreaperstax" commonness="100">    
+      <WaitAction time="5" />
+      <TagAction criteria="crew" tag="crew" />
+      <!-- one of the players needs to have the reaper's tax affliction for the event to do anything -->
+      <CheckAfflictionAction identifier="reaperstax" targettag="crew">
+        <Success>
+          <ConversationAction text="EventText.healreaperstax.c1" speakertag="outpostdoctor" invokertag="patient" endeventifinterrupted="false" dialogtype="Regular" eventsprite="redbluebottles"/>
+          <CheckAfflictionAction identifier="reaperstax" targettag="patient">
+            <Success>
+              <ConversationAction text="EventText.healreaperstax.c2" speakertag="outpostdoctor" waitforinteraction="false" targettag="patient" endeventifinterrupted="false" dialogtype="Regular" eventsprite="redbluebottles">
+                <Option text="EventText.healreaperstax.o1" endconversation="true">
+                  <CheckMoneyAction amount="1000" endconversation="true">
+                    <Success endconversation="true">
+                      <MoneyAction amount="-1000" />
+                      <AfflictionAction affliction="reaperstax" strength="-100" targettag="patient" />
+                      <TriggerEventAction identifier="healreaperstax" />
+                    </Success>
+                    <Failure endconversation="true">
+                      <ConversationAction speakertag="outpostdoctor" waitforinteraction="false" targettag="patient" text="EventText.healreaperstax.o1.nomoney" eventsprite="redbluebottles" />
+                      <TriggerEventAction identifier="healreaperstax" />
+                    </Failure>
+                  </CheckMoneyAction>
+                </Option>
+                <Option text="EventText.healreaperstax.o2" endconversation="true">
+                  <TriggerEventAction identifier="healreaperstax" />
+                </Option>
+              </ConversationAction>
+            </Success>
+            <Failure endconversation="true">
+              <TriggerEventAction identifier="healreaperstax" />
+            </Failure>
+          </CheckAfflictionAction>
+        </Success>
+        <Failure />
+      </CheckAfflictionAction>
+    </ScriptedEvent>
+
+    <!--RANDOM NPC MISSIONS-->
+    <ScriptedEvent identifier="missionevent_killmonster" commonness="100">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="missionnpc" spawnlocation="Outpost" spawnpointtype="Path" />
+      <ConversationAction text="EventText.missionevent_killmonster.c1" speakertag="missionnpc" endeventifinterrupted="false" dialogtype="Small"/>
+      <MissionAction missiontag="killmonster_set1" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_cargo" commonness="100">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="missionnpc" spawnlocation="Outpost" spawnpointtype="Path" />
+      <ConversationAction text="EventText.missionevent_cargo.c1" speakertag="missionnpc" endeventifinterrupted="false" dialogtype="Small"/>
+      <MissionAction missiontag="cargo" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_salvage" commonness="100">
+      <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" targettag="missionnpc" spawnlocation="Outpost" spawnpointtype="Path" />
+      <ConversationAction text="EventText.missionevent_salvage.c1" speakertag="missionnpc" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="salvage" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_clownoutbreak" commonness="40">
+      <TagAction criteria="player" tag="player" />
+      <TagAction criteria="itemidentifier:opdeco_hrflyers" tag="potentialflyers" submarinetype="outpost" />
+      <TriggerAction target1tag="potentialflyers" target2tag="player" applytotarget2="triggerer_player" radius="150" waitforinteraction="true"/>
+      <ConversationAction targettag="triggerer_player" text="EventText.missionevent_clownoutbreak.c1">
+        <Option text="EventText.missionevent_clownoutbreak.o1">
+          <ConversationAction targettag="triggerer_player" text="EventText.missionevent_clownoutbreak.o1.c1" />
+          <MissionAction missiontag="cargoclown" />
+        </Option>
+        <Option text="EventText.missionevent_clownoutbreak.o2">
+          <ConversationAction targettag="triggerer_player" text="EventText.missionevent_clownoutbreak.o2.c1" />
+          <MissionAction missiontag="cargoclown" />
+        </Option>
+        <Option text="EventText.missionevent_clownoutbreak.o3" />
+      </ConversationAction>
+    </ScriptedEvent>
+    <!--MANAGER MISSIONS-->
+    <ScriptedEvent identifier="missionevent_cargo1" commonness="125">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_cargo1.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="cargomaterials" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_cargo2" commonness="50">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_cargo2.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="cargoexplosive" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_cargo3" commonness="100">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_cargo3.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="cargoresearch" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_cargoany" commonness="100">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_cargo1.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="cargo" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_cargo_difficult" commonness="75">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_cargo_difficult.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="cargodifficult" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_cargoweaponscoalition" commonness="100">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_cargoweaponscoalition.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="cargoweaponscoalition" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_cargoexplosiveseparatists" commonness="100">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_cargocompoundn.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="cargoexplosiveseparatists" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_cargoexplosiveseparatistsvolatile" commonness="100">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_cargocompoundn.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="cargoexplosiveseparatistsvolatile" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_killswarm_set1" commonness="100">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_killswarm.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="killswarm_set1" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_killswarm_set2" commonness="100">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_killswarm.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="killswarm_set2" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_killswarm_set3" commonness="100">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_killswarm.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="killswarm_set3" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_killswarm_set4" commonness="100">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_killswarm.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="killswarm_set4" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_killswarm_set5" commonness="100">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_killswarm.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="killswarm_set5" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_killmonster_set1" commonness="85">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_killmonstercommon.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="killmonster_set1" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_killmonster_set2" commonness="85">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_killmonstercommon.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="killmonster_set2" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_killmonster_set3" commonness="85">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_killmonsterrare.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="killmonster_set3" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_killmonster_set4" commonness="85">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_killmonsterrare.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="killmonster_set4" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_salvageartifact" commonness="75">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_salvageartifact.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="salvageartifact" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_salvageartifactabyss" commonness="25">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="Eventtext.missionevent_salvageartifactabyss.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="salvageartifactabyss" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_salvagewreck" commonness="75">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_salvagewreck.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="salvagewreck" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_salvagewreckcargo" commonness="75">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_salvagewreckcargo.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="salvagewreckcargo" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_salvagewreckartifact" commonness="50">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_salvagewreckartifact.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="salvagewreckartifact" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_crawlernest" commonness="80">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_crawlernest.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="crawlernest" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_mudraptornest" commonness="70">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_mudraptornest.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="mudraptornest" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_tigerthreshernest" commonness="60">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_tigerthreshernest.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="tigerthreshernest" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent> 
+    <ScriptedEvent identifier="missionevent_crawlernest_hard" commonness="80">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_crawlernest.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="crawlernesthard" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_mudraptornest_hard" commonness="70">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_mudraptornest.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="mudraptornesthard" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_tigerthreshernest_hard" commonness="60">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_tigerthreshernest.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="tigerthreshernesthard" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_beacon" commonness="200" requirebeaconstation="True">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text= "EventText.missionevent_beacon.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missionidentifier="beacon" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_collectminerals_mainpath" commonness="70">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_collectminerals.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="collectminerals_mainpath" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_collectminerals_set1" commonness="70">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_collectminerals.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="collectminerals_set1" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_collectminerals_set2" commonness="70">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_collectminerals.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="collectminerals_set2" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_collectminerals_set3" commonness="70">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_collectminerals.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="collectminerals_set3" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_collectminerals_set4" commonness="70">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_collectminerals.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="collectminerals_set4" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_escort1coalition" commonness="100">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_escort1.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="escortcommonerscoalition" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_escort2coalition" commonness="80">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_escort2.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="escortVIPcoalition" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_escort3coalition" commonness="60">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_escort3.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="escortprisonerscoalition" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_escort4coalition" commonness="60">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_escort4.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="escortterroristscoalition" />
+    </ScriptedEvent>
+
+    <ScriptedEvent identifier="missionevent_escort1separatists" commonness="100">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_escort1separatists.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="escortcommonersseparatists" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_escort2separatists" commonness="80">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_escort2separatists.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="escortVIPseparatists" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_escort3separatists" commonness="60">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_escort3separatists.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="escortprisonersseparatists" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_escort4separatists" commonness="60">
+      <CheckReputationAction targettype="faction" identifier="separatists" condition="gte 30">
+        <Success>
+          <NPCWaitAction npctag="outpostmanager" wait="true" />
+          <ConversationAction text="EventText.missionevent_escort4separatists.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+          <MissionAction missiontag="escortterroristsseparatists" />
+        </Success>
+        <Failure>
+          <!-- do nothing -->
+        </Failure>
+      </CheckReputationAction>
+    </ScriptedEvent>
+    
+    <ScriptedEvent identifier="missionevent_pirate1" commonness="80">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_pirate1.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="combatcoalitionvsseparatists" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_pirate1separatists" commonness="80">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text="EventText.missionevent_pirate1separatists.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="combatseparatistsvscoalition" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_scanruin" commonness="200">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text= "eventtext.missionevent_scanruin.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="alienruinscan" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_clearruin" commonness="200">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text= "eventtext.missionevent_clearruin.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="alienruinclear" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+    <ScriptedEvent identifier="missionevent_clearruin2" commonness="200">
+      <NPCWaitAction npctag="outpostmanager" wait="true" />
+      <ConversationAction text= "eventtext.missionevent_clearruin.c1" speakertag="outpostmanager" endeventifinterrupted="false" dialogtype="Small" />
+      <MissionAction missiontag="alienruinclearhard" />
+      <NPCWaitAction npctag="outpostmanager" wait="false" />
+    </ScriptedEvent>
+  </EventPrefabs>
+
+  <!--EVENT SETS-->
+  <EventSet identifier="outpostevents" leveltype="outpost" locationtype="outpost,city,research,military,mine" allowatstart="true" minleveldifficulty="0" maxleveldifficulty="80" chooserandom="false" ignorecooldown="true">
+    
+    <!-- TODO: more sets here-->
+    
+    <!-- low-difficulty random events -->
+    <EventSet identifier="outpostevents.easy.generic.randomevents" minleveldifficulty="0" maxleveldifficulty="30" allowatstart="true" chooserandom="true" onceperoutpost="true">
+      <OverrideEventCount locationtype="City" eventcount="3" />
+      <ScriptedEvent identifier="givingdirections" commonness="100" />
+      <ScriptedEvent identifier="goodsamaritan" commonness="100" />      
+      <ScriptedEvent identifier="miketheidiot1" commonness="25" />      
+      <ScriptedEvent identifier="Engineers_are_special" commonness="100" />
+      <ScriptedEvent identifier="fanclub" commonness="100" />
+      <ScriptedEvent identifier="shockjock" commonness="60" />
+      <ScriptedEvent identifier="manandhisraptor1" commonness="50" />
+      <ScriptedEvent identifier="assassinationofjacovsubra2" commonness="100" />
+      <ScriptedEvent identifier="assassinationofjacovsubra3" commonness="100" />
+      <ScriptedEvent identifier="propaganda" commonness="100" faction="coalition" /> <!-- technically a separatist event, but takes place in coalition outposts -->
+      <ScriptedEvent identifier="bombscare" commonness="50" faction="coalition" />      
+      <ScriptedEvent identifier="terrorism101" commonness="50" faction="coalition" /> <!-- technically a separatist event, but takes place in coalition outposts -->
+      <ScriptedEvent identifier="separatistrelations" commonness="100" faction="coalition" /> <!-- technically a separatist event, but takes place in coalition outposts -->
+      <!-- events that only occur in low difficulty-->
+      <ScriptedEvent identifier="atwitsend" commonness="60" />
+    </EventSet>
+    <!-- low-difficulty clown events -->
+    <EventSet identifier="outpostevents.easy.generic.randomevents.clowns" minleveldifficulty="0" maxleveldifficulty="30" allowatstart="true" chooserandom="true" onceperoutpost="true">
+      <ScriptedEvent identifier="clownrelations1" commonness="100" faction="clowns" probability="0.5" />
+      <ScriptedEvent identifier="infiltration" commonness="70" faction="clowns" probability="0.5" />
+      <ScriptedEvent identifier="censorship" commonness="60" faction="clowns" probability="0.5" />
+    </EventSet>
+    <!-- low-difficulty husk cult events -->
+    <EventSet identifier="outpostevents.easy.generic.randomevents.huskcult" minleveldifficulty="0" maxleveldifficulty="30" allowatstart="true" chooserandom="true" onceperoutpost="true">
+      <ScriptedEvent identifier="huskcultist" commonness="100" faction="huskcult" probability="0.5" />
+    </EventSet>
+
+    <!-- high-difficulty random events -->
+    <EventSet identifier="outpostevent.difficult.generic.randomevents" minleveldifficulty="30" maxleveldifficulty="80" allowatstart="true" chooserandom="true" onceperoutpost="true">
+      <OverrideEventCount locationtype="City" eventcount="3" />
+      <!-- events that can occur in both low and high difficulty, commoness reduced here to favor the more difficult ones-->
+      <ScriptedEvent identifier="givingdirections" commonness="50" />
+      <ScriptedEvent identifier="goodsamaritan" commonness="50" />     
+      <ScriptedEvent identifier="miketheidiot1" commonness="12" />     
+      <ScriptedEvent identifier="Engineers_are_special" commonness="50" />
+      <ScriptedEvent identifier="fanclub" commonness="50" />
+      <ScriptedEvent identifier="shockjock" commonness="40" />
+      <ScriptedEvent identifier="manandhisraptor1" commonness="60" />
+      <ScriptedEvent identifier="assassinationofjacovsubra2" commonness="100" />
+      <ScriptedEvent identifier="assassinationofjacovsubra3" commonness="100" />
+      <ScriptedEvent identifier="nothingtoseehere" commonness="50" faction="coalition" />
+      <ScriptedEvent identifier="propaganda" commonness="50" faction="coalition" /> <!-- technically a separatist event, but takes place in coalition outposts -->
+      <ScriptedEvent identifier="bombscare" commonness="40" faction="coalition" />     
+      <ScriptedEvent identifier="terrorism101" commonness="40" faction="coalition" /> <!-- technically a separatist event, but takes place in coalition outposts -->
+      <ScriptedEvent identifier="separatistrelations" commonness="50" faction="coalition" /> <!-- technically a separatist event, but takes place in coalition outposts -->      
+      <!-- events that only occur in high difficulty-->
+      <ScriptedEvent identifier="blackmarket" commonness="100" />
+      <ScriptedEvent identifier="mediator" commonness="100" />
+      <ScriptedEvent identifier="firefighting" commonness="100" />
+      <ScriptedEvent identifier="sleightofhand" commonness="100" />
+      <ScriptedEvent identifier="miketheidiot2" commonness="25" />
+      <ScriptedEvent identifier="goblincooking1" commonness="50" />
+      <ScriptedEvent identifier="soundinthevent" commonness="100" />
+      <ScriptedEvent identifier="badvibrations3" commonness="50" />
+      <ScriptedEvent identifier="stuckinthemiddle" commonness="50" faction="coalition" /> <!-- technically a separatist event, but happens in a coalition outpost -->
+      <ScriptedEvent identifier="returner" commonness="50" />
+    </EventSet>
+    <!-- high-difficulty clown events -->
+    <EventSet identifier="outpostevent.difficult.generic.randomevents.clowns" minleveldifficulty="30" maxleveldifficulty="80" allowatstart="true" chooserandom="true" onceperoutpost="true">
+      <ScriptedEvent identifier="clownrelations1" commonness="50" faction="clowns" probability="0.5" />
+      <ScriptedEvent identifier="clownbrutality" commonness="100" faction="clowns" probability="0.5" />
+      <ScriptedEvent identifier="clownrelations2" commonness="100" faction="clowns" probability="0.5" />
+    </EventSet>
+    <!-- high-difficulty husk cult events -->
+    <EventSet identifier="outpostevent.difficult.generic.randomevents.huskcult" minleveldifficulty="30" maxleveldifficulty="80" allowatstart="true" chooserandom="true" onceperoutpost="true">
+      <ScriptedEvent identifier="outbreak" commonness="100" faction="huskcult" probability="0.5" />
+      <ScriptedEvent identifier="huskcultist" commonness="50" faction="huskcult" probability="0.5" />
+      <ScriptedEvent identifier="huskcultambush" commonness="50" faction="huskcult" probability="0.5" />
+      <ScriptedEvent identifier="huskcultrelations" commonness="100" faction="huskcult" probability="0.5" />
+    </EventSet>
+    
+    <!-- Events specific to military outposts -->    
+    <EventSet identifier="outpostevent.military.randomevents" minleveldifficulty="0" maxleveldifficulty="80" locationtype="military" allowatstart="true" chooserandom="true" onceperoutpost="true">
+      <!-- 50% chance of getting a military-specific event (TODO: increase if/when we have more of these available?) -->
+      <ScriptedEvent identifier="bigbrother" commonness="150" probability="0.5" faction="coalition"/>
+      <ScriptedEvent identifier="tastetest" commonness="150" probability="0.5" />
+    </EventSet>
+    
+    <!-- Events specific to research outposts -->
+    <EventSet identifier="outpostevent.research.randomevents" minleveldifficulty="0" maxleveldifficulty="80" locationtype="research" allowatstart="true" chooserandom="true" onceperoutpost="true">
+      <!-- 50% chance of getting a research-specific event (TODO: increase if/when we have more of these available?) -->
+      <ScriptedEvent identifier="crawleroutbreak" commonness="150" probability="0.5" />
+      <ScriptedEvent identifier="impromptuengineering" commonness="150" probability="0.5" />
+      <ScriptedEvent identifier="captivesouls" commonness="50" probability="0.5" />
+      <ScriptedEvent identifier="researcherescort" commonness="50" />
+      <ScriptedEvent identifier="explosivemishap" commonness="50" probability="0.5" />
+    </EventSet>
+    
+    <!-- Events specific to mining outposts -->
+    <EventSet identifier="outpostevent.mine.randomevents" minleveldifficulty="0" maxleveldifficulty="80" locationtype="mine" allowatstart="true" chooserandom="true" onceperoutpost="true">
+      <!-- 50% chance of getting a mine-specific event (TODO: increase if/when we have more of these available?) -->
+      <ScriptedEvent identifier="consultant" commonness="150" probability="0.5" />
+      <ScriptedEvent identifier="occupationalhazards" commonness="150" probability="0.5" />
+    </EventSet>
+
+    <!-- Events specific to cities -->
+    <EventSet identifier="outpostevent.city.randomevents" minleveldifficulty="0" maxleveldifficulty="80" locationtype="city" allowatstart="true" chooserandom="true" onceperoutpost="true">
+      <!-- 50% chance of getting a city-specific event (TODO: increase if/when we have more of these available?) -->
+      <ScriptedEvent identifier="captivesouls" commonness="50" probability="0.5" />
+      <ScriptedEvent identifier="explosivemishap" commonness="50" probability="0.5" />
+      <ScriptedEvent identifier="hognose" commonness="50" probability="0.5" />
+      <ScriptedEvent identifier="radiationescapee" commonness="50" />
+    </EventSet>
+
+    <!--Always trigger when past difficulty 25, unless completed. Introduces alien ruins.-->
+    <EventSet identifier="ruinintroduction" allowatstart="true" minleveldifficulty="25">
+      <ScriptedEvent identifier="badvibrations1" />
+    </EventSet>
+
+    <!-- Biome specific sets. Difficulty progression. -->
+    
+    <EventSet identifier="missionevents.coldcaverns.start" minleveldifficulty="0" maxleveldifficulty="1" allowatstart="true" eventcount="3" chooserandom="false" exhaustible="true">
+      <ScriptedEvent identifier="missionevent_cargoany" />
+      <ScriptedEvent identifier="missionevent_killmonster_set1" />
+      <ScriptedEvent identifier="missionevent_collectminerals_mainpath" />
+    </EventSet>
+
+    <EventSet identifier="missionevents.coldcaverns.basic" minleveldifficulty="1" maxleveldifficulty="5" allowatstart="true" setcount="3" chooserandom="false" exhaustible="true">
+      <EventSet identifier="missionevents.coldcaverns.basic.cargo" chooserandom="true" allowatstart="true">
+        <ScriptedEvent identifier="missionevent_cargoany" commonness="50" />
+        <ScriptedEvent identifier="missionevent_cargoweaponscoalition" commonness="25" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_cargoexplosiveseparatists" commonness="25" faction="separatists" />
+      </EventSet>
+      <EventSet identifier="missionevents.coldcaverns.basic.monster" chooserandom="true" allowatstart="true">
+        <ScriptedEvent identifier="missionevent_killswarm_set1" commonness="25" />
+        <ScriptedEvent identifier="missionevent_killmonster_set1" commonness="75" />
+      </EventSet>
+      <EventSet identifier="missionevents.coldcaverns.basic.mining" chooserandom="true" allowatstart="true">
+        <ScriptedEvent identifier="missionevent_collectminerals_mainpath" commonness="50" />
+        <ScriptedEvent identifier="missionevent_collectminerals_set1" commonness="50" />
+      </EventSet>
+    </EventSet>
+
+    <EventSet identifier="missionevents.coldcaverns.advanced" minleveldifficulty="5" maxleveldifficulty="15" allowatstart="true" chooserandom="false" exhaustible="true">
+      <EventSet identifier="missionevents.coldcaverns.advanced.general" chooserandom="true" setcount="2" allowatstart="true">
+        <EventSet identifier="missionevents.coldcaverns.advanced.general.cargo" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_cargoany" commonness="50" />
+          <ScriptedEvent identifier="missionevent_cargoweaponscoalition" commonness="50" faction="coalition" />
+          <ScriptedEvent identifier="missionevent_cargoexplosiveseparatists" commonness="50" faction="separatists" />
+        </EventSet>
+        <EventSet identifier="missionevents.coldcaverns.advanced.general.monster" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_killswarm_set1" commonness="20" />
+          <ScriptedEvent identifier="missionevent_killmonster_set1" commonness="40" />
+          <ScriptedEvent identifier="missionevent_killmonster_set2" commonness="40" />
+        </EventSet>
+        <EventSet identifier="missionevents.coldcaverns.advanced.general.mining" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_collectminerals_set1" commonness="75" />
+          <ScriptedEvent identifier="missionevent_collectminerals_set2" commonness="25" />
+        </EventSet>
+      </EventSet>
+      <EventSet identifier="missionevents.coldcaverns.advanced.faction" chooserandom="true" eventcount="1" allowatstart="true">
+        <ScriptedEvent identifier="missionevent_escort1coalition" commonness="100" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_escort1separatists" commonness="100" faction="separatists" />
+      </EventSet>
+    </EventSet>
+
+    <EventSet identifier="missionevents.europanridge.basic" minleveldifficulty="15" maxleveldifficulty="25" allowatstart="true" chooserandom="false" exhaustible="true">
+      <EventSet identifier="missionevents.europanridge.basic.general" chooserandom="true" setcount="3" allowatstart="true">
+        <EventSet identifier="missionevents.europanridge.basic.general.cargo" chooserandom="true" commonness="200" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_cargoany" commonness="30" />
+          <ScriptedEvent identifier="missionevent_cargoweaponscoalition" commonness="35" faction="coalition" />
+          <ScriptedEvent identifier="missionevent_cargoexplosiveseparatists" commonness="35" faction="separatists" />
+        </EventSet>
+        <EventSet identifier="missionevents.europanridge.basic.general.swarm" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_killswarm_set1" commonness="25" />
+          <ScriptedEvent identifier="missionevent_killswarm_set2" commonness="25" />
+        </EventSet>
+        <EventSet identifier="missionevents.europanridge.basic.general.monster" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_killmonster_set2" commonness="75" />
+          <ScriptedEvent identifier="missionevent_killmonster_set3" commonness="25" />
+        </EventSet>
+        <EventSet identifier="missionevents.europanridge.basic.general.salvage" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_salvagewreck" commonness="100" />
+          <ScriptedEvent identifier="missionevent_salvagewreckcargo" commonness="100" />
+        </EventSet>
+        <EventSet identifier="missionevents.europanridge.basic.general.nest" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_crawlernest" commonness="75" />
+          <ScriptedEvent identifier="missionevent_mudraptornest" commonness="25" />
+        </EventSet>
+        <EventSet identifier="missionevents.europanridge.basic.general.mining" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_collectminerals_set1" commonness="25" />
+          <ScriptedEvent identifier="missionevent_collectminerals_set2" commonness="75" />
+        </EventSet>
+      </EventSet>
+      <EventSet identifier="missionevents.europanridge.basic.faction" chooserandom="true" eventcount="1" allowatstart="true">
+        <ScriptedEvent identifier="missionevent_escort1coalition,missionevent_escort2coalition,missionevent_escort3coalition" commonness="100" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_escort1separatists,missionevent_escort2separatists,missionevent_escort3separatists" commonness="100" faction="separatists" />
+      </EventSet>
+    </EventSet>
+
+    <EventSet identifier="missionevents.europanridge.advanced" minleveldifficulty="25" maxleveldifficulty="35" allowatstart="true" chooserandom="false" exhaustible="true">
+      <EventSet identifier="missionevents.europanridge.advanced.general" chooserandom="true" setcount="3" allowatstart="true">
+        <EventSet identifier="missionevents.europanridge.advanced.general.cargo" chooserandom="true" commonness="200" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_cargoany" commonness="20" />
+          <ScriptedEvent identifier="missionevent_cargoweaponscoalition" commonness="40" faction="coalition" />
+          <ScriptedEvent identifier="missionevent_cargoexplosiveseparatists" commonness="40" faction="separatists" />
+        </EventSet>
+        <EventSet identifier="missionevents.europanridge.advanced.general.swarm" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_killswarm_set1" commonness="25" />
+          <ScriptedEvent identifier="missionevent_killswarm_set2" commonness="50" />
+          <ScriptedEvent identifier="missionevent_killswarm_set3" commonness="25" />
+        </EventSet>
+        <EventSet identifier="missionevents.europanridge.advanced.general.monster" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_killmonster_set2" commonness="25" />
+          <ScriptedEvent identifier="missionevent_killmonster_set3" commonness="75" />
+        </EventSet>
+        <EventSet identifier="missionevents.europanridge.advanced.general.salvage" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_salvagewreck" />
+          <ScriptedEvent identifier="missionevent_salvagewreckcargo" />
+          <ScriptedEvent identifier="missionevent_salvagewreckartifact" />
+        </EventSet>
+        <EventSet identifier="missionevents.europanridge.advanced.general.nest" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_crawlernest" commonness="50" />
+          <ScriptedEvent identifier="missionevent_mudraptornest" commonness="25" />
+          <ScriptedEvent identifier="missionevent_tigerthreshernest" commonness="25" />
+        </EventSet>
+        <EventSet identifier="missionevents.europanridge.advanced.general.mining" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_collectminerals_set1" commonness="25" />
+          <ScriptedEvent identifier="missionevent_collectminerals_set2" commonness="50" />
+          <ScriptedEvent identifier="missionevent_collectminerals_set3" commonness="25" />
+        </EventSet>
+      </EventSet>
+      <EventSet identifier="missionevents.europanridge.advanced.faction" chooserandom="true" eventcount="1" allowatstart="true">
+        <ScriptedEvent identifier="missionevent_escort2coalition,missionevent_escort3coalition,missionevent_escort4coalition" commonness="100" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_escort2separatists,missionevent_escort3separatists,missionevent_escort4separatists" commonness="100" faction="separatists" />
+        <ScriptedEvent identifier="missionevent_jailbreak_separatists" commonness="25" faction="separatists" />
+        <ScriptedEvent identifier="missionevent_jailbreak_coalition" commonness="25" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_pirate1" commonness="50" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_pirate1separatists" commonness="50" faction="separatists" />
+      </EventSet>
+    </EventSet>
+
+    <EventSet identifier="missionevents.theaphoticplateau" minleveldifficulty="35" maxleveldifficulty="50" allowatstart="true" chooserandom="false" exhaustible="true">
+      <EventSet identifier="missionevents.theaphoticplateau.general" chooserandom="true" setcount="3" allowatstart="true">
+        <EventSet identifier="missionevents.theaphoticplateau.general.cargo" chooserandom="true" commonness="200" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_cargoany" commonness="10" />
+          <ScriptedEvent identifier="missionevent_cargo_difficult" commonness="20" />
+          <ScriptedEvent identifier="missionevent_cargoweaponscoalition" commonness="35" faction="coalition" />
+          <ScriptedEvent identifier="missionevent_cargoexplosiveseparatists" commonness="13" faction="separatists" />
+          <ScriptedEvent identifier="missionevent_cargoexplosiveseparatistsvolatile" commonness="22" faction="separatists" />
+        </EventSet>
+        <EventSet identifier="missionevents.theaphoticplateau.general.swarm" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_killswarm_set2" commonness="50" />
+          <ScriptedEvent identifier="missionevent_killswarm_set3" commonness="50" />
+        </EventSet>
+        <EventSet identifier="missionevents.theaphoticplateau.general.monster" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_killmonster_set3" commonness="50" />
+          <ScriptedEvent identifier="missionevent_killmonster_set4" commonness="50" />
+        </EventSet>
+        <EventSet identifier="missionevents.theaphoticplateau.general.salvage" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_salvageartifact" commonness="50" />
+          <ScriptedEvent identifier="missionevent_salvagewreck" commonness="15" />
+          <ScriptedEvent identifier="missionevent_salvagewreckcargo" commonness="15" />
+          <ScriptedEvent identifier="missionevent_salvagewreckartifact" commonness="15" />
+        </EventSet>
+        <EventSet identifier="missionevents.theaphoticplateau.general.nest" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_crawlernest_hard" commonness="33" />
+          <ScriptedEvent identifier="missionevent_mudraptornest" commmonness="33"/>
+          <ScriptedEvent identifier="missionevent_tigerthreshernest" commonness="33" />
+        </EventSet>
+        <EventSet identifier="missionevents.theaphoticplateau.general.mining" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_collectminerals_set3" commonness="50" />
+          <ScriptedEvent identifier="missionevent_collectminerals_set4" commonness="50" />
+        </EventSet>
+        <EventSet identifier="missionevents.theaphoticplateau.general.ruin" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_scanruin" />
+        </EventSet>
+      </EventSet>
+      <EventSet identifier="missionevents.theaphoticplateau.faction" chooserandom="true" eventcount="1" allowatstart="true">
+        <ScriptedEvent identifier="missionevent_escort2coalition,missionevent_escort3coalition,missionevent_escort4coalition" commonness="100" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_escort2separatists,missionevent_escort3separatists,missionevent_escort4separatists" commonness="100" faction="separatists" />
+        <ScriptedEvent identifier="missionevent_jailbreak_separatists" commonness="25" faction="separatists" />
+        <ScriptedEvent identifier="missionevent_jailbreak_coalition" commonness="25" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_pirate1" commonness="100" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_pirate1separatists" commonness="100" faction="separatists" />
+      </EventSet>
+    </EventSet>
+
+    <EventSet identifier="missionevents.greatsea" minleveldifficulty="50" maxleveldifficulty="65" allowatstart="true" chooserandom="false" exhaustible="true">
+      <EventSet identifier="missionevents.greatsea.general" chooserandom="true" setcount="3" allowatstart="true">
+        <EventSet identifier="missionevents.greatsea.general.cargo" chooserandom="true" commonness="200" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_cargoany" commonness="5" />
+          <ScriptedEvent identifier="missionevent_cargo_difficult" commonness="25" />
+          <ScriptedEvent identifier="missionevent_cargoweaponscoalition" commonness="35" faction="coalition" />
+          <ScriptedEvent identifier="missionevent_cargoexplosiveseparatists" commonness="13" faction="separatists" />
+          <ScriptedEvent identifier="missionevent_cargoexplosiveseparatistsvolatile" commonness="22" faction="separatists" />
+        </EventSet>
+        <EventSet identifier="missionevents.greatsea.general.swarm" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_killswarm_set3" commonness="50" />
+          <ScriptedEvent identifier="missionevent_killswarm_set4" commonness="50" />
+        </EventSet>
+        <EventSet identifier="missionevents.greatsea.general.monster" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_killmonster_set3" commonness="75" />
+          <ScriptedEvent identifier="missionevent_killmonster_set4" commonness="25" />
+        </EventSet>
+        <EventSet identifier="missionevents.greatsea.general.salvage" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_salvageartifact" commonness="40" />
+          <ScriptedEvent identifier="missionevent_salvageartifactabyss" commonness="20" />
+          <ScriptedEvent identifier="missionevent_salvagewreck" commonness="15" />
+          <ScriptedEvent identifier="missionevent_salvagewreckcargo" commonness="15" />
+          <ScriptedEvent identifier="missionevent_salvagewreckartifact" commonness="15" />
+        </EventSet>
+        <EventSet identifier="missionevents.greatsea.general.nest" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_crawlernest_hard" commonness="33" />
+          <ScriptedEvent identifier="missionevent_mudraptornest_hard" commmonness="33"/>
+          <ScriptedEvent identifier="missionevent_tigerthreshernest_hard" commonness="33" />
+        </EventSet>
+        <EventSet identifier="missionevents.greatsea.general.mining" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_collectminerals_set2" commonness="25" />
+          <ScriptedEvent identifier="missionevent_collectminerals_set3" commonness="50" />
+          <ScriptedEvent identifier="missionevent_collectminerals_set4" commonness="25" />
+        </EventSet>
+        <EventSet identifier="missionevents.greatsea.general.ruin" chooserandom="true" commonness="200" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_scanruin" commonness="100" />
+          <ScriptedEvent identifier="missionevent_clearruin" commonness="100" />
+        </EventSet>
+      </EventSet>
+      <EventSet identifier="missionevents.greatsea.faction" chooserandom="true" eventcount="1" allowatstart="true">
+        <ScriptedEvent identifier="missionevent_escort2coalition,missionevent_escort3coalition,missionevent_escort4coalition" commonness="100" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_escort2separatists,missionevent_escort3separatists,missionevent_escort4separatists" commonness="100" faction="separatists" />
+        <ScriptedEvent identifier="missionevent_jailbreak_separatists" commonness="25" faction="separatists" />
+        <ScriptedEvent identifier="missionevent_jailbreak_coalition" commonness="25" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_pirate1" commonness="100" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_pirate1separatists" commonness="100" faction="separatists" />
+      </EventSet>
+    </EventSet>
+
+    <EventSet identifier="missionevents.wastes" minleveldifficulty="65" maxleveldifficulty="100" allowatstart="true" chooserandom="false" exhaustible="true">
+      <EventSet identifier="missionevents.wastes.general" chooserandom="true" setcount="3" allowatstart="true">
+        <EventSet identifier="missionevents.wastes.general.cargo" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_cargo_difficult" commonness="30" />
+          <ScriptedEvent identifier="missionevent_cargoweaponscoalition" commonness="35" faction="coalition" />
+          <ScriptedEvent identifier="missionevent_cargoexplosiveseparatists" commonness="13" faction="separatists" />
+          <ScriptedEvent identifier="missionevent_cargoexplosiveseparatistsvolatile" commonness="22" faction="separatists" />
+        </EventSet>
+        <EventSet identifier="missionevents.wastes.general.swarm" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_killswarm_set3" commonness="15" />
+          <ScriptedEvent identifier="missionevent_killswarm_set4" commonness="65" />
+          <ScriptedEvent identifier="missionevent_killswarm_set5" commonness="20" />
+        </EventSet>
+        <EventSet identifier="missionevents.wastes.general.monster" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_killmonster_set3" commonness="25" />
+          <ScriptedEvent identifier="missionevent_killmonster_set4" commonness="75" />
+        </EventSet>
+        <EventSet identifier="missionevents.wastes.general.salvage" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_salvageartifact" commonness="40" />
+          <ScriptedEvent identifier="missionevent_salvageartifactabyss" commonness="20" />
+          <ScriptedEvent identifier="missionevent_salvagewreck" commonness="15" />
+          <ScriptedEvent identifier="missionevent_salvagewreckcargo" commonness="15" />
+          <ScriptedEvent identifier="missionevent_salvagewreckartifact" commonness="15" />
+        </EventSet>
+        <EventSet identifier="missionevents.wastes.general.nest" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_crawlernest_hard" commonness="20" />
+          <ScriptedEvent identifier="missionevent_mudraptornest" commmonness="40"/>
+          <ScriptedEvent identifier="missionevent_tigerthreshernest" commonness="40" />
+        </EventSet>
+        <EventSet identifier="missionevents.wastes.general.mining" chooserandom="true" commonness="100" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_collectminerals_set3" commonness="25" />
+          <ScriptedEvent identifier="missionevent_collectminerals_set4" commonness="75" />
+        </EventSet>
+        <EventSet identifier="missionevents.wastes.general.ruin" chooserandom="true" commonness="200" allowatstart="true">
+          <ScriptedEvent identifier="missionevent_scanruin" commonness="50" />
+          <ScriptedEvent identifier="missionevent_clearruin2" commonness="150" />
+        </EventSet>
+      </EventSet>
+      <EventSet idenfitier="missionevents.wastes.faction" chooserandom="true" eventcount="1" allowatstart="true">
+        <ScriptedEvent identifier="missionevent_escort2coalition,missionevent_escort3coalition,missionevent_escort4coalition" commonness="100" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_escort2separatists,missionevent_escort3separatists,missionevent_escort4separatists" commonness="100" faction="separatists" />
+        <ScriptedEvent identifier="missionevent_jailbreak_separatists" commonness="25" faction="separatists" />
+        <ScriptedEvent identifier="missionevent_jailbreak_coalition" commonness="25" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_pirate1" commonness="100" faction="coalition" />
+        <ScriptedEvent identifier="missionevent_pirate1separatists" commonness="100" faction="separatists" />
+      </EventSet>
+    </EventSet>
+
+    <!-- generic clown missions -->
+    <EventSet identifier="outpostevents.clowns.missionevents" minleveldifficulty="0" maxleveldifficulty="100" allowatstart="true" chooserandom="true" exhaustible="true">
+      <ScriptedEvent identifier="missionevent_escort1clowns" commonness="50" faction="clowns" probability="0.8" />
+      <ScriptedEvent identifier="missionevent_clownoutbreak" commonness="50" faction="clowns" probability="0.8" />
+    </EventSet>
+    <!-- generic husk cult missions -->
+    <EventSet identifier="outpostevents.huskcult.missionevents" minleveldifficulty="0" maxleveldifficulty="100" allowatstart="true" chooserandom="true" exhaustible="true">
+      <ScriptedEvent identifier="missionevent_escort1huskcult" commonness="50" faction="huskcult" probability="0.8" />
+      <ScriptedEvent identifier="missionevent_cargohuskcult" commonness="50" faction="huskcult" probability="0.8" />
+    </EventSet>
+
+    <!--  Faction-specific events that can only occur once. 
+        In a separate set to make these very common (when they are valid for the situation) -->
+    <EventSet identifier="outpostevents.clowns" allowatstart="true" chooserandom="true" eventcount="3" faction="clowns">
+      <ScriptedEvent identifier="clownspecialhire1" commonness="100" />
+      <ScriptedEvent identifier="pathofthebikehorn1" commonness="100" />
+      <ScriptedEvent identifier="pathofthebikehorn2" commonness="100" />
+      <ScriptedEvent identifier="pathofthebikehorn3" commonness="100" />
+      <ScriptedEvent identifier="pathofthebikehorn4" commonness="100" />
+      <ScriptedEvent identifier="pathofthebikehorn5" commonness="100" />
+    </EventSet>
+    <EventSet identifier="outpostevents.separatists" allowatstart="true" chooserandom="true" eventcount="2" faction="separatists">
+      <ScriptedEvent identifier="separatistspecialhire1" commonness="100" />
+      <ScriptedEvent identifier="separatistspecialhire2" commonness="100" />
+      <ScriptedEvent identifier="missionevent_tormsdalereport" commonness="100" />
+      <ScriptedEvent identifier="missionevent_jailbreak_sootman" commonness="10" faction="separatists" />
+    </EventSet>
+    <EventSet identifier="outpostevents.separatists.triggeralways" allowatstart="true" eventcount="1" faction="separatists">
+      <ScriptedEvent identifier="tormsdalereport_complete" commonness="100" />
+    </EventSet>
+    <EventSet identifier="outpostevents.coalition" allowatstart="true" chooserandom="true" eventcount="1" faction="coalition">
+      <ScriptedEvent identifier="coalitionspecialhire1" commonness="50" />
+      <ScriptedEvent identifier="coalitionspecialhire2" commonness="50" />
+    </EventSet>
+    <EventSet identifier="outpostevents.huskcult" allowatstart="true" chooserandom="true" eventcount="4" faction="huskcult">
+      <ScriptedEvent identifier="huskcultspecialhire1" commonness="100" />
+      <ScriptedEvent identifier="youngcultists" commonness="100" />
+      <ScriptedEvent identifier="waytoascension1" commonness="100" />
+      <ScriptedEvent identifier="waytoascension2" commonness="100" />
+      <ScriptedEvent identifier="waytoascension3" commonness="100" />
+      <ScriptedEvent identifier="waytoascension4" commonness="100" />
+      <ScriptedEvent identifier="waytoascension5" commonness="100" />
+    </EventSet>
+  </EventSet>
+  
+  <!--TRANSIT EVENTS-->
+  <EventSet identifier="transitevents" allowatstart="true" minleveldifficulty="0" maxleveldifficulty="80" chooserandom="true" campaign="true" additive="true">
+    <ScriptedEvent identifier="stowaway1" commonness="100" probability="0.1" triggercooldown="false" />
+    <!--<ScriptedEvent identifier="stowaway2" commonness="100" probability="0.2" triggercooldown="false" />-->
+  </EventSet>
+
+  <EventSet identifier="outpostevent.endoutpostentrance" leveltype="LocationConnection" biome="endzone" chooserandom="false" allowatstart="true" campaign="true" ignoreintensity="true">
+    <Commonness commonness="0">
+      <Override leveltype="endoutpostentrance" commonness="1" />
+    </Commonness>
+    <ScriptedEvent identifier="alienwriting1" />
+    <ScriptedEvent identifier="buttonpressed1" />
+    <ScriptedEvent identifier="prophetofsierpinsk" />
+  </EventSet>
+  <EventSet identifier="outpostevent.endoutpostmid" leveltype="Outpost" biome="endzone" chooserandom="false" allowatstart="true" campaign="true" ignoreintensity="true">
+    <Commonness commonness="0">
+      <Override leveltype="endoutpostmid" commonness="1" />
+    </Commonness>
+    <ScriptedEvent identifier="alienwriting2" />
+    <ScriptedEvent identifier="alienwriting3" />
+  </EventSet>
+  <EventSet identifier="outpostevent.endoutpostfinal" leveltype="Outpost" biome="endzone" chooserandom="false" allowatstart="true" campaign="true" ignoreintensity="true">
+    <Commonness commonness="0">
+      <Override leveltype="endoutpostfinal" commonness="1" />
+    </Commonness>
+    <ScriptedEvent identifier="ancientencounter" />
+  </EventSet>
+  
+</Randomevents>


### PR DESCRIPTION
Simply adds requiredDestinationTypes="outpost,city,research,military,mine" to all missionevents that give cargo/escort missions so they do not generate if there's no viable adjacent destination. 

No more of this:
![218220031-6ebe2701-3360-4565-b76e-107c0caac5bc](https://github.com/FakeFishGames/Barotrauma/assets/73229309/de6f1fe9-6b14-4661-854b-30464def7eef)


_A side effect is that those missions will spawn less in practice as they will be picked at random by the eventset, but not trigger in the case of no adjacent outposts. If eventmanager generates its default 3 missionevents and 2 are cargo/escort, you will in practice only have 1 mission offered._

This is acceptable imo.

**NOTE: STILL NEEDS ANYOUTPOST SUPPORT FOR MODS.**
**THESE SHOULD BE USING requiredDestinationTypes="AnyOutpost" WITH THE ABILITY TO DEFINE IF A LOCATIONTYPE CAN BE USED BY ANYOUTPOST**



https://github.com/FakeFishGames/Barotrauma/discussions/13941