### PR TITLE
Changes to make adding scopes possible

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Characters/Character.cs
@@ -425,6 +425,10 @@ namespace Barotrauma
                 {
                     cam.OffsetAmount = targetOffsetAmount = item.Prefab.OffsetOnSelected * item.OffsetOnSelectedMultiplier;
                 }
+                else if (HeldItems.FirstOrDefault(item => item.GetComponent<Holdable>()?.Aimable ?? false) is Item item2 && IsKeyDown(InputType.Aim))
+                {
+                    cam.OffsetAmount = targetOffsetAmount = item2.GetComponent<Holdable>().CameraAimOffset;
+                }
                 else if (SelectedItem != null && ViewTarget == null &&
                     SelectedItem.Components.Any(ic => ic?.GuiFrame != null && ic.ShouldDrawHUD(this)))
                 {

--- a/Barotrauma/BarotraumaClient/ClientSource/Map/Lights/LightManager.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Map/Lights/LightManager.cs
@@ -72,7 +72,7 @@ namespace Barotrauma.Lights
 
         public float ObstructVisionAmount;
 
-        private readonly Texture2D visionCircle;
+        private readonly Texture2D visionCircle, visionCone;
 
         private readonly Texture2D gapGlowTexture;
 
@@ -101,6 +101,7 @@ namespace Barotrauma.Lights
             rayCastThread.Start();
 
             visionCircle = Sprite.LoadTexture("Content/Lights/visioncircle.png");
+            visionCone = Sprite.LoadTexture("Content/Lights/lightcone.png");
             highlightRaster = Sprite.LoadTexture("Content/UI/HighlightRaster.png");
             gapGlowTexture = Sprite.LoadTexture("Content/Lights/pointlight_rays.png");
 
@@ -695,25 +696,18 @@ namespace Barotrauma.Lights
                 if (diff.LengthSquared() > 20.0f * 20.0f) { losOffset = diff; }
                 float rotation = MathUtils.VectorToAngle(losOffset);
 
-                //the visible area stretches to the maximum when the cursor is this far from the character
-                const float MaxOffset = 256.0f;
-                //the magic numbers here are just based on experimentation
-                float MinHorizontalScale = MathHelper.Lerp(3.5f, 1.5f, ObstructVisionAmount);
-                float MaxHorizontalScale = MinHorizontalScale * 1.25f;
-                float VerticalScale = MathHelper.Lerp(4.0f, 1.25f, ObstructVisionAmount);
+                // Cone starts at the opposite edge of the circle so it doesn't need to be as tall
+                const float coneHeightMultiplier = 2f;
+                const float scaleMultiplier = 1f;
 
-                //Starting point and scale-based modifier that moves the point of origin closer to the edge of the texture if the player moves their mouse further away, or vice versa.
-                float relativeOriginStartPosition = 0.1f; //Increasing this value moves the origin further behind the character
-                float originStartPosition = visionCircle.Width * relativeOriginStartPosition * MinHorizontalScale;
-                float relativeOriginLookAtPosModifier = -0.055f; //Increase this value increases how much the vision changes by moving the mouse
-                float originLookAtPosModifier = visionCircle.Width * relativeOriginLookAtPosModifier;
-
-                Vector2 scale = new Vector2(
-                    MathHelper.Clamp(losOffset.Length() / MaxOffset, MinHorizontalScale, MaxHorizontalScale), VerticalScale);
+                float scale = (1f - ObstructVisionAmount) * scaleMultiplier;
+                Vector2 circleOrigin = new Vector2(visionCircle.Width, visionCircle.Height) / 2f;
+                Vector2 coneOrigin = new Vector2(0f, visionCone.Height / 2f);
+                Vector2 coneScale = new Vector2(1f / visionCone.Width, scale / visionCone.Height * coneHeightMultiplier) * (losOffset.Length() + circleOrigin.X);
 
                 spriteBatch.Begin(SpriteSortMode.Deferred, transformMatrix: cam.Transform * Matrix.CreateScale(new Vector3(GameSettings.CurrentConfig.Graphics.LightMapScale, GameSettings.CurrentConfig.Graphics.LightMapScale, 1.0f)));
-                spriteBatch.Draw(visionCircle, new Vector2(ViewTarget.WorldPosition.X, -ViewTarget.WorldPosition.Y), null, Color.White, rotation,
-                    new Vector2(originStartPosition + (scale.X * originLookAtPosModifier), visionCircle.Height / 2), scale, SpriteEffects.None, 0.0f);
+                spriteBatch.Draw(visionCircle, new Vector2(ViewTarget.WorldPosition.X, -ViewTarget.WorldPosition.Y), null, Color.White, rotation, circleOrigin, scale, SpriteEffects.None, 0f);
+                spriteBatch.Draw(visionCone, new Vector2(ViewTarget.WorldPosition.X, -ViewTarget.WorldPosition.Y) - Vector2.Normalize(losOffset) * circleOrigin / 2f, null, Color.White, rotation, coneOrigin, coneScale, SpriteEffects.None, 0f);
                 spriteBatch.End();
             }
             else

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Holdable/Holdable.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Holdable/Holdable.cs
@@ -82,6 +82,9 @@ namespace Barotrauma.Items.Components
             set;
         }
 
+        [Serialize(0f, IsPropertySaveable.Yes, description: "Camera offset to apply when aiming this item. Only valid if Aimable is set to true.")]
+        public float CameraAimOffset { get; set; }
+
         [Serialize(false, IsPropertySaveable.No, description: "Should the character adjust its pose when aiming with the item. Most noticeable underwater, where the character will rotate its entire body to face the direction the item is aimed at.")]
         public bool ControlPose
         {


### PR DESCRIPTION
This PR does two things:
1. Adds a new attribute to the Holdable component: `CameraAimOffset`
2. Reworks vision obstruction to work with long range sight.

### Mod for Testing: [Mod.zip](https://github.com/user-attachments/files/16107111/Mod.zip)

## Obstruction Rework Previews
**Lighting Disabled**
![image](https://github.com/FakeFishGames/Barotrauma/assets/67431770/e96d3325-6dd3-4366-b2e9-bcd2558e6744)
**Lighting Disabled w/ Scope**
![image](https://github.com/FakeFishGames/Barotrauma/assets/67431770/3399777f-2a5d-416a-bb62-1e193769f976)
**Lighting Enabled**
![image](https://github.com/FakeFishGames/Barotrauma/assets/67431770/7d2f542c-4f57-4191-a4e8-861d0fdc7db0)
**Lighting Enabled w/ Scope**
![image](https://github.com/FakeFishGames/Barotrauma/assets/67431770/4026d36b-000c-426d-b26d-9d9c679b9403)

## Reworked light sprites
**Content/Lights/lightcone.png**
![Content/Lights/visioncircle.png](https://github.com/FakeFishGames/Barotrauma/assets/67431770/9d006827-db2c-41f3-96c7-6b0ceff009e3)
**Content/Lights/visioncircle.png**
![Content/Lights/visioncircle.png](https://github.com/FakeFishGames/Barotrauma/assets/67431770/b852626b-9475-40f5-93da-c86bf2cf22ab)
