### PR TITLE
Extra Missions

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Events/Missions/Mission.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Events/Missions/Mission.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Xml.Linq;
+using static Barotrauma.Networking.MessageFragment;
 
 namespace Barotrauma
 {
@@ -211,12 +212,12 @@ namespace Barotrauma
 
         public virtual void SetLevel(LevelData level) { }
 
-        public static Mission LoadRandom(Location[] locations, string seed, bool requireCorrectLocationType, MissionType missionType, bool isSinglePlayer = false)
+        public static List<Mission> LoadRandom(Location[] locations, string seed, bool requireCorrectLocationType, MissionType missionType, bool isSinglePlayer = false)
         {
             return LoadRandom(locations, new MTRandom(ToolBox.StringToInt(seed)), requireCorrectLocationType, missionType, isSinglePlayer);
         }
 
-        public static Mission LoadRandom(Location[] locations, MTRandom rand, bool requireCorrectLocationType, MissionType missionType, bool isSinglePlayer = false)
+        public static List<Mission> LoadRandom(Location[] locations, MTRandom rand, bool requireCorrectLocationType, MissionType missionType, bool isSinglePlayer = false)
         {
             List<MissionPrefab> allowedMissions = new List<MissionPrefab>();
             if (missionType == MissionType.None)

--- a/Barotrauma/BarotraumaShared/SharedSource/Events/Missions/Mission.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Events/Missions/Mission.cs
@@ -7,7 +7,6 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Xml.Linq;
-using static Barotrauma.Networking.MessageFragment;
 
 namespace Barotrauma
 {

--- a/Barotrauma/BarotraumaShared/SharedSource/GameSession/GameModes/CampaignMode.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/GameSession/GameModes/CampaignMode.cs
@@ -400,7 +400,7 @@ namespace Barotrauma
                         }
                         Random rand = new MTRandom(ToolBox.StringToInt(levelData.Seed));
                         var beaconMissionPrefab = ToolBox.SelectWeightedRandom(beaconMissionPrefabs, p => p.Commonness, rand);
-                        extraMissions.Add(beaconMissionPrefab.Instantiate(Map.SelectedConnection.Locations, Submarine.MainSub));
+                        extraMissions.AddRange(beaconMissionPrefab.Instantiate(Map.SelectedConnection.Locations, Submarine.MainSub));
                     }
                 }
                 if (levelData.HasHuntingGrounds)
@@ -433,7 +433,7 @@ namespace Barotrauma
                         var huntingGroundsMissionPrefab = ToolBox.SelectWeightedRandom(prefabs, weights, rand);
                         if (!Missions.Any(m => m.Prefab.Tags.Contains("huntinggrounds")))
                         {
-                            extraMissions.Add(huntingGroundsMissionPrefab.Instantiate(Map.SelectedConnection.Locations, Submarine.MainSub));
+                            extraMissions.AddRange(huntingGroundsMissionPrefab.Instantiate(Map.SelectedConnection.Locations, Submarine.MainSub));
                         }
                     }
                 }
@@ -479,11 +479,11 @@ namespace Barotrauma
                                 }
                                 if (automaticMission.LevelType == LevelData.LevelType.Outpost)
                                 {
-                                    extraMissions.Add(missionPrefab.Instantiate(new Location[] { currentLocation, currentLocation }, Submarine.MainSub));
+                                    extraMissions.AddRange(missionPrefab.Instantiate(new Location[] { currentLocation, currentLocation }, Submarine.MainSub));
                                 }
                                 else
                                 {
-                                    extraMissions.Add(missionPrefab.Instantiate(Map.SelectedConnection.Locations, Submarine.MainSub));
+                                    extraMissions.AddRange(missionPrefab.Instantiate(Map.SelectedConnection.Locations, Submarine.MainSub));
                                 }                               
                             }
                         }                        
@@ -520,11 +520,11 @@ namespace Barotrauma
                         {
                             if (levelData.Type == LevelData.LevelType.LocationConnection)
                             {
-                                extraMissions.Add(endLevelMissionPrefab.Instantiate(map.SelectedConnection.Locations, Submarine.MainSub));
+                                extraMissions.AddRange(endLevelMissionPrefab.Instantiate(map.SelectedConnection.Locations, Submarine.MainSub));
                             }
                             else
                             {
-                                extraMissions.Add(endLevelMissionPrefab.Instantiate(new Location[] { map.CurrentLocation, map.CurrentLocation }, Submarine.MainSub));
+                                extraMissions.AddRange(endLevelMissionPrefab.Instantiate(new Location[] { map.CurrentLocation, map.CurrentLocation }, Submarine.MainSub));
                             }
                         }
                     }

--- a/Barotrauma/BarotraumaShared/SharedSource/GameSession/GameModes/MissionMode.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/GameSession/GameModes/MissionMode.cs
@@ -21,7 +21,7 @@ namespace Barotrauma
             Location[] locations = { GameMain.GameSession.StartLocation, GameMain.GameSession.EndLocation };
             foreach (MissionPrefab missionPrefab in missionPrefabs)
             {
-                missions.Add(missionPrefab.Instantiate(locations, Submarine.MainSub));
+                missions.AddRange(missionPrefab.Instantiate(locations, Submarine.MainSub));
             }
         }
 
@@ -29,11 +29,7 @@ namespace Barotrauma
             : base(preset)
         {
             Location[] locations = { GameMain.GameSession.StartLocation, GameMain.GameSession.EndLocation };
-            var mission = Mission.LoadRandom(locations, seed, false, missionType);
-            if (mission != null)
-            {
-                missions.Add(mission);
-            }
+            missions.AddRange(Mission.LoadRandom(locations, seed, false, missionType));
         }
 
         protected static IEnumerable<MissionPrefab> ValidateMissionPrefabs(IEnumerable<MissionPrefab> missionPrefabs, Dictionary<MissionType, Type> missionClasses)


### PR DESCRIPTION
Adds an XML tag to also start additional missions when a mission is started.
### Format:
- `ExtraMission`
  - `identifier`: Additional mission's identifier; takes priority over `tags`.
    - default: ""
    - type: String
  - `tags`: Additional mission's tags; selects a random mission that has any of the valid tags.
    - default: ""
    - type: String[]
  - `probability`: Chance for the mission to be added.
    - default: 1
    - type: float (0 to 1)
  - `mindifficulty`: Minimum level difficulty for the mission to be added.
    - default: 0
    - type: float (0 to 100)
  - `maxdifficulty`: Maximum level difficulty for the mission to be added.
    - default: 100
    - type: float (0 to 100)

Any amount of `ExtraMission` elements can be added.