### PR TITLE
README.md: Update Copyright date range to 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Barotrauma
 
-Copyright © FakeFish Ltd 2017-2022
+Copyright © FakeFish Ltd 2017-2024
 
 Before downloading the source code, please read the [EULA](EULA.txt).
 


### PR DESCRIPTION
Just noticed that README.md still had 2022 as the end of its copyright range.