### PR TITLE
More accurate yellow crush depth warnings on map connections

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Map/Map/Map.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Map/Map/Map.cs
@@ -1114,8 +1114,16 @@ namespace Barotrauma
                 string tooltip = null;
 
                 float subCrushDepth = SubmarineInfo.GetSubCrushDepth(SubmarineSelection.CurrentOrPendingSubmarine(), ref pendingSubInfo);
+
+
+                float levelInitialDepth = connection.LevelData.InitialDepth * Physics.DisplayToRealWorldRatio;
+                float levelHeight = connection.LevelData.Size.Y * Physics.DisplayToRealWorldRatio;
+
+                float startPositionY = levelInitialDepth + levelHeight * connection.LevelData.GenerationParams.StartPosition.Y;
+                float endPositionY = levelInitialDepth + levelHeight * connection.LevelData.GenerationParams.EndPosition.Y;
+                
                 string crushDepthWarningIconStyle = null;
-                if (connection.LevelData.InitialDepth * Physics.DisplayToRealWorldRatio > subCrushDepth)
+                if (subCrushDepth < startPositionY || subCrushDepth < endPositionY)
                 {
                     iconCount++;
                     crushDepthWarningIconStyle = "CrushDepthWarningHighIcon";


### PR DESCRIPTION
Previous logic: 
```
if subCrushDepth < Level.Top then it's Red
if subCrushDepth < Level.Bottom then it's Yellow
if subCrushDepth > Level.Bottom then it's fine
```
Even if crush depth is 1m below Level.Top warning will be Yellow
But, outposts aren't on Level.Top, they are somewhere in the level
If start is below crush depth you will just implode
If end is below crush depth then you won't be able to dock and will have to swim back 

So i suggest marking connections with Red warning if start or end outposts are below crush depth

#### Notes
This estimate is accurate up to 20m. I suspect that something somewhere is rounded to Level.GridCellSize

Warning text is also a bit confusing
It says "route starts at", so i would expect starting outpost to be at that depth, but in fact it's LevelData.InitialDepth
I can make it show outpost depth, but it will be a bit inconsistent
What if you are far away from that route? Which outpost depth should i show? Random? Leftmost? It might get flipped once you get there

![20240524090842_1](https://github.com/FakeFishGames/Barotrauma/assets/122838333/b51a7908-deb3-4d16-ae04-e95de91c0bba)





