### PR TITLE
TagAction improvements

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Events/EventActions/TagAction.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Events/EventActions/TagAction.cs
@@ -13,7 +13,7 @@ namespace Barotrauma
     {
         public enum SubType { Any = 0, Player = 1, Outpost = 2, Wreck = 4, BeaconStation = 8 }
 
-        [Serialize("", IsPropertySaveable.Yes, description: "What criteria to use to select the entities to target. Valid values are players, player, traitor, nontraitor, nontraitorplayer, bot, crew, humanprefabidentifier:[id], jobidentifier:[id], structureidentifier:[id], structurespecialtag:[tag], itemidentifier:[id], itemtag:[tag], hull, hullname:[name], submarine:[type], eventtag:[tag].")]
+        [Serialize("", IsPropertySaveable.Yes, description: "What criteria to use to select the entities to target. Valid values are players, player, traitor, nontraitor, nontraitorplayer, bot, crew, humanprefabidentifier:[id], jobidentifier:[id], structureidentifier:[id], structurespecialtag:[tag], itemidentifier:[id], itemtag:[tag], hull, hullname:[name], submarine:[type], eventtag:[tag], speciesname:[id].")]
         public string Criteria { get; set; }
 
         [Serialize("", IsPropertySaveable.Yes, description: "The tag to apply to the target.")]

--- a/Barotrauma/BarotraumaShared/SharedSource/Events/EventActions/TagAction.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Events/EventActions/TagAction.cs
@@ -438,7 +438,7 @@ namespace Barotrauma
 
         public override string ToDebugString()
         {
-            return $"{ToolBox.GetDebugSymbol(isFinished)} {nameof(TagAction)} -> (Criteria: {Criteria.ColorizeObject()}, Tag: {Tag.ColorizeObject()}, Sub: {SubmarineType.ColorizeObject()})";
+            return $"{ToolBox.GetDebugSymbol(isFinished)} {nameof(TagAction)} -> (Criteria: {Criteria.ColorizeObject()}, Tag: {Tag.ColorizeObject()}, Sub: {SubmarineType.ColorizeObject()}, Team: {Team.ColorizeObject()})";
         }
     }
 }

--- a/Barotrauma/BarotraumaShared/SharedSource/Events/EventActions/TagAction.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Events/EventActions/TagAction.cs
@@ -11,7 +11,7 @@ namespace Barotrauma
     /// </summary>
     class TagAction : EventAction
     {
-        public enum SubType { Any = 0, Player = 1, Outpost = 2, Wreck = 4, BeaconStation = 8 }
+        public enum SubType { Any = 0, Player = 1, Outpost = 2, Wreck = 4, BeaconStation = 8, Enemy = 16, Ruin = 32 }
 
         [Serialize("", IsPropertySaveable.Yes, description: "What criteria to use to select the entities to target. Valid values are players, player, traitor, nontraitor, nontraitorplayer, bot, crew, humanprefabidentifier:[id], jobidentifier:[id], structureidentifier:[id], structurespecialtag:[tag], itemidentifier:[id], itemtag:[tag], hull, hullname:[name], submarine:[type], eventtag:[tag], speciesname:[id].")]
         public string Criteria { get; set; }
@@ -287,6 +287,10 @@ namespace Barotrauma
                     return submarineType.HasFlag(SubType.Wreck);
                 case Barotrauma.SubmarineType.BeaconStation:
                     return submarineType.HasFlag(SubType.BeaconStation);
+                case Barotrauma.SubmarineType.EnemySubmarine:
+                    return submarineType.HasFlag(SubType.Enemy);
+                case Barotrauma.SubmarineType.Ruin:
+                    return submarineType.HasFlag(SubType.Ruin);
                 default:
                     return false;
             }

--- a/Barotrauma/BarotraumaShared/SharedSource/Events/EventActions/TagAction.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Events/EventActions/TagAction.cs
@@ -77,6 +77,7 @@ namespace Barotrauma
                 ("hullname", TagHullsByName),
                 ("submarine", TagSubmarinesByType),
                 ("eventtag", TagByEventTag),
+                ("speciesname", TagBySpeciesName)
             }.Select(t => (t.k.ToIdentifier(), t.v)).ToImmutableDictionary();
         }
 
@@ -87,6 +88,11 @@ namespace Barotrauma
         public override void Reset()
         {
             isFinished = false;
+        }
+
+        private void TagBySpeciesName(Identifier speciesName)
+        {
+            AddTarget(Tag, Character.CharacterList.Where(c => c.SpeciesName == speciesName));
         }
 
         private void TagByEventTag(Identifier eventTag)


### PR DESCRIPTION
The first in a series of PR's based on requests from some XML modders.

Improves the TagAction to allow for better tagging, mainly:
- Allows tagging by species name
- Adds EnemySubmarine and Ruin to required submarine type
- Adds CharacterTeamType as a possible requirement to the following criteria `jobidentifier, humanidentifier, players, speciesname`

Example XML for testing
```xml
<ScriptedEvent identifier="tag_test">
    <SpawnAction speciesname="Crawler"/>
    <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" spawnlocation="Outpost" teamid="None" />
    <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" spawnlocation="Outpost" teamid="Team1" />
    <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" spawnlocation="Outpost" teamid="Team2" />
    <SpawnAction npcsetidentifier="outpostnpcs1" npcidentifier="commoner" spawnlocation="Outpost" teamid="FriendlyNPC" />
    <TagAction criteria="speciesname:Crawler" tag="allcrawlers" />
    <TagAction criteria="speciesname:Human" tag="allhumans" />
    <TagAction criteria="players" tag="players" />
    <TagAction criteria="humanprefabidentifier:commoner" tag="team_none_commner" team="None" />
    <TagAction criteria="jobidentifier:mechanic" tag="team1_mechanic" team="Team1" />
    <TagAction criteria="humanprefabidentifier:commoner" tag="team2_commoner" team="Team2" />
    <TagAction criteria="humanprefabidentifier:commoner" tag="friendlynpc_commoner" team="FriendlyNPC"/>
</ScriptedEvent>
```