### PR TITLE
Fixed steam networking ping estimation being completely wrong on the server list

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/ServerList/PingUtils.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/ServerList/PingUtils.cs
@@ -144,9 +144,9 @@ namespace Barotrauma.Networking
 
             var pingLocation = NetPingLocation.TryParseFromString(pingLocationStr);
 
-            if (pingLocation.HasValue && Steamworks.SteamNetworkingUtils.LocalPingLocation.HasValue)
+            if (pingLocation.HasValue)
             {
-                int ping = Steamworks.SteamNetworkingUtils.LocalPingLocation.Value.EstimatePingTo(pingLocation.Value);
+                int ping = Steamworks.SteamNetworkingUtils.EstimatePingTo(pingLocation.Value);
                 if (ping < 0) { return Result.Failure(SteamLobbyPingError.PingEstimationFailed); }
                 return Result.Success(ping);
             }


### PR DESCRIPTION
# Old ping estimation
![ping1](https://github.com/FakeFishGames/Barotrauma/assets/36804725/995f99b6-2322-47cf-968f-0e820f0b37d2)
# New ping estimation
![ping2](https://github.com/FakeFishGames/Barotrauma/assets/36804725/538a4f37-2774-4d3a-8889-b0789523e4c9)
**(by the way, all the servers have high ping because I'm on Brazil)**

# Why old ping estimation gave wrong values
The old ping estimation only used https://partner.steamgames.com/doc/api/ISteamNetworkingUtils#EstimatePingTimeBetweenTwoLocations to estimate the ping between two locations, without combining it with GetLocalPingLocation to give the actual accurate results as pointed by the documentation. While also at it, steam API has https://partner.steamgames.com/doc/api/ISteamNetworkingUtils#EstimatePingTimeFromLocalHost which gives even more accurate results than combining GetLocalPingLocation and EstimatePingTimeBetweenTwoLocations according to the documentation, so the new ping code is now using that instead.