### PR TITLE
Fix NPCOperateItemAction Operate="false" not doing anything

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Events/EventActions/NPCOperateItemAction.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Events/EventActions/NPCOperateItemAction.cs
@@ -115,7 +115,7 @@ namespace Barotrauma
                     if (npc.Removed || npc.AIController is not HumanAIController humanAiController) { continue; }
                     foreach (var operateItemObjective in humanAiController.ObjectiveManager.GetActiveObjectives<AIObjectiveOperateItem>())
                     {
-                        if (operateItemObjective.OperateTarget == target)
+                        if (operateItemObjective.Component.Item == target)
                         {
                             operateItemObjective.Abandon = true;
                         }

--- a/Barotrauma/BarotraumaShared/SharedSource/Events/EventActions/NPCOperateItemAction.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Events/EventActions/NPCOperateItemAction.cs
@@ -86,7 +86,7 @@ namespace Barotrauma
                 {
                     foreach (var objective in humanAiController.ObjectiveManager.Objectives)
                     {
-                        if (objective is AIObjectiveOperateItem operateItemObjective && operateItemObjective.OperateTarget == target)
+                        if (objective is AIObjectiveOperateItem operateItemObjective && operateItemObjective.Component.Item == target)
                         {
                             objective.Abandon = true;
                         }


### PR DESCRIPTION
Related to #14216 

Fixes the issue mentioned in the above discussion by implementing the suggested fix, that being changing `operateItemObjective.OperateTarget == target` to `operateItemObjective.Component.Item == target`

This could also be fixed by actually assigning the `OperateTarget` in the objective constructor, however I didn't want to change how the action operated and potentially cause unexpected compatibility issues.

Here's a mod to test that it's working correctly, this is the same mod in the above issue.
[NPCOperateAction.zip](https://github.com/user-attachments/files/15995089/NPCOperateAction.zip)

To test:
1. Load up the "NPCOperateItemAction" sub in the sub editor
2. Type `triggerevent npcoperateaction_example` into the console

Expected behavior with this pull request is the NPC cancels the operate objective correctly and starts following the player.