### PR TITLE
Improved bed healing

### DIFF
--- a/healing beds/Afflictions.xml
+++ b/healing beds/Afflictions.xml
@@ -3170,4 +3170,29 @@
     </Effect>
     <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="256,896,128,128" color="10,193,114,255" origin="0,0"/>
   </Affliction>
+  
+  <Affliction
+    name="Resting"
+    identifier="resting"
+    description="Taking some rest. Recover faster."
+    type="buff"
+    isbuff="true"
+    limbspecific="false"
+    maxstrength="30"
+    showinhealthscannerthreshold="1000"
+    iconcolors="100,120,100,255;90,130,90,255;80,140,80,255">
+    <!-- Gradual improvement of healing effectiveness, up to 30% after 30 seconds (on a regular bed) -->
+    <!-- -30 strength per second, beds give +31 -->
+    <Effect minstrength="0" maxstrength="10" strengthchange="-30">
+      <StatValue stattype="MedicalItemEffectivenessMultiplier" minvalue="0" maxvalue="0.1" />
+    </Effect>
+    <Effect minstrength="10" maxstrength="20" strengthchange="-30">
+      <StatValue stattype="MedicalItemEffectivenessMultiplier" minvalue="0.1" maxvalue="0.2" />
+    </Effect>
+    <Effect minstrength="20" maxstrength="30" strengthchange="-30">
+      <StatValue stattype="MedicalItemEffectivenessMultiplier" minvalue="0.2" maxvalue="0.3" />
+    </Effect>
+    <icon texture="Content/UI/CommandUIAtlas.png" sourcerect="384,512,128,128" color="255,255,255,255" origin="0,0"/>
+  </Affliction>
+  
 </Afflictions>

--- a/healing beds/Afflictions.xml
+++ b/healing beds/Afflictions.xml
@@ -1,0 +1,3173 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Afflictions>
+
+  <!-- Basic afflictions. 
+  These afflictions are required by the vanilla game; 
+  modifying them may require modifications to the code. -->
+
+  <CPRSettings
+    revivechanceperskill="0.007"
+    revivechanceexponent="2"
+    revivechancemin="0.05"
+    revivechancemax="0.5"
+    stabilizationperskill="0.02"
+    stabilizationmin="0.5"
+    stabilizationmax="2"
+    damageskillthreshold="50"
+    damageskillmultiplier="0.05"
+    insufficientskillaffliction="internaldamage">
+    <!--
+    CPR revive chance = max(min((medicalskill * cprrevivechanceperskill) ^ cprrevivechanceexponent, cprrevivechancemin), cprrevivechancemax)
+      Example:
+        cprrevivechanceperskill="0.007"
+        cprrevivechanceexponent="2"
+        cprrevivechancemin="0.05"  
+        cprrevivechancemax="0.5"  
+        
+        Skill 5: 5%
+        Skill 20: 5%
+        Skill 50: 12%
+        Skill 70: 24%
+        Skill 90: 40%
+        Skill 100: 49%
+        
+    Stabilization means that the oxygen level of the target increases (but doesn't get back to normal until the character is revived).
+    A value of 1 means that the oxygen level doesn't drop (nor increase), 0.5 means the character takes twice as long to die of lack of oxygen
+      Example:
+        cprstabilizationperskill="0.02"
+        cprstabilizationmin="0.5"
+        cprstabilizationmax="2"
+        
+        Skill 5: stabilization 50%, character takes twice as long to die of lack of oxygen
+        Skill 20: stabilization 50%
+        Skill 50: stabilization 100%, character won't die of lack of oxygen, but oxygen level doesn't rise
+        Skill 75: stabilization 150%, oxygen level rises      
+        
+    If the skill of the character performing cpr is below damageskillthreshold, each pump causes damage
+    The amount damage is calculated as (damageskillthreshold - skill) * damageskillmultiplier
+      Example:
+        damageskillthreshold="20"
+        damageskillmultiplier="0.05"
+        
+        Skill 5: 0.75
+        Skill 15: 0.25
+        Skill 38: 0.0
+    -->
+  </CPRSettings>
+
+  <DamageOverlay texture="Content/UI/damageOverlay.png"/>
+
+  <!--Generic damage.-->
+  <InternalDamage
+    name="Internal Damage"
+    identifier="internaldamage"
+    description="The area is an ugly shade of purple, and apparently very painful to touch. You suspect a bone might be broken."
+    type="damage"
+    causeofdeathdescription="Died of internal injuries"
+    selfcauseofdeathdescription="You have succumbed to your internal injuries."
+    limbspecific="true"
+    maxstrength="200"
+    damageoverlayalpha="0.1">
+    <Description 
+      textidentifier="afflictiondescription.internaldamage.low"
+      minstrength="0"
+      maxstrength="40"/>
+    <Description
+      textidentifier="afflictiondescription.internaldamage"
+      minstrength="40"
+      maxstrength="200"/>
+    <Effect minstrength="0" maxstrength="200" multiplybymaxvitality="true"
+      minvitalitydecrease="0"
+      maxvitalitydecrease="2"/>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="128,768,128,128" color="195,136,60,255" origin="0,0"/>
+  </InternalDamage>
+
+  <!--Blunt force trauma is received from crowbars, wrenches, etc.-->
+  <InternalDamage
+    name="Blunt force trauma"
+    identifier="blunttrauma"
+    description=""
+    type="damage"
+    causeofdeathdescription=""
+    selfcauseofdeathdescription=""
+    limbspecific="true"
+    maxstrength="200"
+    damageoverlayalpha="0.5"
+    WeaponsSkillGain="1.0">
+    <Description 
+      textidentifier="afflictiondescription.blunttrauma.low"
+      minstrength="0"
+      maxstrength="40"/>
+    <Description
+      textidentifier="afflictiondescription.blunttrauma"
+      minstrength="40"
+      maxstrength="200"/>
+    <Effect minstrength="0" maxstrength="200" multiplybymaxvitality="true"
+      minvitalitydecrease="0"
+      maxvitalitydecrease="2"/>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="768,896,128,128" color="195,136,60,255" origin="0,0"/>
+  </InternalDamage>
+
+  <!--Lacerations are received from sharp damage sources-->
+  <InternalDamage
+    name="Lacerations"
+    identifier="lacerations"
+    description=""
+    type="damage"
+    causeofdeathdescription=""
+    selfcauseofdeathdescription=""
+    limbspecific="true"
+    maxstrength="200"
+    damageoverlayalpha="2"
+    WeaponsSkillGain="1.0">
+     <Description 
+      textidentifier="afflictiondescription.lacerations.low"
+      minstrength="0"
+      maxstrength="40"/>
+    <Description
+      textidentifier="afflictiondescription.lacerations"
+      minstrength="40"
+      maxstrength="200"/>
+    <Effect minstrength="0" maxstrength="200" multiplybymaxvitality="true"
+      minvitalitydecrease="0"
+      maxvitalitydecrease="2"/>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="896,896,128,128" color="195,136,60,255" origin="0,0"/>
+  </InternalDamage>
+
+  <!--Bite wounds are monster specific-->
+  <InternalDamage
+    name="Bite wounds"
+    identifier="bitewounds"
+    description=""
+    type="damage"
+    causeofdeathdescription="Mauled to death"
+    selfcauseofdeathdescription="You have been mauled to death."
+    limbspecific="true"
+    maxstrength="200"
+    damageoverlayalpha="2">
+    <Description
+      textidentifier="afflictiondescription.bitewounds.low"
+      minstrength="0"
+      maxstrength="40"/>
+    <Description
+      textidentifier="afflictiondescription.bitewounds"
+      minstrength="40"
+      maxstrength="200"/>
+    <Effect minstrength="0" maxstrength="200" multiplybymaxvitality="true"
+      minvitalitydecrease="0"
+      maxvitalitydecrease="2"/>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="0,512,128,128" color="195,136,60,255" origin="0,0"/>
+  </InternalDamage>
+
+  <InternalDamage
+    name="Gunshot wound"
+    identifier="gunshotwound"
+    description="The entry site is a small, dark, bruised hole oozing a little blood. The exit wound however is a large ragged mess of exposed tissue and pouring blood."
+    type="damage"
+    causeofdeathdescription="Shot to death"
+    selfcauseofdeathdescription="You have died of gunshot wounds."
+    limbspecific="true"
+    maxstrength="200"
+    karmachangeonapplied="-1"
+    damageoverlayalpha="2"
+    WeaponsSkillGain="1.0">
+    <Description
+      textidentifier="afflictiondescription.gunshotwound.low"
+      minstrength="0"
+      maxstrength="40"/>
+    <Description
+      textidentifier="afflictiondescription.gunshotwound"
+      minstrength="40"
+      maxstrength="200"/>
+    <Effect minstrength="0" maxstrength="200" multiplybymaxvitality="true"
+      minvitalitydecrease="0"
+      maxvitalitydecrease="2"
+      dialogflag="GunshotWound"/>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="256,768,128,128" color="195,60,60,255" origin="0,0"/>
+  </InternalDamage>
+
+  <!--Mainly for medical side effects-->
+  <InternalDamage
+    name="Organ damage"
+    identifier="organdamage"
+    description=""
+    type="damage"
+    causeofdeathdescription=""
+    selfcauseofdeathdescription=""
+    limbspecific="false"
+    indicatorlimb="Torso"
+    maxstrength="200"
+    affectmachines="false"
+    damageoverlayalpha="0"
+    damageparticles="false"
+    MedicalSkillGain="0.1">
+    <Description
+      textidentifier="afflictiondescription.organdamage.self"
+      target="Self" />
+    <Description
+      textidentifier="afflictiondescription.organdamage"
+      target="OtherCharacter " />
+    <Effect minstrength="0" maxstrength="200" multiplybymaxvitality="true"
+      minvitalitydecrease="0"
+      maxvitalitydecrease="2"/>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="128,384,128,128" color="195,136,60,255" origin="0,0"/>
+  </InternalDamage>
+
+  <!--For damage inflicted by explosions' blast waves and other sources that aren't quite blunt force trauma-->
+  <InternalDamage
+    name="Deep tissue injury"
+    identifier="explosiondamage"
+    description=""
+    type="damage"
+    causeofdeathdescription=""
+    selfcauseofdeathdescription=""
+    limbspecific="true"
+    maxstrength="200"
+    damageoverlayalpha="1"
+    WeaponsSkillGain="1.0">
+    <Description
+      textidentifier="afflictiondescription.explosiondamage.low"
+      minstrength="0"
+      maxstrength="40"/>
+    <Description
+      textidentifier="afflictiondescription.explosiondamage"
+      minstrength="40"
+      maxstrength="200"/>
+    <Effect minstrength="0" maxstrength="200" multiplybymaxvitality="true"
+      minvitalitydecrease="0"
+      maxvitalitydecrease="2"/>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="896,0,128,128" color="195,136,60,255" origin="0,0"/>
+  </InternalDamage>
+
+  <Bleeding
+    identifier="bleeding"
+    type="bleeding"
+    causeofdeathdescription="Bled to death"
+    selfcauseofdeathdescription="You have bled to death."
+    limbspecific="true"
+    maxstrength="100"
+    karmachangeonapplied="-1"
+    damageoverlayalpha="0.6"
+    healcostmultiplier="2.5"
+    WeaponsSkillGain="1.0">
+    <Description 
+      textidentifier="afflictiondescription.bleeding.low"
+      minstrength="0"
+      maxstrength="20"/>
+    <Description
+      textidentifier="afflictiondescription.bleeding"
+      minstrength="20"
+      maxstrength="60"/>
+    <Description
+      textidentifier="afflictiondescription.bleeding.high"
+      minstrength="60"
+      maxstrength="100"/>
+    <!-- Strength 0-20 -->
+    <Effect minstrength="0" maxstrength="20"
+      minvitalitydecrease="0"
+      maxvitalitydecrease="2"
+      strengthchange="-0.1" />
+    <!-- Strength 20-40 -->
+    <Effect minstrength="20" maxstrength="40"
+      minvitalitydecrease="2"
+      maxvitalitydecrease="4"
+      strengthchange="-0.1">
+      <StatusEffect target="Limb" interval="5" disabledeltatime="true" ConditionalComparison="And">
+        <Conditional IsHuman="true"/>
+        <Conditional WorldHostility="gte high" />
+        <Affliction identifier="infection" amount="5" probability="0.025" />
+      </StatusEffect>
+    </Effect>
+    <!-- Strength 40-60 -->
+    <Effect minstrength="40" maxstrength="60"
+      minvitalitydecrease="4"
+      maxvitalitydecrease="6"
+      strengthchange="-0.1">
+      <StatusEffect target="Limb" interval="5" disabledeltatime="true" ConditionalComparison="And">
+        <Conditional IsHuman="true"/>
+        <Conditional WorldHostility="gte high" />
+        <Affliction identifier="infection" amount="5" probability="0.05" />
+      </StatusEffect>
+    </Effect>
+    <!-- Strength 60-100 -->
+    <Effect minstrength="60" maxstrength="100"
+      minvitalitydecrease="6"
+      maxvitalitydecrease="10"
+      strengthchange="-0.1">
+      <StatusEffect target="Limb" interval="5" disabledeltatime="true" ConditionalComparison="And">
+        <Conditional IsHuman="true"/>
+        <Conditional WorldHostility="gte high" />
+        <Affliction identifier="infection" amount="5" probability="0.08" />
+      </StatusEffect>
+    </Effect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="896,640,128,128" color="139,60,42,255" origin="0,0"/>
+  </Bleeding>
+
+  <Bleeding
+    name="Bleeding"
+    identifier="bleedingnonstop"
+    translationoverride="bleeding"
+    description="Blood pours freely from this ragged and particularly nasty open wound"
+    type="bleeding"
+    causeofdeathdescription="Bled to death"
+    selfcauseofdeathdescription="You have bled to death."
+    limbspecific="true"
+    maxstrength="100"
+    karmachangeonapplied="-1"
+    damageoverlayalpha="0.6">
+    <Effect minstrength="0" maxstrength="100"
+      minvitalitydecrease="0"
+      maxvitalitydecrease="10"
+      strengthchange="0"/>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="896,640,128,128" color="139,60,42,255" origin="0,0"/>
+  </Bleeding>
+
+  <Burn
+    name="Burn"
+    identifier="burn"
+    description="The area is blistered and red, and skin is already beginning to peel away in sheets. The patient is in a great deal of pain."
+    type="burn"
+    causeofdeathdescription="Burned to death"
+    selfcauseofdeathdescription="You have burned to death."
+    limbspecific="true"
+    maxstrength="200"
+    burnoverlayalpha="1"
+    healcostmultiplier="2.25"
+    WeaponsSkillGain="1.0">
+    <Description
+      textidentifier="afflictiondescription.burn.low"
+      minstrength="0"
+      maxstrength="30"/>
+    <Description
+      textidentifier="afflictiondescription.burn"
+      minstrength="30"
+      maxstrength="60"/>
+    <Description
+      textidentifier="afflictiondescription.burn.high"
+      minstrength="60"
+      maxstrength="200"/>
+    <Effect minstrength="0" maxstrength="30" multiplybymaxvitality="true"
+      minvitalitydecrease="0"
+      maxvitalitydecrease="0.3"/>
+    <Effect minstrength="30" maxstrength="60" multiplybymaxvitality="true"
+      minvitalitydecrease="0.3"
+      maxvitalitydecrease="0.6">
+      <StatusEffect target="Limb" interval="5" disabledeltatime="true" ConditionalComparison="And">
+        <Conditional IsHuman="true"/>
+        <Conditional WorldHostility="gte high" />
+        <Affliction identifier="infection" amount="5" probability="0.015" />
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="60" maxstrength="200" multiplybymaxvitality="true"
+      minvitalitydecrease="0.6"
+      maxvitalitydecrease="2">
+      <StatusEffect target="Limb" interval="5" disabledeltatime="true" ConditionalComparison="And">
+        <Conditional IsHuman="true"/>
+        <Conditional WorldHostility="gte high" />
+        <Affliction identifier="infection" amount="5" probability="0.03" />
+      </StatusEffect>
+    </Effect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="768,640,128,128" color="195,104,60,255" origin="0,0"/>
+  </Burn>
+
+  <AcidBurn
+    identifier="acidburn"
+    type="burn"
+    limbspecific="true"
+    maxstrength="200"
+    burnoverlayalpha="0"
+    causeofdeathdescription="causeofdeathdescription.damage"
+    selfcauseofdeathdescription="self_causeofdeathdescription.damage"
+    healcostmultiplier="2.25"
+    WeaponsSkillGain="0.5"
+    MedicalSkillGain="0.5">
+     <Description
+      textidentifier="afflictiondescription.acidburn.low"
+      minstrength="0"
+      maxstrength="30"/>
+    <Description
+      textidentifier="afflictiondescription.acidburn"
+      minstrength="30"
+      maxstrength="60"/>
+    <Description
+      textidentifier="afflictiondescription.acidburn.high"
+      minstrength="60"
+      maxstrength="200"/>
+    <Effect minstrength="0" maxstrength="30" multiplybymaxvitality="true"
+      minvitalitydecrease="0"
+      maxvitalitydecrease="0.3"/>
+    <Effect minstrength="30" maxstrength="60" multiplybymaxvitality="true"
+      minvitalitydecrease="0.3"
+      maxvitalitydecrease="0.6">
+      <StatusEffect target="Limb" interval="5" disabledeltatime="true" ConditionalComparison="And">
+        <Conditional IsHuman="true"/>
+        <Conditional WorldHostility="gte high" />
+        <Affliction identifier="infection" amount="5" probability="0.015" />
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="60" maxstrength="200" multiplybymaxvitality="true"
+      minvitalitydecrease="0.6"
+      maxvitalitydecrease="2">
+      <StatusEffect target="Limb" interval="5" disabledeltatime="true" ConditionalComparison="And">
+        <Conditional IsHuman="true"/>
+        <Conditional WorldHostility="gte high" />
+        <Affliction identifier="infection" amount="5" probability="0.03" />
+      </StatusEffect>
+    </Effect>
+    <icon texture="Content/UI/CommandUIBackground.png" sourcerect="640,768,128,128" color="84,171,90,255" origin="0,0"/>
+  </AcidBurn>
+
+  <OxygenLow
+    name="Oxygen low"
+    identifier="oxygenlow"
+    description="The skin is pale and clammy, and the lips turning blue."
+    type="oxygenlow"
+    causeofdeathdescription="Suffocated"
+    selfcauseofdeathdescription="You have suffocated."
+    limbspecific="false"
+    indicatorlimb="Torso"
+    activationthreshold="1"
+    karmachangeonapplied="-0.2"
+    maxstrength="200"
+    treatmentthreshold="100"
+    healcostmultiplier="0.5">
+     <Description
+      textidentifier="afflictiondescription.oxygenlow.low"
+      minstrength="0"
+      maxstrength="50"/>
+    <Description
+      textidentifier="afflictiondescription.oxygenlow"
+      minstrength="50"
+      maxstrength="200"/>
+    <Effect minstrength="1" maxstrength="50"
+      minfacetint="200,180,255,0"
+      maxfacetint="200,180,255,100"/>
+    <Effect minstrength="50" maxstrength="200" multiplybymaxvitality="true"
+      minvitalitydecrease="0"
+      maxvitalitydecrease="2"
+      minfacetint="200,180,255,100"
+      maxfacetint="200,180,255,200"
+      minbodytint="150,150,255,0"
+      maxbodytint="150,150,255,100"/>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="512,640,128,128" color="68,157,198,255" origin="0,0"/>
+  </OxygenLow>
+
+  <Bloodloss
+    identifier="bloodloss"
+    type="bloodloss"
+    causeofdeathdescription="Bled to death"
+    selfcauseofdeathdescription="You have bled to death."
+    limbspecific="false"
+    indicatorlimb="Torso"
+    activationthreshold="5"
+    karmachangeonapplied="-0.1"
+    maxstrength="100"
+    affectmachines="false"
+    healcostmultiplier="1.5">
+    <Description
+      textidentifier="afflictiondescription.bloodloss.low.self"
+      target="Self"
+      minstrength="0"
+      maxstrength="30"/>
+    <Description
+      textidentifier="afflictiondescription.bloodloss.high.self"
+      target="Self"
+      minstrength="30"
+      maxstrength="100"/>
+    <Description
+      textidentifier="afflictiondescription.bloodloss.low"
+      target="OtherCharacter"
+      minstrength="0"
+      maxstrength="30"/>
+    <Description
+      textidentifier="afflictiondescription.bloodloss"
+      target="OtherCharacter"
+      minstrength="30"
+      maxstrength="100"/>
+    <!-- no effects at this point -->
+    <Effect minstrength="0" maxstrength="5" strengthchange="-0.1" />
+    <Effect minstrength="5" maxstrength="45" multiplybymaxvitality="true"
+      minvitalitydecrease="0"
+      maxvitalitydecrease="0.75"
+      strengthchange="-0.1"
+      dialogflag="Bloodloss"/>
+    <Effect minstrength="45" maxstrength="100" multiplybymaxvitality="true"
+      minvitalitydecrease="0.75"
+      maxvitalitydecrease="2"
+      strengthchange="-0.1"
+      dialogflag="Bloodloss"
+      minscreenblur="0.0"
+      maxscreenblur="6.0"
+      minchromaticaberration="0.0"
+      maxchromaticaberration="2.0"
+      minbodytint="255,0,0,0"
+      maxbodytint="255,0,0,150"/>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="0,768,128,128" color="139,60,42,255" origin="0,0"/>
+  </Bloodloss>
+
+  <Stun
+    name="Stun"
+    identifier="stun"
+    description="The patient is dazed and unresponsive."
+    type="stun"
+    limbspecific="false"
+    indicatorlimb="Head"
+    activationthreshold="1.0"
+    showiconthreshold="1000"
+    maxstrength="30">
+     <Description
+      textidentifier="afflictiondescription.stun"
+      target="OtherCharacter" />
+     <Description
+      textidentifier="afflictiondescription.stun.self"
+      target="Self" />
+    <Effect minstrength="0" maxstrength="100"
+      minvitalitydecrease="0"
+      maxvitalitydecrease="0"
+      strengthchange="-1.0"/>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="128,640,128,128" color="195,177,60,255" origin="0,0"/>
+  </Stun>
+  
+  <Slow
+    name="Slow"
+    identifier="slow"
+    description="The target is slowed."
+    type="slow"
+    limbspecific="false"
+    indicatorlimb="Torso"
+    activationthreshold="1.0"
+    showiconthreshold="1000"
+    showinhealthscannerthreshold="1000"
+    maxstrength="80">
+    <Effect minstrength="0" maxstrength="80"
+      strengthchange="-10"
+      minspeedmultiplier="1"
+      maxspeedmultiplier="0.35" >
+    </Effect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="128,896,128,128" color="10,193,114,255" origin="0,0"/>
+  </Slow>
+
+  <Pressure
+    name="Barotrauma"
+    identifier="pressure"
+    description="There is obvious massive organ damage and the blood vessels of the eye have burst, creating an unnerving red gaze."
+    type="pressure"
+    causeofdeathdescription="Crushed by water pressure"
+    selfcauseofdeathdescription="You have been crushed by water pressure."
+    limbspecific="false"
+    maxstrength="1"
+    showiconthreshold="10"
+    damageoverlayalpha="0.6">
+    <Effect minstrength="0" maxstrength="1" multiplybymaxvitality="true"
+      minvitalitydecrease="10"
+      maxvitalitydecrease="10"
+      minbodytint="60,0,0,0"
+      maxbodytint="60,0,0,200"/>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="768,768,128,128" color="143,111,160,255" origin="0,0"/>
+  </Pressure>
+
+  <Affliction
+    name="Concussion"
+    identifier="concussion"
+    type="damage"
+    limbspecific="false"
+    indicatorlimb="Head"
+    activationthreshold="0"
+    maxstrength="10"
+    treatmentthreshold="5"
+    healcostmultiplier="2.5">
+     <Description
+      textidentifier="afflictiondescription.concussion.low.self"
+      target="Self"
+      minstrength="0"
+      maxstrength="5"/>
+    <Description
+      textidentifier="afflictiondescription.concussion.high.self"
+      target="Self"
+      minstrength="5"
+      maxstrength="10"/>
+    <Description
+      textidentifier="afflictiondescription.concussion.low"
+      target="OtherCharacter"
+      minstrength="0"
+      maxstrength="5"/>
+    <Description
+      textidentifier="afflictiondescription.concussion"
+      target="OtherCharacter"
+      minstrength="5"
+      maxstrength="10"/>
+    <Effect minstrength="0" maxstrength="10"
+      minvitalitydecrease="0"
+      maxvitalitydecrease="0"
+      minscreendistort="0.02"
+      maxscreendistort="0.1"
+      minscreenblur="0.1"
+      maxscreenblur="2.0"
+      screeneffectfluctuationfrequency="0.05"
+      strengthchange="-0.01">
+      <StatusEffect target="Character">
+        <TriggerAnimation Type="Walk" filename="DrunkenWalk" priority="6" ExpectedSpecies="Human" />
+        <TriggerAnimation Type="Run" filename="DrunkenRun" priority="6" ExpectedSpecies="Human" />
+      </StatusEffect>
+    </Effect>
+    <PeriodicEffect mininterval="30" maxinterval="60">
+      <StatusEffect target="Character" comparison="and">
+        <Conditional ishuman="true" />
+        <Conditional hasspecifiertag="male"/>
+        <Sound file="Content/Sounds/HUMAN_chokeMale1.ogg" selectionmode="Random" />
+        <Sound file="Content/Sounds/HUMAN_chokeMale2.ogg" />
+        <Sound file="Content/Sounds/HUMAN_chokeMale3.ogg" />
+      </StatusEffect>
+      <StatusEffect target="Character" comparison="and">
+        <Conditional ishuman="true" />
+        <Conditional hasspecifiertag="female"/>
+        <Sound file="Content/Sounds/HUMAN_chokeFemale1.ogg" selectionmode="Random" />
+        <Sound file="Content/Sounds/HUMAN_chokeFemale2.ogg" />
+        <Sound file="Content/Sounds/HUMAN_chokeFemale3.ogg" />
+      </StatusEffect>
+      <StatusEffect target="Character" duration="2">
+        <TriggerAnimation Type="Walk" filename="Vomit" priority="10" ExpectedSpecies="Human" />
+      </StatusEffect>
+      <StatusEffect target="Character" targetlimbs="Head" delay="0.3" duration="1">
+        <ParticleEmitter particle="vomitsplash" copyentityangle="true" anglemin="-10" anglemax="10" particlespersecond="50" velocitymin="50" velocitymax="200" scalemin="0.1" scalemax="0.2" />
+        <Conditional HideFace="eq False" />
+      </StatusEffect>
+      <StatusEffect target="Character" targetlimbs="Head" delay="0.5">
+        <Explosion range="0.0" structuredamage="0" itemdamage="0" force="0.0" severlimbsprobability="0.0" decal="vomitsplatter" decalsize="1.25" shockwave="false" underwaterbubble="false" />
+        <Conditional HideFace="eq False" />
+      </StatusEffect>
+    </PeriodicEffect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="128,640,128,128" color="195,177,60,255" origin="0,0"/>
+  </Affliction>
+
+  <AfflictionHusk
+    name="Husk infection"
+    identifier="huskinfection"
+    description="Something dark and unpleasant moves in the mouth. They are rendered completely mute, save for occasional clicking sounds apparently emanating from deep within the throat."
+    type="alieninfection"
+    targets="human,crawler"
+    huskedspeciesname="husk"
+    causeofdeathdescription="Taken over by a husk parasite"
+    selfcauseofdeathdescription="You have been taken over by the husk parasite."
+    limbspecific="false"
+    indicatorlimb="Torso"
+    activationthreshold="0"
+    showiconthreshold="40"
+    showinhealthscannerthreshold="20"
+    karmachangeonapplied="-1"
+    maxstrength="100"
+    transferbuffs="true"
+    achievementonremoved="healhusk"
+    dormantthreshold="50"
+    activethreshold="75"
+    transformthresholdondeath="75"
+    transitionthreshold="100"
+    IgnoreTreatmentIfAfflictedBy="husktransformimmunity,husktransformimmunitytemporary"
+    healcostmultiplier="2.5"
+    basehealcost="200"
+    iconcolors="60,140,195,255;60,107,195,255;60,0,195,255">
+     <Description
+      textidentifier="afflictiondescription.huskinfection.dormant.self"
+      target="Self"
+      minstrength="0"
+      maxstrength="50"/>
+    <Description
+      textidentifier="afflictiondescription.huskinfection.transition.self"
+      target="Self"
+      minstrength="50"
+      maxstrength="75"/>
+    <Description
+      textidentifier="afflictiondescription.huskinfection.active.self"
+      target="Self"
+      minstrength="75"
+      maxstrength="99"/>
+    <Description
+      textidentifier="afflictiondescription.huskinfection.dormant.other"
+      target="OtherCharacter"
+      minstrength="0"
+      maxstrength="50"/>
+    <Description
+      textidentifier="afflictiondescription.huskinfection.transition.other"
+      target="OtherCharacter"
+      minstrength="50"
+      maxstrength="75"/>
+    <Description
+      textidentifier="afflictiondescription.huskinfection.active.other"
+      target="OtherCharacter"
+      minstrength="75"
+      maxstrength="99"/>
+    <Description
+      textidentifier="afflictiondescription.huskinfection.final"
+      minstrength="99"
+      maxstrength="101"/>
+    <Effect minstrength="0" maxstrength="75"
+      maxvitalitydecrease="0"
+      strengthchange="0.3"
+      minbodytint="195,195,195,0"
+      maxbodytint="195,195,195,150"/>
+    <Effect minstrength="75" maxstrength="100"
+      maxvitalitydecrease="0"
+      strengthchange="0.3"
+      minbodytint="195,195,195,150"
+      maxbodytint="195,195,195,200"
+      tag="huskinfected"/>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="0,640,128,128" color="60,107,195,255" origin="0,0"/>
+  </AfflictionHusk>
+
+
+  <AfflictionHusk
+    identifier="husksymbiosis"
+    type="alieninfection"    
+    targets="human"
+    isbuff="true"
+    huskedspeciesname="[speciesname]husk"
+    limbspecific="false"
+    indicatorlimb="Torso"
+    activationthreshold="0"
+    showiconthreshold="0"
+    showinhealthscannerthreshold="0"
+    karmachangeonapplied="-1"
+    maxstrength="100"
+    transferbuffs="true"
+    causespeechimpediment="false"
+    achievementonreceived="ascension"
+    achievementonremoved="healhusk"
+    dormantthreshold="50"
+    activethreshold="75"
+    transformthresholdondeath="1000"
+    transitionthreshold="1000"
+    healableinmedicalclinic="false"
+    iconcolors="60,140,195,255;60,107,195,255;60,0,195,255">
+    <Effect minstrength="0" maxstrength="75"
+      maxvitalitydecrease="0"
+      strengthchange="50"
+      minbodytint="255,255,255,0"
+      maxbodytint="255,255,255,255"
+      minfacetint="255,255,255,0"
+      maxfacetint="255,255,255,255"
+      tag="huskinfected" blocktransformation="huskinfection"
+      resistancefor="huskinfection"  minresistance="1.0" maxresistance="1.0">
+      <StatusEffect target="Character" type="OnActive">
+        <ReduceAffliction identifier="huskinfection" amount="1000" />
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="75" maxstrength="100"
+      maxvitalitydecrease="0"
+      strengthchange="10"
+      minbodytint="255,255,255,255"
+      maxbodytint="255,255,255,255"
+      minfacetint="255,255,255,255"
+      maxfacetint="255,255,255,255"
+      tag="huskinfected" blocktransformation="huskinfection"
+      resistancefor="huskinfection"  minresistance="1.0" maxresistance="1.0">
+      <StatusEffect target="Character" type="OnActive">
+        <ReduceAffliction identifier="huskinfection" amount="1000" />
+      </StatusEffect>
+      <StatusEffect target="Character">
+        <ReduceAffliction type="damage" amount="0.75" />
+        <ReduceAffliction type="bleeding" amount="0.18" />
+      </StatusEffect>
+    </Effect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="0,640,128,128" color="60,107,195,255" origin="0,0"/>
+  </AfflictionHusk>
+
+  <AfflictionSpaceHerpes
+    name="Space herpes"
+    identifier="spaceherpes"
+    description=""
+    type="spaceherpes"
+    causeofdeathdescription=""
+    selfcauseofdeathdescription=""
+    limbspecific="false"
+    indicatorlimb="Torso"
+    showiconthreshold="20"
+    showinhealthscannerthreshold="10"
+    maxstrength="100">
+    <Description
+      textidentifier="afflictiondescription.spaceherpes"
+      target="OtherCharacter" />
+    <Description
+      textidentifier="afflictiondescription.spaceherpes.self"
+      target="Self" />
+    <Effect minstrength="0" maxstrength="50"
+      minscreendistort="0.0"
+      maxscreendistort="0.0"
+      minradialdistort="0.0"
+      maxradialdistort="0.0">
+    </Effect>
+    <Effect minstrength="50" maxstrength="100"
+      minscreendistort="0.0"
+      maxscreendistort="0.5"
+      minradialdistort="0.0"
+      maxradialdistort="0.5"            
+      minspeedmultiplier="0.6"
+      maxspeedmultiplier="0.6">
+    </Effect>
+
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="0,384,128,128" color="193,162,122,255" origin="0,0"/>
+  </AfflictionSpaceHerpes>
+
+  <Affliction
+    name="Disoriented"
+    identifier="invertcontrols"
+    description=""
+    type="invertcontrols"
+    causeofdeathdescription=""
+    selfcauseofdeathdescription=""
+    limbspecific="false"
+    showiconthreshold="100"
+    maxstrength="100">
+    <Description
+      textidentifier="afflictiondescription.invertcontrols"
+      target="OtherCharacter" />
+    <Description
+      textidentifier="afflictiondescription.invertcontrols.self"
+      target="Self" />
+    <Effect minstrength="50" maxstrength="100"
+      minscreendistort="0.0"
+      maxscreendistort="0.5"
+      minradialdistort="0.0"
+      maxradialdistort="0.5"
+      minspeedmultiplier="0.7"
+      maxspeedmultiplier="0.7"
+      strengthchange="-1.0">
+    </Effect>
+  </Affliction>
+  
+  <AfflictionPsychosis
+    name="Psychosis"
+    identifier="psychosis"
+    description="The patient rants and mutters in an agitated fashion, a steady commentary of unseen events."
+    type="psychosis"
+    limbspecific="false"
+    indicatorlimb="Head"
+    activationthreshold="0"
+    showiconthreshold="1000"
+    showicontoothersthreshold="20"
+    showinhealthscannerthreshold="10"
+    treatmentthreshold="20"
+    karmachangeonapplied="-1"
+    maxstrength="100"
+    affectmachines="false"
+    achievementonremoved="healpsychosis"
+    healcostmultiplier="3.5">
+    <Description
+      textidentifier="afflictiondescription.psychosis.low"
+      minstrength="0"
+      maxstrength="50"/>
+    <Description
+      textidentifier="afflictiondescription.psychosis"
+      minstrength="50"
+      maxstrength="100"/>
+    <Effect minstrength="0" maxstrength="100"
+      maxvitalitydecrease="0"
+      strengthchange="-0.1"/>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="256,640,128,128" color="150,26,26,255" origin="0,0"/>
+    <PeriodicEffect mininterval="30" maxinterval="120">
+      <StatusEffect target="Character" onlyoutside="true">
+        <Conditional IsLocalPlayer="True"/>
+        <Sound file="Content/Characters/Spineling/SPINELING_idle2.ogg" selectionmode="Random"/>
+        <Sound file="Content/Characters/Spineling/SPINELING_idle4.ogg" />
+        <Sound file="Content/Characters/Tigerthresher/TIGERTRESHER_idle1.ogg" />
+        <Sound file="Content/Characters/Tigerthresher/TIGERTRESHER_idle2.ogg" />
+        <Sound file="Content/Characters/Tigerthresher/TIGERTRESHER_attack1.ogg" />
+        <Sound file="Content/Characters/Moloch/MOLOCH_attack1.ogg" />
+        <Sound file="Content/Characters/Moloch/MOLOCH_attack2.ogg" />
+        <Sound file="Content/Characters/Husk/HUSK_idle1.ogg" />
+        <Sound file="Content/Characters/Husk/HUSK_idle4.ogg" />
+        <Sound file="Content/Characters/Hammerheadmatriarch/MHAMMERHEAD_idle3.ogg" />
+        <Sound file="Content/Characters/Hammerhead/HAMMERHEAD_idle4.ogg" />
+        <Sound file="Content/Characters/Hammerhead/HAMMERHEAD_attack2.ogg" />
+        <Sound file="Content/Characters/Hammerhead/HAMMERHEAD_attack3.ogg" />
+        <Sound file="Content/Characters/Crawlerhusk/HUSKEDCRAWLER_idle1.ogg" />
+        <Sound file="Content/Characters/Crawlerhusk/HUSKEDCRAWLER_idle3.ogg" />
+        <Sound file="Content/Characters/Crawlerhusk/HUSKEDCRAWLER_attack2.ogg" />
+      </StatusEffect>
+      <StatusEffect target="Character" onlyinside="true">
+        <Conditional IsLocalPlayer="True"/>
+        <Sound file="Content/Items/Weapons/honk.ogg" selectionmode="Random" />
+        <Sound file="Content/Items/Weapons/ShotgunShot1.ogg" />
+        <Sound file="Content/Items/Weapons/ShotgunShot2.ogg" />
+        <Sound file="Content/Characters/Moloch/MOLOCH_attack1.ogg" />
+        <Sound file="Content/Characters/Moloch/MOLOCH_attack2.ogg" />
+        <Sound file="Content/Characters/Mudraptor/MUDRAPTOR_attack1.ogg" />
+        <Sound file="Content/Characters/Mudraptor/MUDRAPTOR_attack2.ogg" />
+        <Sound file="Content/Characters/Mudraptor/MUDRAPTOR_idle4.ogg" />
+        <Sound file="Content/Characters/Husk/HUSK_idle1.ogg" />
+        <Sound file="Content/Characters/Husk/HUSK_idle4.ogg" />
+        <Sound file="Content/Characters/Husk/HUSK_attack4.ogg" />
+        <Sound file="Content/Characters/Crawler/CRAWLER_idle3.ogg" />
+      </StatusEffect>
+    </PeriodicEffect>
+    <PeriodicEffect mininterval="100" maxinterval="200">
+      <StatusEffect target="Character" duration="30" onlyinside="true">
+        <Conditional IsLocalPlayer="True"/>
+        <Sound file="Content/Items/WarningSiren.ogg" />
+      </StatusEffect>
+    </PeriodicEffect>
+  </AfflictionPsychosis>
+
+  <Affliction
+    identifier="drunk"
+    description="The smell of alcohol rises from them like a vapor, their speech slurs a little, and their eyes fail to focus."
+    type="debuff"
+    causeofdeathdescription="Alcohol poisoning"
+    selfcauseofdeathdescription="You have died of alcohol poisoning."
+    limbspecific="false"
+    indicatorlimb="Head"
+    activationthreshold="20"
+    treatmentthreshold="1000"
+    maxstrength="100"
+    affectmachines="false">
+     <Description
+      textidentifier="afflictiondescription.drunk.self"
+      target="Self"
+      minstrength="0"
+      maxstrength="80"/>
+     <Description
+      textidentifier="afflictiondescription.drunk.lethal.self"
+      target="Self"
+      minstrength="80"
+      maxstrength="100"/>
+     <Description
+      textidentifier="afflictiondescription.drunk.low"
+      target="OtherCharacter"
+      minstrength="0"
+      maxstrength="40"/>
+    <Description
+      textidentifier="afflictiondescription.drunk"
+      target="OtherCharacter"
+      minstrength="40"
+      maxstrength="80"/>
+    <Description
+      textidentifier="afflictiondescription.drunk.lethal"
+      target="OtherCharacter"
+      minstrength="80"
+      maxstrength="100"/>
+    <!-- no effects at this point -->
+    <Effect minstrength="0" maxstrength="20" strengthchange="-0.1" />
+    <!-- Low level of drunkenness decreases vitality and speed slightly -->
+    <Effect minstrength="20" maxstrength="40"
+      minvitalitydecrease="0"
+      maxvitalitydecrease="10"
+      minscreendistort="0"
+      maxscreendistort="0.1"
+      strengthchange="-0.1"
+      minfacetint="255,0,0,0"
+      maxfacetint="255,0,0,50"
+      minspeedmultiplier="1.0"
+      maxspeedmultiplier="0.8">
+    </Effect>
+
+    <!-- Heavier drunkenness decreases vitality and speed more -->
+    <Effect minstrength="40" maxstrength="80"
+      minvitalitydecrease="10"
+      maxvitalitydecrease="30"
+      minscreendistort="0.1"
+      maxscreendistort="1.0"
+      minscreenblur="0.1"
+      maxscreenblur="1.0"
+      strengthchange="-0.2"
+      minradialdistort="0.0"
+      maxradialdistort="2.0"
+      dialogflag="DrunkMedium"
+      minfacetint="255,0,0,50"
+      maxfacetint="255,0,0,100"
+      minspeedmultiplier="0.8"
+      maxspeedmultiplier="0.7">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <Affliction identifier="nausea" strength="10" probability="0.05" />
+      </StatusEffect>
+      <StatusEffect target="Character">
+        <TriggerAnimation Type="Walk" filename="DrunkenWalk" priority="4" ExpectedSpecies="Human" />
+        <TriggerAnimation Type="Run" filename="DrunkenRun" priority="4" ExpectedSpecies="Human" />
+      </StatusEffect>
+    </Effect>
+
+    <!-- After drinking enough the effect starts to get lethal -->
+    <Effect minstrength="80" maxstrength="100"
+      minvitalitydecrease="30"
+      maxvitalitydecrease="100"
+      minscreendistort="1.0"
+      maxscreendistort="3.0"
+      minscreenblur="1.0"
+      maxscreenblur="3.0"
+      strengthchange="-0.2"
+      minradialdistort="2.0"
+      maxradialdistort="3.0"
+      dialogflag="DrunkHigh"
+      minfacetint="255,0,0,150"
+      maxfacetint="255,0,0,150"
+      minspeedmultiplier="0.8"
+      maxspeedmultiplier="0.5">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <Affliction identifier="nausea" strength="20" probability="0.15" />
+      </StatusEffect>
+      <StatusEffect target="Character">
+        <TriggerAnimation Type="Walk" filename="DrunkenWalk" priority="6" ExpectedSpecies="Human" />
+        <TriggerAnimation Type="Run" filename="DrunkenRun" priority="6" ExpectedSpecies="Human" />
+      </StatusEffect>
+    </Effect>
+
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="384,640,128,128" color="170,194,147,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    identifier="drunknodebuffs"
+    type="debuff"
+    translationoverride="drunk"
+    limbspecific="false"
+    indicatorlimb="Head"
+    activationthreshold="20"
+    maxstrength="100"
+    affectmachines="false">
+
+    <!-- no effects at this point -->
+    <Effect minstrength="0" maxstrength="20" strengthchange="-0.1" />
+    
+    <Effect minstrength="20" maxstrength="40"
+      minscreendistort="0"
+      maxscreendistort="0.1"
+      strengthchange="-0.1"
+      minfacetint="255,0,0,0"
+      maxfacetint="255,0,0,50">
+    </Effect>
+
+    <Effect minstrength="40" maxstrength="80"
+      minscreendistort="0.1"
+      maxscreendistort="1.0"
+      minscreenblur="0.1"
+      maxscreenblur="0.5"
+      strengthchange="-0.2"
+      minradialdistort="0.0"
+      maxradialdistort="2.0"
+      dialogflag="DrunkMedium"
+      minfacetint="255,0,0,50"
+      maxfacetint="255,0,0,100">
+    </Effect>
+
+    <Effect minstrength="80" maxstrength="100"
+      minscreendistort="1.0"
+      maxscreendistort="3.0"
+      minscreenblur="0.5"
+      maxscreenblur="1.0"
+      strengthchange="-0.2"
+      minradialdistort="2.0"
+      maxradialdistort="3.0"
+      dialogflag="DrunkHigh"
+      minfacetint="255,0,0,150"
+      maxfacetint="255,0,0,150">
+    </Effect>
+
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="384,640,128,128" color="170,194,147,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="Opiate withdrawal"
+    identifier="opiatewithdrawal"
+    description="Agitation and a tremor are obvious, as are the signs of nausea."
+    type="debuff"
+    causeofdeathdescription="Died of opiate withdrawal"
+    selfcauseofdeathdescription="You have died of opiate withdrawal."
+    limbspecific="false"
+    indicatorlimb="Head"
+    showiconthreshold="20"
+    showinhealthscannerthreshold="5"
+    treatmentthreshold="50"
+    maxstrength="100"
+    affectmachines="false">
+     <Description
+      textidentifier="afflictiondescription.opiatewithdrawal.low"
+      minstrength="0"
+      maxstrength="50"/>
+    <Description
+      textidentifier="afflictiondescription.opiatewithdrawal"
+      minstrength="50"
+      maxstrength="100"/>
+    <!-- no effects at this point -->
+    <Effect minstrength="0" maxstrength="20" strengthchange="-0.05" />  
+    <!-- Slow down the character and slightly decrease vitality -->
+    <Effect minstrength="20" maxstrength="40"
+      minvitalitydecrease="0"
+      maxvitalitydecrease="20"
+      strengthchange="-0.1"
+      minchromaticaberration="0.0"
+      maxchromaticaberration="1.0"
+      dialogflag="OpiateWithdrawalLow"
+      minfacetint="255,255,255,0"
+      maxfacetint="255,255,255,50"
+      minspeedmultiplier="1.0"
+      maxspeedmultiplier="0.8">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <Affliction identifier="nausea" strength="10" probability="0.05" />
+      </StatusEffect>
+    </Effect>
+    <!-- Decrease vitality more.  -->
+    <Effect minstrength="40" maxstrength="80"
+      minvitalitydecrease="20"
+      maxvitalitydecrease="50"
+      strengthchange="-0.1"
+      minchromaticaberration="1.0"
+      maxchromaticaberration="5.0"
+      dialogflag="OpiateWithdrawalMedium"
+      minfacetint="255,255,255,50"
+      maxfacetint="255,255,255,100"
+      minspeedmultiplier="0.8"
+      maxspeedmultiplier="0.7">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <Affliction identifier="nausea" strength="20" probability="0.15" />
+      </StatusEffect>
+    </Effect>
+    <!-- Withdrawal symptoms start to get lethal at this level -->
+    <Effect minstrength="80" maxstrength="100"
+      minvitalitydecrease="50"
+      maxvitalitydecrease="200"
+      minscreendistort="0.0"
+      maxscreendistort="3.0"
+      strengthchange="-0.2"
+      minchromaticaberration="5.0"
+      maxchromaticaberration="10.0"
+      minradialdistort="40.0"
+      maxradialdistort="80.0"
+      dialogflag="OpiateWithdrawalHigh"
+      minfacetint="255,255,255,100"
+      maxfacetint="255,255,255,150"
+      minspeedmultiplier="0.8"
+      maxspeedmultiplier="0.5">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <Affliction identifier="nausea" strength="30" probability="0.25" />
+      </StatusEffect>
+    </Effect>
+
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="512,768,128,128" color="209,121,84,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="Opiate overdose"
+    identifier="opiateoverdose"
+    description="The patient has pinpoint pupils and icy cold skin. They struggle to breathe and swallow."
+    type="debuff"
+    causeofdeathdescription="Died of opiate overdose"
+    selfcauseofdeathdescription="You have died of opiate overdose."
+    limbspecific="false"
+    indicatorlimb="Head"
+    showiconthreshold="50"
+    showinhealthscannerthreshold="5"
+    treatmentthreshold="50"
+    karmachangeonapplied="-1"
+    maxstrength="100"
+    affectmachines="false"
+    healcostmultiplier="1.25">
+    <Description
+      textidentifier="afflictiondescription.opiateoverdose.self"
+      target="Self" />
+    <Description
+      textidentifier="afflictiondescription.opiateoverdose"
+      target="OtherCharacter" />
+    <!-- No effects except slight distortion at this level -->
+    <Effect minstrength="0" maxstrength="50"
+      strengthchange="-0.5"
+      minchromaticaberration="0.0"
+      maxchromaticaberration="1.0">
+    </Effect>
+
+    <!-- Starts to become lethal when strength is above 50 -->
+    <Effect minstrength="50" maxstrength="100"
+      minvitalitydecrease="0"
+      maxvitalitydecrease="200"
+      minscreendistort="0.0"
+      maxscreendistort="3.0"
+      strengthchange="-0.5"
+      minchromaticaberration="0.0"
+      maxchromaticaberration="10.0"
+      minradialdistort="0.0"
+      maxradialdistort="10.0"
+      minspeedmultiplier="1.0"
+      maxspeedmultiplier="0.5">
+    </Effect>
+
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="640,768,128,128" color="103,103,103,255" origin="0,0"/>
+  </Affliction>
+
+  <!-- Gradually applies the "opiate withdrawal" affliction to the character -->
+  <Affliction
+    name="Opiate addiction"
+    identifier="opiateaddiction"
+    description="The patient is happy enough... so long as they get what they need."
+    type="debuff"
+    limbspecific="false"
+    indicatorlimb="Head"
+    showiconthreshold="20"
+    showinhealthscannerthreshold="5"
+    treatmentthreshold="1000"
+    maxstrength="100"
+    affectmachines="false"
+    karmachangeonapplied="-0.1"
+    achievementonremoved="healopiateaddiction"
+    healcostmultiplier="2.85">
+    <Description
+      textidentifier="afflictiondescription.opiateaddiction.self"
+      target="Self" />
+    <Description
+      textidentifier="afflictiondescription.opiateaddiction"
+      target="OtherCharacter" />
+    <Effect minstrength="0" maxstrength="20" strengthchange="-0.05"/>
+
+    <Effect minstrength="20" maxstrength="40" strengthchange="-0.05">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <Affliction identifier="opiatewithdrawal" strength="0.15"/>
+      </StatusEffect>
+    </Effect>
+
+    <Effect minstrength="40" maxstrength="80" strengthchange="-0.1">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <Affliction identifier="opiatewithdrawal" strength="0.25"/>
+      </StatusEffect>
+    </Effect>
+
+    <Effect minstrength="80" maxstrength="100" strengthchange="-0.1"
+      minvitalitydecrease="0"
+      maxvitalitydecrease="20">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <Affliction identifier="opiatewithdrawal" strength="0.5"/>
+      </StatusEffect>
+    </Effect>
+
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="384,768,128,128" color="195,180,60,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="Radiation sickness"
+    identifier="radiationsickness"
+    description="Burns and sores can be seen on patient's skin. They seem to be spreading."
+    type="poison"
+    causeofdeathdescription="Died of radiation sickness."
+    selfcauseofdeathdescription="You have died of radiation sickness."
+    limbspecific="false"
+    indicatorlimb="Torso"
+    showiconthreshold="25"
+    showinhealthscannerthreshold="5"
+    karmachangeonapplied="-1"
+    treatmentthreshold="25"
+    maxstrength="200"
+    affectmachines="false"
+    grainburst="3"
+    healcostmultiplier="4.0"
+    MedicalSkillGain="1.0">
+    <Description
+      textidentifier="afflictiondescription.radiationsickness.low.self"
+      target="Self"
+      minstrength="0"
+      maxstrength="75"/>
+    <Description
+      textidentifier="afflictiondescription.radiationsickness.high.self"
+      target="Self"
+      minstrength="75"
+      maxstrength="200"/>
+    <Description
+      textidentifier="afflictiondescription.radiationsickness"
+      target="OtherCharacter"
+      minstrength="0"
+      maxstrength="75"/>
+    <Description
+      textidentifier="afflictiondescription.radiationsickness.high"
+      target="OtherCharacter"
+      minstrength="75"
+      maxstrength="200"/>
+    <!-- No effects at this level  -->
+    <Effect minstrength="0" maxstrength="25" strengthchange="-0.07" />
+    <!-- Cause burns depending on strength -->
+    <Effect minstrength="25" maxstrength="50" mingrainstrength="0.5" maxgrainstrength="0.25" strengthchange="-0.07">
+      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true" interval="0.1" disabledeltatime="true">
+        <Affliction identifier="burn" amount="0.006" />
+      </StatusEffect>
+    </Effect>
+
+    <Effect minstrength="50" maxstrength="75" mingrainstrength="1.0" maxgrainstrength="0.5" strengthchange="-0.07"
+      minchromaticaberration="0.0"
+      maxchromaticaberration="1.0"
+      minbodytint="255,0,0,0"
+      maxbodytint="255,0,0,30">
+      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true" interval="0.1" disabledeltatime="true">
+        <Affliction identifier="burn" amount="0.0115" />
+        <!-- nausea decreases by 1 per second, so effectively this increases it by 0.05 -->
+        <Affliction identifier="nausea" amount="0.105" />
+      </StatusEffect>
+    </Effect>
+
+    <Effect minstrength="75" maxstrength="100" mingrainstrength="1.0" maxgrainstrength="0.75" strengthchange="-0.07"
+      minchromaticaberration="1.0"
+      maxchromaticaberration="5.0"
+      minbodytint="255,0,0,30"
+      maxbodytint="255,0,0,60">
+      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true" interval="0.1" disabledeltatime="true">
+        <Affliction identifier="burn" amount="0.0235" />
+        <Affliction identifier="nausea" amount="0.11" />
+      </StatusEffect>
+    </Effect>
+
+    <Effect minstrength="100" maxstrength="125" mingrainstrength="1.0" maxgrainstrength="1.0" strengthchange="-0.07"
+      minchromaticaberration="1.0"
+      maxchromaticaberration="5.0"
+      minbodytint="255,0,0,60"
+      maxbodytint="255,0,0,90">
+      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true" interval="0.1" disabledeltatime="true">
+        <Affliction identifier="burn" amount="0.0395" />
+        <Affliction identifier="nausea" amount="0.12" />
+      </StatusEffect>
+    </Effect>
+
+    <Effect minstrength="125" maxstrength="150" mingrainstrength="1.0" maxgrainstrength="1.0" strengthchange="-0.07"
+      minchromaticaberration="1.0"
+      maxchromaticaberration="5.0"
+      minbodytint="255,0,0,90"
+      maxbodytint="255,0,0,120">
+      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true" interval="0.1" disabledeltatime="true">
+        <Affliction identifier="burn" amount="0.0555" />
+        <Affliction identifier="nausea" amount="0.14" />
+      </StatusEffect>
+    </Effect>
+
+    <Effect minstrength="150" maxstrength="175" mingrainstrength="1.0" maxgrainstrength="1.0" strengthchange="-0.07"
+      minchromaticaberration="1.0"
+      maxchromaticaberration="5.0"
+      minbodytint="255,0,0,120"
+      maxbodytint="255,0,0,150">
+      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true" interval="0.1" disabledeltatime="true">
+        <Affliction identifier="burn" amount="0.0715" />
+        <Affliction identifier="nausea" amount="0.16" />
+      </StatusEffect>
+    </Effect>
+
+    <Effect minstrength="175" maxstrength="200" mingrainstrength="1.0" maxgrainstrength="0.1" strengthchange="-0.07"
+      minchromaticaberration="0.1"
+      maxchromaticaberration="0.5"
+      minbodytint="255,0,0,150"
+      maxbodytint="255,0,0,180">
+      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true" interval="0.1" disabledeltatime="true">
+        <Affliction identifier="burn" amount="0.0875" />
+        <Affliction identifier="nausea" amount="0.18" />
+      </StatusEffect>
+    </Effect>
+
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="896,768,128,128" color="195,136,60,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="Morbusine poisoning"
+    identifier="morbusinepoisoning"
+    description="Gradually progressing, movement hindering and relatively quick poisoning."
+    type="poison"
+    causeofdeathdescription="Died of morbusine poisoning."
+    selfcauseofdeathdescription="You have died of morbusine poisoning."
+    limbspecific="false"
+    indicatorlimb="Torso"
+    showiconthreshold="40"
+    showinhealthscannerthreshold="20"
+    treatmentthreshold="40"
+    karmachangeonapplied="-100"
+    maxstrength="100"
+    affectmachines="false"
+    healcostmultiplier="0"
+    basehealcost="300"
+    MedicalSkillGain="3.0">
+    <Description
+      textidentifier="afflictiondescription.morbusinepoisoning.low.self"
+      target="Self"
+      minstrength="0"
+      maxstrength="50"/>
+    <Description
+      textidentifier="afflictiondescription.morbusinepoisoning.high.self"
+      target="Self"
+      minstrength="50"
+      maxstrength="100"/>
+    <Description
+      textidentifier="afflictiondescription.morbusinepoisoning.low"
+      target="OtherCharacter"
+      minstrength="0"
+      maxstrength="50"/>
+    <Description
+      textidentifier="afflictiondescription.morbusinepoisoning"
+      target="OtherCharacter"
+      minstrength="50"
+      maxstrength="100"/>
+    <!-- Reduce oxygen intake for the victim, cause suffocation -->
+    <!-- Wears off slowly if the strength is less than 10 -->
+    <Effect minstrength="0" maxstrength="10"
+      strengthchange="-0.25"
+      minchromaticaberration="0.0"
+      maxchromaticaberration="0.2"
+      minspeedmultiplier="1.0"
+      maxspeedmultiplier="0.9">
+      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true">
+        <Affliction identifier="oxygenlow" amount="12" />
+      </StatusEffect>
+    </Effect>
+    <!-- lethal after str 10 -->
+    <Effect minstrength="10" maxstrength="20"
+      strengthchange="1"
+      minscreendistort="0.1"
+      maxscreendistort="0.1"
+      minchromaticaberration="0.2"
+      maxchromaticaberration="0.2"
+      minspeedmultiplier="0.9"
+      maxspeedmultiplier="0.9"
+      tag="poisoned">
+      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true">
+        <!-- Don't suffocate just yet-->
+        <Affliction identifier="oxygenlow" amount="11" />
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="20" maxstrength="75"
+      strengthchange="1"
+      minscreendistort="0.1"
+      maxscreendistort="1.0"
+      minchromaticaberration="0.2"
+      maxchromaticaberration="2.0"
+      minspeedmultiplier="0.9"
+      maxspeedmultiplier="0.5"
+      tag="poisoned">
+      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true">
+        <Affliction identifier="oxygenlow" amount="11" />
+      </StatusEffect>
+      <StatusEffect target="Character">
+        <Conditional NeedsAir="false"/>
+        <Affliction identifier="organdamage" amount="4" />
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="75" maxstrength="99"
+      strengthchange="1"
+      minscreendistort="1.0"
+      maxscreendistort="1.0"
+      minchromaticaberration="2.0"
+      maxchromaticaberration="2.0"
+      minspeedmultiplier="0.5"
+      maxspeedmultiplier="0.2"
+      tag="poisoned">
+      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true">
+        <Affliction identifier="oxygenlow" amount="12" />
+      </StatusEffect>
+      <StatusEffect target="Character">
+        <Conditional NeedsAir="false"/>
+        <Affliction identifier="organdamage" amount="10" />
+      </StatusEffect>
+      <StatusEffect target="Character" setvalue="true">
+        <Conditional healthpercentage="lt 75"/>
+        <Affliction identifier="stun" amount="1" />
+      </StatusEffect>     
+    </Effect>
+    <Effect minstrength="99" maxstrength="100"
+      strengthchange="1"
+      minscreendistort="1.0"
+      maxscreendistort="1.0"
+      minchromaticaberration="2.0"
+      maxchromaticaberration="2.0"
+      minspeedmultiplier="0.5"
+      maxspeedmultiplier="0.2"
+      tag="poisoned">
+      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true">
+        <Affliction identifier="oxygenlow" amount="12" />
+      </StatusEffect>
+      <StatusEffect target="Character">
+        <Conditional NeedsAir="false"/>
+        <Affliction identifier="organdamage" amount="45" />
+      </StatusEffect>
+      <StatusEffect target="Character" interval="1" disabledeltatime="true" multiplyafflictionsbymaxvitality="true" ConditionalComparison="And">
+        <Conditional IsHuman="false"/>
+        <Conditional healthpercentage="gt 50"/>
+        <Affliction identifier="morbusinepoisoning" amount="-9999" probability="0.1" />
+      </StatusEffect>
+      <StatusEffect target="Character" setvalue="true">
+        <Conditional healthpercentage="lt 90"/>
+        <Affliction identifier="stun" amount="1" />
+      </StatusEffect>
+    </Effect>
+    <PeriodicEffect mininterval="30" maxinterval="60" minstrength="30" maxstrength="100">
+      <StatusEffect target="Character" multiplybymaxvitality="true">
+        <Affliction identifier="stun" amount="5" />
+      </StatusEffect>
+    </PeriodicEffect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="640,640,128,128" color="106,106,106,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="Sufforin Poisoning"
+    identifier="sufforinpoisoning"
+    description="Sneaky, slowly progressing poisoning that eventually leads to death."
+    type="poison"
+    causeofdeathdescription="Died of sufforin poisoning."
+    selfcauseofdeathdescription="You have died of sufforin poisoning."
+    limbspecific="false"
+    indicatorlimb="Torso"
+    showiconthreshold="75"
+    showinhealthscannerthreshold="50"
+    treatmentthreshold="75"
+    karmachangeonapplied="-50"
+    maxstrength="100"
+    affectmachines="false"
+    healcostmultiplier="0"
+    basehealcost="100"
+    MedicalSkillGain="1.5">
+    <Description
+      textidentifier="afflictiondescription.sufforinpoisoning.medium.self"
+      target="Self"
+      minstrength="0"
+      maxstrength="100"/>
+    <Description
+      textidentifier="afflictiondescription.sufforinpoisoning.low"
+      target="OtherCharacter"
+      minstrength="0"
+      maxstrength="25"/>
+    <Description
+      textidentifier="afflictiondescription.sufforinpoisoning"
+      target="OtherCharacter"
+      minstrength="25"
+      maxstrength="50"/>
+    <Description
+      textidentifier="afflictiondescription.sufforinpoisoning.high"
+      target="OtherCharacter"
+      minstrength="50"
+      maxstrength="100"/>
+    <Effect minstrength="0" maxstrength="10"
+      strengthchange="-0.25"
+      minscreenblur="0.0"
+      maxscreenblur="0.1">
+    </Effect>
+    <Effect minstrength="10" maxstrength="50"
+      strengthchange="0.5"
+      minscreenblur="0.1"
+      maxscreenblur="0.2">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <ReduceAffliction identifier="huskinfection" amount="0.5" />
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="50" maxstrength="75"
+      strengthchange="1"
+      minscreenblur="0.1"
+      maxscreenblur="1.0"
+      minfacetint="255,255,0,0"
+      maxfacetint="255,255,0,80"
+      minbodytint="255,255,0,0"
+      maxbodytint="255,255,0,60"
+      minspeedmultiplier="1.0"
+      maxspeedmultiplier="0.8"
+      tag="poisoned">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <ReduceAffliction identifier="huskinfection" amount="2" />
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="75" maxstrength="99"
+      strengthchange="1"
+      minscreenblur="1.0"
+      maxscreenblur="2.0"
+      minscreendistort="0.0"
+      maxscreendistort="1.0"
+      minfacetint="255,255,0,80"
+      maxfacetint="255,255,0,80"
+      minbodytint="255,255,0,60"
+      maxbodytint="255,255,0,60"
+      minspeedmultiplier="0.8"
+      maxspeedmultiplier="0.8"
+      tag="poisoned">
+      <StatusEffect target="Character">
+        <Affliction identifier="organdamage" amount="5" />
+      </StatusEffect>
+      <StatusEffect target="Character" setvalue="true">
+        <Conditional healthpercentage="lt 90"/>
+        <Affliction identifier="stun" amount="1" />
+      </StatusEffect>
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <ReduceAffliction identifier="huskinfection" amount="5" />
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="99" maxstrength="100"
+      strengthchange="1"
+      minscreenblur="2.0"
+      maxscreenblur="2.0"
+      minscreendistort="1.0"
+      maxscreendistort="1.0"
+      minfacetint="255,255,0,80"
+      maxfacetint="255,255,0,80"
+      minbodytint="255,255,0,60"
+      maxbodytint="255,255,0,60"
+      minspeedmultiplier="0.8"
+      maxspeedmultiplier="0.8"
+      tag="poisoned">
+      <StatusEffect target="Character" setvalue="true">
+        <Conditional healthpercentage="lt 90"/>
+        <Affliction identifier="stun" amount="1" />
+      </StatusEffect>
+      <StatusEffect target="Character">
+        <Affliction identifier="organdamage" amount="10" />
+      </StatusEffect>
+      <StatusEffect target="Character" interval="1" disabledeltatime="true" multiplyafflictionsbymaxvitality="true" ConditionalComparison="And">
+        <Conditional IsHuman="false"/>
+        <Conditional healthpercentage="gt 50"/>
+        <Affliction identifier="sufforinpoisoning" amount="-9999" probability="0.1" />
+      </StatusEffect>
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <ReduceAffliction identifier="huskinfection" amount="100" />
+      </StatusEffect>
+    </Effect>
+    <PeriodicEffect mininterval="1" maxinterval="3" minstrength="60" maxstrength="100">
+      <StatusEffect target="Character" multiplybymaxvitality="true">
+        <Affliction identifier="nausea" amount="50" probability="0.25" />
+      </StatusEffect>
+    </PeriodicEffect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="640,640,128,128" color="106,106,106,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="Deliriumine Poisoning"
+    identifier="deliriuminepoisoning"
+    description="Patient is hallucinating and exhibits paranoia."
+    type="poison"
+    limbspecific="false"
+    indicatorlimb="Torso"
+    showiconthreshold="1000"
+    showicontoothersthreshold="50"
+    showinhealthscannerthreshold="20"
+    treatmentthreshold="100"
+    karmachangeonapplied="-25"
+    maxstrength="100"
+    affectmachines="false"
+    healcostmultiplier="0"
+    basehealcost="100"
+    MedicalSkillGain="3.0">
+    <Description
+      textidentifier="afflictiondescription.deliriuminepoisoning.high.self"
+      target="Self"
+      minstrength="0"
+      maxstrength="100"/>
+    <Description
+      textidentifier="afflictiondescription.deliriuminepoisoning"
+      target="OtherCharacter"
+      minstrength="0"
+      maxstrength="50"/>
+    <Description
+      textidentifier="afflictiondescription.deliriuminepoisoning.high"
+      target="OtherCharacter"
+      minstrength="50"
+      maxstrength="100"/>
+    <!-- Wears off slowly if the strength is less than 10 -->
+    <Effect minstrength="0" maxstrength="10" strengthchange="-0.25">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <Affliction identifier="psychosis" amount="1" />
+      </StatusEffect>
+    </Effect>
+    <!-- Slowly cause psychosis -->
+    <!-- Non-lethal -->
+    <Effect minstrength="10" maxstrength="100" strengthchange="1">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <Affliction identifier="psychosis" amount="1" />
+      </StatusEffect>
+    </Effect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="640,640,128,128" color="106,106,106,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="Cyanide poisoning"
+    identifier="cyanidepoisoning"
+    description="Rapid death"
+    type="poison"
+    causeofdeathdescription="Died of cyanide poisoning."
+    selfcauseofdeathdescription="You have died of cyanide poisoning."
+    limbspecific="false"
+    indicatorlimb="Torso"
+    showiconthreshold="30"
+    showinhealthscannerthreshold="15"
+    treatmentthreshold="30"
+    karmachangeonapplied="-100"
+    maxstrength="100"
+    affectmachines="false"
+    healcostmultiplier="0"
+    basehealcost="500"
+    MedicalSkillGain="4.0">
+    <Description
+      textidentifier="afflictiondescription.cyanidepoisoning.medium.self"
+      target="Self"
+      minstrength="0"
+      maxstrength="50"/>
+    <Description
+      textidentifier="afflictiondescription.cyanidepoisoning.high.self"
+      target="Self"
+      minstrength="50"
+      maxstrength="100"/>
+    <Description
+      textidentifier="afflictiondescription.cyanidepoisoning.low"
+      target="OtherCharacter"
+      minstrength="0"
+      maxstrength="30"/>
+    <Description
+      textidentifier="afflictiondescription.cyanidepoisoning"
+      target="OtherCharacter"
+      minstrength="30"
+      maxstrength="60"/>
+    <Description
+      textidentifier="afflictiondescription.cyanidepoisoning.high"
+      target="OtherCharacter"
+      minstrength="60"
+      maxstrength="100"/>
+    <Effect minstrength="0" maxstrength="10"
+      strengthchange="-0.25"
+      minscreendistort="0.0"
+      maxscreendistort="0.4"
+      minscreenblur="0.0"
+      maxscreenblur="0.4"
+      minfacetint="0,100,180,0"
+      maxfacetint="0,100,180,20">
+      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true">
+        <Affliction identifier="oxygenlow" amount="11" />
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="10" maxstrength="30"
+      strengthchange="2"
+      minscreendistort="0.4"
+      maxscreendistort="0.0"
+      minscreenblur="0.4"
+      maxscreenblur="0.0"
+      minfacetint="0,100,180,20"
+      maxfacetint="0,100,180,40"
+      minbodytint="0,100,180,0"
+      maxbodytint="0,100,180,20"
+      minspeedmultiplier="1.0"
+      maxspeedmultiplier="0.9">
+      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true">
+        <Affliction identifier="oxygenlow" amount="11" />
+      </StatusEffect>
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <ReduceAffliction identifier="huskinfection" amount="4" />
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="30" maxstrength="50"
+      strengthchange="3"
+      minscreendistort="0.0"
+      maxscreendistort="0.8"
+      minscreenblur="0.0"
+      maxscreenblur="0.8"
+      minfacetint="0,100,180,40"
+      maxfacetint="0,100,180,60"
+      minbodytint="0,100,180,0"
+      maxbodytint="0,100,180,40"
+      minspeedmultiplier="0.9"
+      maxspeedmultiplier="0.7">
+      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true">
+        <Affliction identifier="oxygenlow" amount="10" />
+      </StatusEffect>
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <ReduceAffliction identifier="huskinfection" amount="8" />
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="50" maxstrength="75"
+      strengthchange="4"
+      minscreendistort="0.8"
+      maxscreendistort="1.0"
+      minscreenblur="0.8"
+      maxscreenblur="1.0"
+      minfacetint="0,100,180,60"
+      maxfacetint="0,100,180,100"
+      minbodytint="0,100,180,40"
+      maxbodytint="0,100,180,80"
+      minspeedmultiplier="0.7"
+      maxspeedmultiplier="0.7"
+      tag="poisoned">
+      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true">
+        <Affliction identifier="oxygenlow" amount="10" />
+      </StatusEffect>
+      <StatusEffect target="Character" setvalue="true">
+        <Conditional healthpercentage="lt 75"/>
+        <Affliction identifier="stun" amount="1" />
+      </StatusEffect>
+      <StatusEffect target="Character">
+        <Affliction identifier="organdamage" amount="10" />
+      </StatusEffect>
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <ReduceAffliction identifier="huskinfection" amount="20" />
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="75" maxstrength="99"
+      strengthchange="5"
+      minscreendistort="1.0"
+      maxscreendistort="1.0"
+      minscreenblur="1.0"
+      maxscreenblur="1.0"
+      minfacetint="0,100,180,100"
+      maxfacetint="0,100,180,100"
+      minbodytint="0,100,180,80"
+      maxbodytint="0,100,180,80"
+      minspeedmultiplier="0.7"
+      maxspeedmultiplier="0.7"
+      tag="poisoned">
+      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true">
+        <Affliction identifier="oxygenlow" amount="10" />
+      </StatusEffect>
+      <StatusEffect target="Character" setvalue="true">
+        <Conditional healthpercentage="lt 90"/>
+        <Affliction identifier="stun" amount="1" />
+      </StatusEffect>
+      <StatusEffect target="Character">
+        <Affliction identifier="organdamage" amount="30" />
+      </StatusEffect>
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <ReduceAffliction identifier="huskinfection" amount="50" />
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="99" maxstrength="100"
+      strengthchange="5"
+      minscreendistort="1.0"
+      maxscreendistort="1.0"
+      minscreenblur="1.0"
+      maxscreenblur="1.0"
+      minfacetint="0,100,180,100"
+      maxfacetint="0,100,180,100"
+      minbodytint="0,100,180,80"
+      maxbodytint="0,100,180,80"
+      minspeedmultiplier="0.7"
+      maxspeedmultiplier="0.7"
+      tag="poisoned">
+      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true">
+        <Affliction identifier="oxygenlow" amount="10" />
+      </StatusEffect>
+      <StatusEffect target="Character" setvalue="true">
+        <Conditional healthpercentage="lt 90"/>
+        <Affliction identifier="stun" amount="1" />
+      </StatusEffect>
+      <StatusEffect target="Character">
+        <Affliction identifier="organdamage" amount="60" />
+      </StatusEffect>
+      <StatusEffect target="Character" interval="1" disabledeltatime="true" multiplyafflictionsbymaxvitality="true" ConditionalComparison="And">
+        <Conditional IsHuman="false"/>
+        <Conditional healthpercentage="gt 50"/>
+        <Affliction identifier="cyanidepoisoning" amount="-9999" probability="0.075" />
+      </StatusEffect>
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <ReduceAffliction identifier="huskinfection" amount="100" />
+      </StatusEffect>
+    </Effect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="640,640,128,128" color="106,106,106,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="Paralysis"
+    identifier="paralysis"
+    type="paralysis"
+    limbspecific="false"
+    indicatorlimb="Torso"
+    showiconthreshold="30"
+    showinhealthscannerthreshold="15"
+    treatmentthreshold="20"
+    karmachangeonapplied="-50"
+    maxstrength="100"
+    affectmachines="false"
+    healcostmultiplier="2.75"
+    MedicalSkillGain="3.0">
+    <Description
+      textidentifier="afflictiondescription.paralysis.low.self"
+      target="Self"
+      minstrength="0"
+      maxstrength="99"/>
+    <Description
+      textidentifier="afflictiondescription.paralysis.high.self"
+      target="Self"
+      minstrength="99"
+      maxstrength="100"/>
+    <Description
+      textidentifier="afflictiondescription.paralysis"
+      target="OtherCharacter"
+      minstrength="0"
+      maxstrength="99"/>
+    <Description
+      textidentifier="afflictiondescription.paralysis.high"
+      target="OtherCharacter"
+      minstrength="99"
+      maxstrength="100"/>
+    <!-- Slow the character down and paralyze in the end-->
+    <Effect minstrength="0" maxstrength="10"
+      strengthchange="-0.25"
+      minscreendistort="0.0"
+      maxscreendistort="0.1"
+      minscreenblur="0.0"
+      maxscreenblur="0.1"
+      minspeedmultiplier="1.0"
+      maxspeedmultiplier="0.9">
+    </Effect>
+    <Effect minstrength="10" maxstrength="99"
+      strengthchange="4"
+      minscreendistort="0.1"
+      maxscreendistort="0.8"
+      minscreenblur="0.1"
+      maxscreenblur="0.8"
+      minspeedmultiplier="0.9"
+      maxspeedmultiplier="0.1">
+    </Effect>
+    <Effect minstrength="99" maxstrength="100"
+      strengthchange="1"
+      minscreendistort="0.8"
+      maxscreendistort="0.8"
+      minscreenblur="0.8"
+      maxscreenblur="0.8"
+      minspeedmultiplier="0.1"
+      maxspeedmultiplier="0.1">
+      <StatusEffect target="Character" setvalue="true">
+        <Affliction identifier="stun" amount="1" />
+      </StatusEffect>
+      <StatusEffect target="Character" interval="1" disabledeltatime="true" multiplyafflictionsbymaxvitality="true" ConditionalComparison="And">
+        <Conditional IsHuman="false"/>
+        <Conditional maxhealth="gt 1000"/>
+        <Affliction identifier="paralysis" amount="-9999" probability="0.05" />
+      </StatusEffect>
+    </Effect>
+    <PeriodicEffect mininterval="15" maxinterval="30" minstrength="50" maxstrength="100">
+      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true">
+        <Affliction identifier="stun" amount="1.0" />
+      </StatusEffect>
+    </PeriodicEffect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="640,640,128,128" color="0,255,0,255" origin="0,0"/>
+  </Affliction>
+
+  <!-- A variant of paralysis that progresses a bit slower. Applied by Leucocytes. -->
+  <Affliction
+    name="Paralysis"
+    identifier="slowparalysis"
+    nameidentifier="paralysis"
+    type="paralysis"
+    limbspecific="false"
+    indicatorlimb="Torso"
+    showiconthreshold="30"
+    showinhealthscannerthreshold="15"
+    treatmentthreshold="20"
+    karmachangeonapplied="-50"
+    maxstrength="100"
+    affectmachines="false"
+    healcostmultiplier="2.75"
+    MedicalSkillGain="3.0">
+    <Description
+      textidentifier="afflictiondescription.paralysis.low.self"
+      target="Self"
+      minstrength="0"
+      maxstrength="99"/>
+    <Description
+      textidentifier="afflictiondescription.paralysis.high.self"
+      target="Self"
+      minstrength="99"
+      maxstrength="100"/>
+    <Description
+      textidentifier="afflictiondescription.paralysis"
+      target="OtherCharacter"
+      minstrength="0"
+      maxstrength="99"/>
+    <Description
+      textidentifier="afflictiondescription.paralysis.high"
+      target="OtherCharacter"
+      minstrength="99"
+      maxstrength="100"/>
+    <!-- Slow the character down and paralyze in the end-->
+    <Effect minstrength="0" maxstrength="10"
+      strengthchange="-0.25"
+      minscreendistort="0.0"
+      maxscreendistort="0.1"
+      minscreenblur="0.0"
+      maxscreenblur="0.1"
+      minspeedmultiplier="1.0"
+      maxspeedmultiplier="0.9">
+    </Effect>
+    <Effect minstrength="10" maxstrength="99"
+      strengthchange="1"
+      minscreendistort="0.1"
+      maxscreendistort="0.8"
+      minscreenblur="0.1"
+      maxscreenblur="0.8"
+      minspeedmultiplier="0.9"
+      maxspeedmultiplier="0.1">
+      <StatusEffect target="Character">
+        <TriggerAnimation Type="Walk" filename="DrunkenWalk" priority="1" ExpectedSpecies="Human" />
+        <TriggerAnimation Type="Run" filename="DrunkenRun" priority="1" ExpectedSpecies="Human" />
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="99" maxstrength="100"
+      strengthchange="1"
+      minscreendistort="0.8"
+      maxscreendistort="0.8"
+      minscreenblur="0.8"
+      maxscreenblur="0.8"
+      minspeedmultiplier="0.1"
+      maxspeedmultiplier="0.1">
+      <StatusEffect target="Character" setvalue="true">
+        <Affliction identifier="stun" amount="1" />
+        <TriggerAnimation Type="Walk" filename="DrunkenWalk" priority="4" ExpectedSpecies="Human" />
+        <TriggerAnimation Type="Run" filename="DrunkenRun" priority="4" ExpectedSpecies="Human" />
+      </StatusEffect>
+      <StatusEffect target="Character" interval="1" disabledeltatime="true" multiplyafflictionsbymaxvitality="true" ConditionalComparison="And">
+        <Conditional IsHuman="false"/>
+        <Conditional maxhealth="gt 1000"/>
+        <Affliction identifier="slowparalysis" amount="-9999" probability="0.05" />
+      </StatusEffect>
+    </Effect>
+    <PeriodicEffect mininterval="15" maxinterval="30" minstrength="50" maxstrength="100">
+      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true">
+        <Affliction identifier="stun" amount="1.0" />
+      </StatusEffect>
+    </PeriodicEffect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="640,640,128,128" color="0,255,0,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="Zapped"
+    identifier="electricshock"
+    type="stun"
+    limbspecific="false"
+    indicatorlimb="Torso"
+    showiconthreshold="10"
+    showinhealthscannerthreshold="10"
+    karmachangeonapplied="-10"
+    maxstrength="100"
+    WeaponsSkillGain="1.0"
+    iconcolors="60,140,195,255;60,107,195,255;60,0,195,255">
+    <!-- Used incrementally -> apply a set amount of affliction per hit until value > 90, then wear off gradually. -->
+    <!-- Value above 90 equals stun. Each point over 90 equals one second of stun. -->
+    <!-- For example, 95 causes 5 seconds of stun, then target starts recovering. -->
+    <Effect minstrength="0" maxstrength="90"
+      minscreenblur="0"
+      maxscreenblur="0.2"
+      minscreendistort="0.0"
+      maxscreendistort="0.2"
+      minradialdistort="0"
+      maxradialdistort="0.1"
+      strengthchange="-5"
+      minspeedmultiplier="1.0"
+      maxspeedmultiplier="0.3">
+    </Effect>
+    <PeriodicEffect minstrength="40" maxstrength="90" mininterval="0.12" maxinterval="0.15">
+      <StatusEffect target="Character" duration="0.1">
+        <TriggerAnimation Type="Walk" filename="Spasm" priority="10" ExpectedSpecies="Human" />
+        <TriggerAnimation Type="Run" filename="SpasmRun" priority="10" ExpectedSpecies="Human" />
+      </StatusEffect>
+    </PeriodicEffect>
+    <Effect minstrength="90" maxstrength="100"
+      minscreendistort="0.6"
+      maxscreendistort="1"
+      minscreenblur="1"
+      maxscreenblur="1"
+      minradialdistort="0.2"
+      maxradialdistort="1"
+      strengthchange="-10">
+      <StatusEffect target="Character" setvalue="true">
+        <Conditional mass="lt 300" />
+        <Affliction identifier="stun" amount="2" />
+        <ReduceAffliction identifier="electricshock" strength="75" />
+        <Affliction identifier="electricshockwearoff" amount="4" />
+      </StatusEffect>
+      <StatusEffect target="Character" setvalue="true">
+        <!-- Scale the stun with the mass of the character/creature hit. -->
+        <Conditional mass="lt 60" />
+        <Affliction identifier="stun" amount="6" />
+        <Affliction identifier="electricshockwearoff" amount="6" />
+      </StatusEffect>
+    </Effect>
+    <icon texture="Content/UI/CommandUIBackground.png" sourcerect="770,768,128,128" color="0,255,0,255" origin="0,0"/>
+  </Affliction>
+  
+  <Affliction
+    name="Woozy"
+    identifier="electricshockwearoff"
+    limbspecific="false"
+    type="debuff"
+    activationthreshold="0"
+    showiconthreshold="1000"
+    showicontoothersthreshold="1000"
+    showinhealthscannerthreshold="1000"
+    affectmachines="false"
+    maxstrength="10">
+    <Effect minstrength="0" maxstrength="10"
+      minscreendistort="0.0"
+      maxscreendistort="0.2"
+      minscreenblur="0.0"
+      maxscreenblur="0.2"
+      strengthchange="-1.0">
+      <StatusEffect target="Character">
+        <Affliction identifier="nausea" amount="3" />
+        <Affliction identifier="slow" amount="20" />
+      </StatusEffect>
+    </Effect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="256,640,128,128" color="150,26,26,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="IncrementalStun"
+    identifier="incrementalstun"
+    type="stun"
+    limbspecific="false"
+    indicatorlimb="Torso"
+    showiconthreshold="1000"
+    showinhealthscannerthreshold="1000"
+    karmachangeonapplied="-10"
+    maxstrength="100"
+    WeaponsSkillGain="1.0">
+    <!-- Used incrementally -> apply a set amount of affliction per hit until value > 90, then wear off gradually. -->
+    <!-- Value above 90 equals stun. Each point over 90 equals one second of stun. -->
+    <!-- For example, 95 causes 5 seconds of stun, then target starts recovering. -->
+    <Effect minstrength="0" maxstrength="90"
+      minscreenblur="0"
+      maxscreenblur="1.0"
+      minscreendistort="0.0"
+      maxscreendistort="0.6"
+      minradialdistort="0"
+      maxradialdistort="0.2"
+      strengthchange="-5"
+      minspeedmultiplier="1.0"
+      maxspeedmultiplier="0.3">
+    </Effect>
+    <Effect minstrength="90" maxstrength="100"
+      minscreendistort="0.6"
+      maxscreendistort="1"
+      minscreenblur="1"
+      maxscreenblur="1"
+      minradialdistort="0.2"
+      maxradialdistort="1"
+      strengthchange="-1">
+      <StatusEffect target="Character" setvalue="true">
+        <Affliction identifier="stun" amount="1" />
+        <TriggerAnimation Type="Walk" filename="DrunkenWalk" priority="1" ExpectedSpecies="Human" />
+        <TriggerAnimation Type="Run" filename="DrunkenRun" priority="1" ExpectedSpecies="Human" />
+      </StatusEffect>
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <Affliction identifier="nausea" amount="3" />
+      </StatusEffect>
+    </Effect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="640,640,128,128" color="0,255,0,255" origin="0,0"/>
+  </Affliction>
+
+  <!-- No longer in use, kept for backwards compatability-->
+  <Affliction
+    name="ProgressiveStun"
+    identifier="progressivestun"
+    type="stun"
+    limbspecific="false"
+    indicatorlimb="Torso"
+    showiconthreshold="1000"
+    showinhealthscannerthreshold="1000"
+    karmachangeonapplied="-10"
+    maxstrength="100"
+    WeaponsSkillGain="1.0">
+    <!-- Basically the same as IncrementalStun, but works the other way around: increases quite rapidly and then causes incremental stun that wears off progressively -->
+    <Effect minstrength="0" maxstrength="9"
+      minscreendistort="0.0"
+      maxscreendistort="0.05"
+      minscreenblur="0"
+      maxscreenblur="0.1"
+      strengthchange="2"
+      minradialdistort="0"
+      maxradialdistort="0.1"
+      minspeedmultiplier="1.0"
+      maxspeedmultiplier="0.9">
+    </Effect>
+    <Effect minstrength="9" maxstrength="99"
+      minscreendistort="0.05"
+      maxscreendistort="0.6"
+      minscreenblur="0.1"
+      maxscreenblur="1.0"
+      strengthchange="18"
+      minradialdistort="0.1"
+      maxradialdistort="1"
+      minspeedmultiplier="0.9"
+      maxspeedmultiplier="0.3">
+    </Effect>
+    <Effect minstrength="99" maxstrength="100"
+      minscreendistort="0.6"
+      maxscreendistort="1"
+      minscreenblur="1"
+      maxscreenblur="1"
+      minradialdistort="1"
+      maxradialdistort="1"
+      strengthchange="10"
+      minspeedmultiplier="0.3"
+      maxspeedmultiplier="0.3">
+      <StatusEffect target="Character" setvalue="true">
+        <ReduceAffliction identifier="progressivestun" strength="100" />
+        <Affliction identifier="incrementalstun" amount="100" />
+      </StatusEffect>
+    </Effect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="640,640,128,128" color="0,255,0,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="Nausea"
+    identifier="nausea"
+    description="The skin is clammy and the patient is vomiting periodically."
+    type="nausea"
+    causeofdeathdescription="Choked on vomit."
+    selfcauseofdeathdescription="You have choked on your own vomit."
+    limbspecific="false"
+    maxstrength="100"
+    affectmachines="false"
+    treatmentthreshold="1000"
+    karmachangeonapplied="-0.1"
+    damageoverlayalpha="0"
+    healcostmultiplier="2.25">
+    <Description
+      textidentifier="afflictiondescription.nausea"
+      target="OtherCharacter"
+      minstrength="0"
+      maxstrength="100"/>
+    <Description
+      textidentifier="afflictiondescription.nausea.low"
+      target="Self"
+      minstrength="0"
+      maxstrength="50"/>
+    <Description
+      textidentifier="afflictiondescription.nausea.high"
+      target="Self"
+      minstrength="50"
+      maxstrength="100"/>
+    <Effect minstrength="0" maxstrength="100" strengthchange="-1.0"
+      minfacetint="230,255,230,0"
+      maxfacetint="230,255,230,100"
+      minbodytint="230,255,230,0"
+      maxbodytint="230,255,230,50"
+      minspeedmultiplier="1.0"
+      maxspeedmultiplier="0.6">
+    </Effect>
+    <PeriodicEffect mininterval="12" maxinterval="16">
+      <StatusEffect target="Character" SpeedMultiplier="0.0" setvalue="true" duration="1.7" />
+      <StatusEffect target="Character" comparison="and">
+        <Conditional ishuman="true" />
+        <Conditional hasspecifiertag="male"/>
+        <Sound file="Content/Sounds/HUMAN_chokeMale1.ogg" selectionmode="Random" />
+        <Sound file="Content/Sounds/HUMAN_chokeMale2.ogg" />
+        <Sound file="Content/Sounds/HUMAN_chokeMale3.ogg" />
+      </StatusEffect>
+      <StatusEffect target="Character" comparison="and">
+        <Conditional ishuman="true" />
+        <Conditional hasspecifiertag="female"/>
+        <Sound file="Content/Sounds/HUMAN_chokeFemale1.ogg" selectionmode="Random" />
+        <Sound file="Content/Sounds/HUMAN_chokeFemale2.ogg" />
+        <Sound file="Content/Sounds/HUMAN_chokeFemale3.ogg" />
+      </StatusEffect>
+      <StatusEffect target="Character" duration="2">
+        <TriggerAnimation Type="Walk" filename="Vomit" priority="10" ExpectedSpecies="Human" />
+      </StatusEffect>
+      <StatusEffect target="Character">
+        <Affliction identifier="organdamage" strength="0.5"/>
+      </StatusEffect>
+      <StatusEffect target="Character" targetlimbs="Head" delay="0.3" duration="1">
+        <ParticleEmitter particle="vomitsplash" copyentityangle="true" anglemin="-10" anglemax="10" particlespersecond="50" velocitymin="50" velocitymax="200" scalemin="0.1" scalemax="0.2" />
+        <Conditional HideFace="eq False" />
+      </StatusEffect>
+      <StatusEffect target="Character" targetlimbs="Head" delay="0.5">
+        <Explosion range="0.0" structuredamage="0" itemdamage="0" force="0.0" severlimbsprobability="0.0" decal="vomitsplatter" decalsize="1.25" shockwave="false" underwaterbubble="false" />
+        <Conditional HideFace="eq False" />
+      </StatusEffect>
+    </PeriodicEffect>
+
+    <icon texture="Content/UI/CommandUIAtlas.png" sourcerect="896,896,128,128" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="Watcher's Gaze"
+    identifier="watchersgaze"
+    description=""
+    type="gaze"
+    limbspecific="false"
+    indicatorlimb="Head"
+    showiconthreshold="1000"
+    showicontoothersthreshold="40"
+    showinhealthscannerthreshold="20"
+    karmachangeonapplied="0"
+    maxstrength="100"
+    affectmachines="false">
+    <Description
+      textidentifier="afflictiondescription.watchersgaze.self"
+      target="Self" />
+    <Description
+      textidentifier="afflictiondescription.watchersgaze"
+      target="OtherCharacter" />
+    <Effect minstrength="0" maxstrength="50"
+      minscreendistort="0"
+      maxscreendistort="0.4"
+      minscreenblur="0"
+      maxscreenblur="0"
+      minradialdistort="0"
+      maxradialdistort="0.4"
+      minchromaticaberration="0"
+      maxchromaticaberration="0"
+      strengthchange="-4">
+      <StatusEffect target="Character" targetlimb="Head" SpeedMultiplier="1.1" HealthMultiplier="1.5" setvalue="true">
+        <Conditional speciesname="crawler" />
+        <Conditional speciesname="mudraptor" />
+        <Conditional speciesname="mudraptor_unarmored" />
+        <Conditional speciesname="mudraptor_veteran" />
+        <Conditional speciesname="tigerthresher" />
+        <Conditional speciesname="bonethresher" />
+        <ParticleEmitter particle="gazerage" particlespersecond="20" scalemin="0.3" scalemax="0.4" velocitymin="0" velocitymax="0" anglemin="0" anglemax="360" copyentityangle="false"/>
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="50" maxstrength="60"
+      minscreendistort="0.4"
+      maxscreendistort="0.5"
+      minscreenblur="0"
+      maxscreenblur="0.4"
+      minradialdistort="0.4"
+      maxradialdistort="0.5"
+      minchromaticaberration="0"
+      maxchromaticaberration="0"
+      strengthchange="-5">
+      <!-- the strength change is equal to the amount of watcher's gaze watchers cause, meaning one watcher will make the affliction stay in this range -->
+      <StatusEffect target="Character">
+        <Conditional ishuman="true" />
+        <Affliction identifier="nausea" strength="1" />
+        <Affliction identifier="psychosis" strength="1.5" />
+      </StatusEffect>
+      <StatusEffect target="Character" targetlimb="Head" SpeedMultiplier="1.2" HealthMultiplier="2" setvalue="true">
+        <Conditional speciesname="crawler" />
+        <Conditional speciesname="mudraptor" />
+        <Conditional speciesname="mudraptor_unarmored" />
+        <Conditional speciesname="mudraptor_veteran" />
+        <Conditional speciesname="tigerthresher" />
+        <Conditional speciesname="bonethresher" />
+        <ParticleEmitter particle="gazerage" particlespersecond="20" scalemin="0.4" scalemax="0.6" velocitymin="0" velocitymax="0" anglemin="0" anglemax="360" copyentityangle="false"/>
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="60" maxstrength="100"
+      minscreendistort="0.5"
+      maxscreendistort="1"
+      minscreenblur="0.5"
+      maxscreenblur="1.0"
+      minradialdistort="0.5"
+      maxradialdistort="2"
+      minchromaticaberration="0"
+      maxchromaticaberration="50"
+      strengthchange="-19">
+      <StatusEffect target="Character" SpeedMultiplier="0.2" setvalue="true">
+        <Conditional ishuman="true" />
+      </StatusEffect>
+      <StatusEffect target="Character">
+        <Conditional ishuman="true" />
+        <Affliction identifier="nausea" strength="2" />
+        <Affliction identifier="psychosis" strength="3" />
+      </StatusEffect>
+      <StatusEffect target="Character" targetlimb="Head" SpeedMultiplier="1.3" HealthMultiplier="3" setvalue="true">
+        <Conditional speciesname="crawler" />
+        <Conditional speciesname="mudraptor" />
+        <Conditional speciesname="mudraptor_unarmored" />
+        <Conditional speciesname="mudraptor_veteran" />
+        <Conditional speciesname="tigerthresher" />
+        <Conditional speciesname="bonethresher" />
+        <ParticleEmitter particle="gazerage" particlespersecond="20" scalemin="0.6" scalemax="1" velocitymin="0" velocitymax="0" anglemin="0" anglemax="360" copyentityangle="false"/>
+      </StatusEffect>
+    </Effect>
+    <icon texture="Content/UI/CommandUIAtlas.png" sourcerect="768,896,128,128" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="Hallucinating"
+    identifier="hallucinating"
+    limbspecific="false"
+    indicatorlimb="Head"
+    activationthreshold="0"
+    showiconthreshold="0"
+    showicontoothersthreshold="1000"
+    karmachangeonapplied="-1"
+    maxstrength="100"
+    affectmachines="false">
+    <Description
+      textidentifier="afflictiondescription.hallucinating.low"
+      target="Self" 
+      minstrength="0"
+      maxstrength="50" />
+    <Description
+      textidentifier="afflictiondescription.hallucinating"
+      target="Self" 
+      minstrength="50"
+      maxstrength="100" />
+    <Effect minstrength="0" maxstrength="30" strengthchange="-1.0" />
+    <Effect minstrength="30" maxstrength="100"
+      minscreendistort="0.0"
+      maxscreendistort="5.0"
+      minscreenblur="0.0"
+      maxscreenblur="0.0"
+      minradialdistort="0"
+      maxradialdistort="2"
+      minchromaticaberration="0"
+      maxchromaticaberration="15"
+      strengthchange="-1.0">
+    </Effect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="256,640,128,128" color="150,26,26,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="Hallucinating (short)"
+    identifier="hallucinatingshortduration"
+    limbspecific="false"
+    type="invertcontrols"
+    indicatorlimb="Head"
+    activationthreshold="0"
+    showiconthreshold="1000"
+    showicontoothersthreshold="1000"
+    showinhealthscannerthreshold="1000"
+    maxstrength="100">
+    <Effect minstrength="0" maxstrength="100"
+      minscreendistort="0.0"
+      maxscreendistort="5.0"
+      minscreenblur="0.0"
+      maxscreenblur="0.0"
+      minradialdistort="0"
+      maxradialdistort="2"
+      minchromaticaberration="0"
+      maxchromaticaberration="15"
+      strengthchange="-10.0">
+    </Effect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="256,640,128,128" color="150,26,26,255" origin="0,0"/>
+  </Affliction>
+
+  <!-- LEGACY: This is only here (for now) in order to not break existing saves -->
+  <Affliction
+    name="Reaper's Tax"
+    identifier="reaperstax"
+    type="respawnpenalty"
+    causeofdeathdescription="Reaper's Tax"
+    selfcauseofdeathdescription="The Reaper takes his toll."
+    limbspecific="false"
+    indicatorlimb="Torso"
+    activationthreshold="0"
+    treatmentthreshold="1000"
+    maxstrength="100"
+    healcostmultiplier="10">
+    <Description
+      textidentifier="afflictiondescription.reaperstax"
+      target="OtherCharacter" />
+    <Description
+      textidentifier="afflictiondescription.reaperstax.self"
+      target="Self"  />
+    <!-- Reduce skills and vitality -->
+    <Effect minstrength="0" maxstrength="100"
+      minvitalitydecrease="10"
+      maxvitalitydecrease="40"
+      minscreendistort="0"
+      maxscreendistort="0"
+      strengthchange="0"
+      minskillmultiplier="0.9"
+      maxskillmultiplier="0.5"
+      minspeedmultiplier="0.8"
+      maxspeedmultiplier="0.8">
+    </Effect>
+    <icon texture="Content/UI/CommandUIAtlas.png" sourcerect="768,768,128,128" color="143,111,160,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="Drag"
+    identifier="drag"
+    type="drag"
+    showiconthreshold="1000"
+    treatmentthreshold="1000"
+    maxstrength="1">
+    <Effect minstrength="0" maxstrength="1" strengthchange="-0.6">
+      <StatusEffect target="Character" SpeedMultiplier="0.3" setvalue="true">
+        <Conditional InWater="false"/>
+      </StatusEffect>
+      <StatusEffect target="Character" SpeedMultiplier="0.6" setvalue="true">
+        <Conditional InWater="true"/>
+      </StatusEffect>
+    </Effect>
+    <icon texture="Content/UI/CommandUIAtlas.png" sourcerect="768,768,128,128" color="143,111,160,255" origin="0,0"/>
+  </Affliction>
+
+  <!-- Basic buffs. -->
+
+  <BuffDurationIncrease
+    name="Slow metabolism"
+    identifier="durationincrease"
+    description="Increases the duration of all buffs."
+    type="durationincrease"
+    isbuff="true"
+    limbspecific="false"
+    maxstrength="600">
+    <Effect minstrength="0" maxstrength="600"
+      strengthchange="-1"
+      minbuffmultiplier="1"
+      maxbuffmultiplier="2.0"/>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="0,896,128,128" color="10,193,114,255" origin="0,0"/>
+  </BuffDurationIncrease>
+
+  <Affliction
+    name="Hyperactivity"
+    identifier="haste"
+    description="Gotta go fast."
+    type="haste"
+    isbuff="true"
+    limbspecific="false"
+    maxstrength="600"
+    MedicalSkillGain="0.01">
+    <Effect minstrength="0" maxstrength="600"
+      strengthchange="-1"
+      minspeedmultiplier="1.0"
+      maxspeedmultiplier="1.35"
+      minfacetint="255,0,0,0"
+      maxfacetint="255,0,0,150">
+      <StatValue stattype="MeleeAttackSpeed" minvalue="0" maxvalue="0.35" />
+      <StatValue stattype="SwimmingSpeed" minvalue="0" maxvalue="0.3" />
+      <StatusEffect target="Character">
+        <TriggerAnimation Type="Walk" filename="VigorousWalk" priority="5" ExpectedSpecies="Human" />
+      </StatusEffect>
+    </Effect>
+    <!-- Greater than 1.48 and the ragdolls start snapping when turning and characters take damage from colliding with doors & walls -->
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="128,896,128,128" color="10,193,114,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="Husk Infection Resistance"
+    identifier="huskinfectionresistance"
+    description="Husk be gone."
+    type="resistance"
+    isbuff="true"
+    limbspecific="false"
+    maxstrength="600"
+    affectmachines="false"
+    MedicalSkillGain="0.01">
+    <Effect minstrength="0" maxstrength="600"
+      strengthchange="-1"
+      resistancefor="huskinfection"
+      minresistance="0"
+      maxresistance="0.75"/>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="384,896,128,128" color="10,193,114,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="Psychosis Resistance"
+    identifier="psychosisresistance"
+    type="resistance"
+    isbuff="true"
+    limbspecific="false"
+    indicatorlimb="Head"
+    maxstrength="600"
+    affectmachines="false"
+    MedicalSkillGain="0.01">
+    <Effect minstrength="0" maxstrength="600"
+      strengthchange="-1"
+      resistancefor="psychosis"
+      minresistance="0"
+      maxresistance="0.75"/>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="640,896,128,128" color="10,193,114,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    identifier="psychosisimmunity"
+    translationoverride="psychosisresistance"
+    type="immunity"
+    isbuff="true"
+    limbspecific="false"
+    indicatorlimb="Head"
+    maxstrength="60"
+    affectmachines="false">
+    <Effect minstrength="0" maxstrength="60"
+      strengthchange="-1"
+      resistancefor="psychosis"
+      minresistance="1.0"
+      maxresistance="1.0"/>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="640,896,128,128" color="10,193,114,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="Pressure Resistance"
+    identifier="pressureresistance"
+    description="Pressure be gone."
+    type="resistance"
+    isbuff="true"
+    limbspecific="false"
+    maxstrength="100">
+    <Effect minstrength="0" maxstrength="100"
+      strengthchange="-1"
+      resistancefor="pressure"
+      minresistance="0"
+      maxresistance="0.75"/>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="512,896,128,128" color="10,193,114,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="Vigor"
+    identifier="strengthen"
+    description="Damage be gone."
+    type="strengthbuff"
+    isbuff="true"
+    limbspecific="false"
+    maxstrength="600"
+    MedicalSkillGain="0.01">
+    <Effect minstrength="0" maxstrength="600"
+      strengthchange="-1"
+      resistancefor="damage"
+      minresistance="0"
+      maxresistance="0.5">
+      <StatValue stattype="MeleeAttackMultiplier" minvalue="0" maxvalue="0.35" />
+      <StatusEffect target="Character">
+        <TriggerAnimation Type="Walk" filename="VigorousWalk" priority="5" ExpectedSpecies="Human" />
+      </StatusEffect>
+    </Effect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="256,896,128,128" color="10,193,114,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="Paralysis Resistance"
+    identifier="paralysisresistance"
+    description=""
+    type="resistance"
+    isbuff="true"
+    limbspecific="false"
+    karmachangeonapplied="0.15"
+    maxstrength="800"
+    affectmachines="false"
+    MedicalSkillGain="0.0005">
+    <Effect minstrength="0" maxstrength="800"
+      strengthchange="-5"
+      resistancefor="paralysis"
+      minresistance="1"
+      maxresistance="3"/>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="640,896,128,128" color="10,193,114,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="Disguised"
+    identifier="disguised"
+    description="Disguised as a crewmember"
+    type="disguiseasanother"
+    isbuff="true"
+    limbspecific="false"
+    indicatorlimb="Head"
+    showicontoothersthreshold="1000"
+    showinhealthscannerthreshold="1000"
+    maxstrength="100">
+    <Effect minstrength="100" maxstrength="100"/>
+    <icon texture="Content/UI/CommandUIAtlas.png" sourcerect="896,768,128,128" color="10,193,114,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    identifier="disguisedashusk"
+    type="disguiseashusk"
+    isbuff="true"
+    limbspecific="false"
+    indicatorlimb="Head"
+    showiconthreshold="1000"
+    showicontoothersthreshold="1000"
+    showinhealthscannerthreshold="1000"
+    maxstrength="1">
+    <Effect minstrength="0" maxstrength="1" strengthchange="-1" tag="huskinfected"/>
+    <icon texture="Content/UI/CommandUIAtlas.png" sourcerect="896,768,128,128" color="10,193,114,255" origin="0,0"/>
+  </Affliction>
+  
+ <Affliction
+    name="Chem Addiction"
+    identifier="chemaddiction"
+    description=""
+    type="debuff"
+    limbspecific="false"
+    indicatorlimb="Head"
+    showiconthreshold="20"
+    showinhealthscannerthreshold="5"
+    maxstrength="100"
+    affectmachines="false"
+    karmachangeonapplied="-0.1">
+    <Effect minstrength="0" maxstrength="20" strengthchange="-0.025"/>
+    <Effect minstrength="20" maxstrength="40" strengthchange="-0.025">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <Affliction identifier="chemwithdrawal" strength="0.1"/>
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="40" maxstrength="60" strengthchange="-0.025">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <Affliction identifier="chemwithdrawal" strength="0.2"/>
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="60" maxstrength="80" strengthchange="-0.025">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <Affliction identifier="chemwithdrawal" strength="0.4"/>
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="80" maxstrength="100" strengthchange="-0.025">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <Affliction identifier="chemwithdrawal" strength="0.8"/>
+      </StatusEffect>
+    </Effect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="384,768,128,128" color="195,180,60,255" origin="0,0"/>
+  </Affliction>
+  
+  <Affliction
+    name="Chem withdrawal"
+    identifier="chemwithdrawal"
+    description=""
+    type="debuff"
+    causeofdeathdescription="Died of chem withdrawal"
+    selfcauseofdeathdescription="You have died of chem withdrawal."
+    limbspecific="false"
+    indicatorlimb="Head"
+    showiconthreshold="20"
+    showinhealthscannerthreshold="5"
+    maxstrength="100"
+    affectmachines="false">
+    <Effect minstrength="0" maxstrength="20" strengthchange="-0.05" />
+    <!-- Slow down the character and slightly decrease vitality -->
+    <Effect minstrength="20" maxstrength="40"
+      minvitalitydecrease="0"
+      maxvitalitydecrease="20"
+      strengthchange="-0.05"
+      minchromaticaberration="0.0"
+      maxchromaticaberration="1.0"
+      minfacetint="255,255,255,0"
+      maxfacetint="255,255,255,50"
+      minspeedmultiplier="1.0"
+      maxspeedmultiplier="0.8">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <Affliction identifier="nausea" strength="10" probability="0.05" />
+      </StatusEffect>
+    </Effect>
+    <!-- Decrease vitality more. The strength of the affliction drops faster, meaning that 
+    the character needs a stronger chem addiction for the withdrawal symptoms to stay at this level -->
+    <Effect minstrength="40" maxstrength="80"
+      minvitalitydecrease="20"
+      maxvitalitydecrease="50"
+      strengthchange="-0.1"
+      minchromaticaberration="1.0"
+      maxchromaticaberration="5.0"
+      minfacetint="255,255,255,50"
+      maxfacetint="255,255,255,100"
+      minspeedmultiplier="0.8"
+      maxspeedmultiplier="0.7">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <Affliction identifier="nausea" strength="20" probability="0.15" />
+      </StatusEffect>
+    </Effect>
+    <!-- Withdrawal symptoms start to get lethal at this level -->
+    <Effect minstrength="80" maxstrength="100"
+      minvitalitydecrease="50"
+      maxvitalitydecrease="200"
+      minscreendistort="0.0"
+      maxscreendistort="3.0"
+      strengthchange="-0.2"
+      minchromaticaberration="5.0"
+      maxchromaticaberration="10.0"
+      minradialdistort="40.0"
+      maxradialdistort="80.0"
+      minfacetint="255,255,255,100"
+      maxfacetint="255,255,255,150"
+      minspeedmultiplier="0.8"
+      maxspeedmultiplier="0.5">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <Affliction identifier="nausea" strength="30" probability="0.25" />
+      </StatusEffect>
+    </Effect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="512,768,128,128" color="209,121,84,255" origin="0,0"/>
+  </Affliction>
+
+  <!-- The icon is hidden because there's no text for the affliction name and the description. TODO: Add the texts and make the icon visible? -->
+  <Affliction
+    name="Damage immunity"
+    identifier="damageimmunity"
+    type="immunity"
+    isbuff="true"
+    limbspecific="false"
+    showiconthreshold="1000"
+    maxstrength="1">
+    <Effect minstrength="0" maxstrength="1" strengthchange="-0.6" resistancefor="damage,bleeding,burn" minresistance="1" maxresistance="1"/>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="256,896,128,128" color="10,193,114,255" origin="0,0"/>
+  </Affliction>
+  
+  <!-- Makes the creature indetectable so that the monsters won't react to it.-->
+  <Affliction
+    name="Concealed"
+    identifier="concealed"
+    type="concealed"
+    limbspecific="false"
+    showiconthreshold="1000"
+    maxstrength="1">
+    <Effect minstrength="0" maxstrength="1" strengthchange="-0.6">
+      <StatusEffect target="Character" indetectable="true" />
+    </Effect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="0,0,128,128" color="255,255,255,255" origin="0,0"/>
+  </Affliction>
+
+  <!-- A special damage type that only affects jove -->
+  <Affliction
+    name="Doom of Jove"
+    identifier="doomofjove"
+    type="doomofjove"
+    limbspecific="false"
+    maxstrength="100"
+    targets="jove">
+    <Effect minstrength="0" maxstrength="100" multiplybymaxvitality="true" minvitalitydecrease="0" maxvitalitydecrease="1"/>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="128,768,128,128" color="195,136,60,255" origin="0,0"/>
+  </Affliction>
+  
+  <Affliction
+    name=""
+    identifier="acidreaction"
+    description="Reagent that drastically increases progression of acid burns and husk infection."
+    type="debuff"
+    limbspecific="false"
+    maxstrength="100"
+    affectmachines="false">
+    <Effect minstrength="0" maxstrength="100"
+      strengthchange="-0.8"
+      resistancefor="acidburn,huskinfection"
+      minresistance="0"
+      maxresistance="-3"/>
+    <icon texture="Content/UI/CommandUIBackground.png" sourcerect="640,768,128,128" color="84,171,90,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    identifier="recoilstabilized"
+    type="recoilstabilized"
+    isbuff="true"
+    limbspecific="false"
+    hideiconafterdelay="true"
+    maxstrength="1"
+    showiconthreshold="1000"
+    treatmentthreshold="1000"
+    showicontoothersthreshold="1000"
+    showinhealthscannerthreshold="1000"
+    duration="1">
+    <Effect minstrength="0" maxstrength="1"/>
+    <icon texture="Content/UI/CommandUIAtlas.png" sourcerect="768,768,128,128" color="143,111,160,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="EMP"
+    identifier="emp"
+    type="emp"
+    limbspecific="false"
+    indicatorlimb="Torso"
+    showiconthreshold="1000"
+    showinhealthscannerthreshold="1000"
+    maxstrength="100"
+    WeaponSkillGain="1.0">
+    <Effect minstrength="0" maxstrength="25" strengthchange="-1.0">
+      <StatusEffect target="Character" setvalue="true">
+        <Affliction identifier="stun" amount="1" />
+        <Sound file="Content/Items/Electricity/Zap1.ogg" range="500" selectionmode="Random" />
+        <Sound file="Content/Items/Electricity/Zap2.ogg" range="500" />
+        <Sound file="Content/Items/Electricity/Zap3.ogg" range="500" />
+        <Sound file="Content/Items/Electricity/Zap4.ogg" range="500" />
+        <Sound file="Content/Items/Electricity/Zap5.ogg" range="500" />
+        <ParticleEmitter drawontop="true" particle="spark" distancemin="0" distancemax="30" anglemin="0" anglemax="360" particlespersecond="5" velocitymin="10" velocitymax="50" scalemin="0.4" scalemax="0.7"/>
+        <ParticleEmitter drawontop="true" particle="swirlysmoke" particlespersecond="2" scalemin="1" scalemax="2" anglemin="0" anglemax="360" velocitymin="0" velocitymax="10" />
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="25" maxstrength="50" strengthchange="-1.5">
+      <StatusEffect target="Character" setvalue="true">
+        <Affliction identifier="stun" amount="1" />
+        <Sound file="Content/Items/Electricity/Zap1.ogg" range="500" selectionmode="Random" />
+        <Sound file="Content/Items/Electricity/Zap2.ogg" range="500" />
+        <Sound file="Content/Items/Electricity/Zap3.ogg" range="500" />
+        <Sound file="Content/Items/Electricity/Zap4.ogg" range="500" />
+        <Sound file="Content/Items/Electricity/Zap5.ogg" range="500" />
+        <ParticleEmitter drawontop="true" particle="spark" distancemin="0" distancemax="30" anglemin="0" anglemax="360" particlespersecond="10" velocitymin="50" velocitymax="100" scalemin="0.4" scalemax="0.7"/>
+        <ParticleEmitter drawontop="true" particle="swirlysmoke" particlespersecond="5" scalemin="1" scalemax="2" anglemin="0" anglemax="360" velocitymin="0" velocitymax="10" />
+        <ParticleEmitter drawontop="true" particle="electricshock" distancemin="0" distancemax="40" particlespersecond="1" anglemin="0" anglemax="360" scalemin="0.03" scalemax="0.06" />
+      </StatusEffect>
+      <StatusEffect target="Character" setvalue="false" multiplyafflictionsbymaxvitality="true">
+        <Affliction identifier="internaldamage" amount="0.1" />
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="50" maxstrength="75" strengthchange="-2.0">
+      <StatusEffect target="Character" setvalue="true">
+        <Affliction identifier="stun" amount="1" />
+        <Sound file="Content/Items/Electricity/Zap1.ogg" range="500" selectionmode="Random" />
+        <Sound file="Content/Items/Electricity/Zap2.ogg" range="500" />
+        <Sound file="Content/Items/Electricity/Zap3.ogg" range="500" />
+        <Sound file="Content/Items/Electricity/Zap4.ogg" range="500" />
+        <Sound file="Content/Items/Electricity/Zap5.ogg" range="500" />
+        <ParticleEmitter drawontop="true" particle="spark" distancemin="0" distancemax="30" anglemin="0" anglemax="360" particlespersecond="15" velocitymin="75" velocitymax="150" scalemin="0.4" scalemax="0.7"/>
+        <ParticleEmitter drawontop="true" particle="swirlysmoke" particlespersecond="7" scalemin="1" scalemax="2" anglemin="0" anglemax="360" velocitymin="0" velocitymax="10" />
+        <ParticleEmitter drawontop="true" particle="electricshock" distancemin="0" distancemax="40" particlespersecond="2" anglemin="0" anglemax="360" scalemin="0.04" scalemax="0.1" />
+      </StatusEffect>
+      <StatusEffect target="Character" setvalue="false" multiplyafflictionsbymaxvitality="true">
+        <Affliction identifier="internaldamage" amount="0.25" />
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="75" maxstrength="100" strengthchange="-3.0">
+      <StatusEffect target="Character" setvalue="true">
+        <Affliction identifier="stun" amount="1" />
+        <Sound file="Content/Items/Electricity/Zap1.ogg" range="500" selectionmode="Random" />
+        <Sound file="Content/Items/Electricity/Zap2.ogg" range="500" />
+        <Sound file="Content/Items/Electricity/Zap3.ogg" range="500" />
+        <Sound file="Content/Items/Electricity/Zap4.ogg" range="500" />
+        <Sound file="Content/Items/Electricity/Zap5.ogg" range="500" />
+        <ParticleEmitter drawontop="true" particle="spark" distancemin="0" distancemax="30" anglemin="0" anglemax="360" particlespersecond="20" velocitymin="100" velocitymax="200" scalemin="0.4" scalemax="0.7"/>
+        <ParticleEmitter drawontop="true" particle="swirlysmoke" particlespersecond="10" scalemin="1" scalemax="2" anglemin="0" anglemax="360" velocitymin="0" velocitymax="10" />
+        <ParticleEmitter drawontop="true" particle="electricshock" distancemin="0" distancemax="40" particlespersecond="3" anglemin="0" anglemax="360" scalemin="0.04" scalemax="0.1" />
+      </StatusEffect>
+      <StatusEffect target="Character" setvalue="false" multiplyafflictionsbymaxvitality="true">
+        <Affliction identifier="internaldamage" amount="0.5" />
+      </StatusEffect>
+    </Effect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="640,640,128,128" color="0,255,0,255" origin="0,0"/>
+  </Affliction>
+
+
+  <Affliction
+    identifier="psychoclown"
+    type="psychoclown"
+    isbuff="true"
+    hideiconafterdelay="true"
+    limbspecific="false"
+    maxstrength="100"
+    showiconthreshold="1000"
+    treatmentthreshold="1000"
+    showicontoothersthreshold="1000"
+    showinhealthscannerthreshold="1000"
+    iconcolors="33,75,78;126,211,224;126,211,224;227,247,249">
+    <Effect minstrength="0" maxstrength="100"
+      strengthchange="0"
+      resistancefor="oxygenlow"
+      minresistance="1"
+      maxresistance="1">
+      <AbilityFlag flagtype="ImmuneToPressure" />
+      <StatusEffect target="Character" usehulloxygen="false" setvalue="true">
+        <ReduceAffliction identifier="oxygenlow" strength="0.5"/>
+      </StatusEffect>
+      <StatusEffect target="Character" interval="5" disabledeltatime="true">
+        <Affliction identifier="psychosis" strength="100" />
+      </StatusEffect>
+      <StatusEffect target="Character">
+        <TriggerAnimation Type="Walk" filename="JollyWalk" priority="7" ExpectedSpecies="Human" />
+      </StatusEffect>
+    </Effect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="512,896,128,128" color="10,193,114,255" origin="0,0"/>
+  </Affliction>
+  
+  <InternalDamage
+    name="Mystery affliction"
+    identifier="mysteryaffliction"
+    description=""
+    type="damage"
+    causeofdeathdescription="Died mysteriously"
+    selfcauseofdeathdescription="You died under mysterious circumstances"
+    limbspecific="false"
+    maxstrength="100"
+    showiconthreshold="1000"
+    treatmentthreshold="1000"
+    showicontoothersthreshold="1000"
+    showinhealthscannerthreshold="1000">
+    <Effect minstrength="0" maxstrength="100" strengthchange="-1"/>
+    <icon texture="Content/UI/CommandUIAtlas.png" sourcerect="768,768,128,128" color="143,111,160,255" origin="0,0"/>
+  </InternalDamage>
+
+  <Infection
+    identifier="infection"
+    type="infection"
+    limbspecific="true"
+    maxstrength="200"
+    burnoverlayalpha="0"
+    causeofdeathdescription="causeofdeathdescription.damage"
+    selfcauseofdeathdescription="self_causeofdeathdescription.damage"
+    healcostmultiplier="2.5">
+    <Description
+     textidentifier="afflictiondescription.infection.low"
+     minstrength="0"
+     maxstrength="30"/>
+    <Description
+      textidentifier="afflictiondescription.infection"
+      minstrength="30"
+      maxstrength="60"/>
+    <Description
+      textidentifier="afflictiondescription.infection.high"
+      minstrength="60"
+      maxstrength="200"/>
+    <Effect minstrength="0" maxstrength="30" multiplybymaxvitality="true" strengthchange="0.1"
+      minvitalitydecrease="0"
+      maxvitalitydecrease="0.3"/>
+    <Effect minstrength="30" maxstrength="60" multiplybymaxvitality="true" strengthchange="0.1"
+      minvitalitydecrease="0.3"
+      maxvitalitydecrease="0.6">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <Conditional IsHuman="true"/>
+        <Affliction identifier="organdamage" amount="0.2"/>
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="60" maxstrength="200" multiplybymaxvitality="true" strengthchange="0.1"
+      minvitalitydecrease="0.6"
+      maxvitalitydecrease="2">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <Conditional IsHuman="true"/>
+        <Affliction identifier="organdamage" amount="0.5"/>
+        <Affliction identifier="nausea" amount="15" probability="0.03" /> 
+      </StatusEffect>
+    </Effect>
+    <icon texture="Content/UI/TalentsIcons4.png" sourcerect="0,384,128,128" color="84,171,90,255" origin="0,0"/>
+  </Infection>
+  
+  <Affliction
+    name="Drunk Vulnerability"
+    identifier="drunkweakness"
+    description=""
+    type="debuff"
+    limbspecific="false"
+    maxstrength="100"
+    affectmachines="false">
+     <Description
+      textidentifier="afflictiondescription.drunkweakness"
+      target="OtherCharacter"
+      minstrength="0"
+      maxstrength="100"/>
+    <Description
+      textidentifier="afflictiondescription.drunkweakness.self"
+      target="Self"
+      minstrength="0"
+      maxstrength="100"/>
+    <Effect minstrength="0" maxstrength="100"
+      strengthchange="-1"
+      resistancefor="drunk"
+      minresistance="0"
+      maxresistance="-5"/>
+    <icon texture="Content/UI/TalentsIcons4.png" sourcerect="128,384,128,128" color="84,171,90,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="Stabilozine Effects"
+    identifier="stabilozineeffect"
+    type="resistance"
+    isbuff="true"
+    limbspecific="false"
+    indicatorlimb="Torso"
+    maxstrength="120"
+    affectmachines="false"
+    MedicalSkillGain="0.01">
+    <Description
+      textidentifier="afflictiondescription.stabilozineeffect.self"
+      target="Self" />
+    <Description
+      textidentifier="afflictiondescription.stabilozineeffect"
+      target="OtherCharacter " />
+    <Effect minstrength="0" maxstrength="120"
+      strengthchange="-1">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <ReduceAffliction type="poison" amount="1" />
+      </StatusEffect>
+    </Effect>
+    <Icon texture="Content/UI/TalentsIcons4.png" sourcerect="896,256,128,128" color="10,193,114,255" origin="0,0"/>
+  </Affliction>
+  
+  <Affliction
+    identifier="adrenalinerush"
+    type="adrenaline"
+    isbuff="true"
+    limbspecific="false"
+    maxstrength="8"
+    iconcolors="33,75,78;126,211,224;126,211,224;227,247,249">
+    <Description
+      textidentifier="afflictiondescription.adrenalinerush.self"
+      target="Self" />
+    <Description
+      textidentifier="afflictiondescription.adrenalinerush"
+      target="OtherCharacter " />
+    <Effect minstrength="0" maxstrength="8" strengthchange="-1"
+      resistancefor="stun" minresistance="0" maxresistance="0.5"> 
+      <StatusEffect target="Character" interval="8" disabledeltatime="true">
+        <ReduceAffliction type="stun" amount="30" />
+      </StatusEffect>
+      <StatusEffect target="Character">
+        <TriggerAnimation Type="Walk" filename="VigorousWalk" priority="4" ExpectedSpecies="Human" />
+      </StatusEffect>
+      <AbilityFlag flagtype="AlwaysStayConscious" />
+    </Effect>
+    <Icon texture="Content/UI/TalentsIcons4.png" sourcerect="768,256,128,128" color="10,193,114,255" origin="0,0"/>
+  </Affliction>
+
+  <Affliction
+    name="Husk Roulette Participation"
+    identifier="huskroulette"
+    description=""
+    type="resistance"
+    isbuff="true"
+    limbspecific="false"
+    hideiconafterdelay="true"
+    maxstrength="120"
+    showiconthreshold="1000"
+    treatmentthreshold="1000"
+    showicontoothersthreshold="1000"
+    showinhealthscannerthreshold="1000" >
+    <Effect minstrength="0" maxstrength="120" strengthchange="-0.1"/>
+    <icon texture="Content/UI/CommandUIAtlas.png" sourcerect="768,768,128,128" color="143,111,160,255" origin="0,0"/>
+  </Affliction>
+
+  <!-- DoT for incendium -->
+  <Affliction name="Burning" identifier="burning" description="The target is burning." type="burn" causeofdeathdescription="" selfcauseofdeathdescription="" limbspecific="true" activationthreshold="1.0" showiconthreshold="1000" maxstrength="15">
+    <Effect minstrength="1" maxstrength="15" minvitalitydecrease="0" maxvitalitydecrease="0" strengthchange="-1.0">
+      <StatusEffect target="Limb">
+        <ParticleEmitter particle="flamethrower" DistanceMin="15" DistanceMax="25" ScaleMin="0.1" ScaleMax="0.15" ParticlesPerSecond="14" AngleMin="0" AngleMax="360" />
+        <ParticleEmitter particle="smoke" particlespersecond="6" scalemin="4" scalemax="3" distancemin="10" distancemax="50" />
+        <Affliction identifier="burn" amount="0.6" />
+        <Conditional InWater="false" />
+      </StatusEffect>
+      <StatusEffect target="Limb" disabledeltatime="true">
+        <ReduceAffliction identifier="burning" amount="5" />
+        <Conditional InWater="true" />
+      </StatusEffect>
+      <StatusEffect target="Character">
+        <sound file="Content/Sounds/FireSmall.ogg" range="200.0" />
+        <Conditional InWater="false" />
+      </StatusEffect>
+    </Effect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="768,640,128,128" color="195,0,0,255" origin="0,0" />
+  </Affliction>
+
+  <!-- This thing makes you "deaf" once a Stun Grenade explodes nearby.-->
+  <Affliction name="Sensory Overload" identifier="sensoryoverload" description="The target's senses have been overloaded, deafening them and distorting their view." type="damage" causeofdeathdescription="" selfcauseofdeathdescription="" limbspecific="false" showiconthreshold="1000" maxstrength="30">
+    <Effect minstrength="0" maxstrength="10" strengthchange="-0.4" minspeedmultiplier="0.9" maxspeedmultiplier="0.7" minscreendistort="0" maxscreendistort="0.6" minscreenblur="0.0" maxscreenblur="0.5" minradialdistort="0.0" maxradialdistort="0.45">
+      <StatusEffect target="Character" LowPassMultiplier="0.2" setvalue="true" />
+    </Effect>
+    <Effect minstrength="10" maxstrength="20" strengthchange="-0.8" minspeedmultiplier="0.7" maxspeedmultiplier="0.5" minscreendistort="0.6" maxscreendistort="0.9" minscreenblur="0.5" maxscreenblur="0.7" minradialdistort="0.45" maxradialdistort="1">
+      <StatusEffect target="Character" ObstructVision="true" LowPassMultiplier="0.1" setvalue="true" />
+    </Effect>
+    <Effect minstrength="20" maxstrength="30" strengthchange="-0.8" minspeedmultiplier="0.5" maxspeedmultiplier="0.2" minscreendistort="0.9" maxscreendistort="1.2" minscreenblur="0.7" maxscreenblur="1" minradialdistort="1" maxradialdistort="2">
+      <StatusEffect target="Character" ObstructVision="true" LowPassMultiplier="0.0" setvalue="true" />
+    </Effect>
+  </Affliction>
+
+  <Affliction name="Blinded" identifier="blind_hard" description="" type="none" limbspecific="false" indicatorlimb="Head" maxstrength="10"  showiconthreshold="1000" showicontoothersthreshold="1000" afflictionoverlayalphaislinear="false">
+    <Effect minstrength="0" maxstrength="10" multiplybymaxvitality="true" strengthchange="-2" minvitalitydecrease="0" maxvitalitydecrease="0">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true" setvalue="true">
+        <Affliction identifier="blind" strength="30" />
+      </StatusEffect>
+    </Effect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="128,768,128,128" color="195,136,60,255" origin="0,0" />
+    <AfflictionOverlay texture="Content/UI/blindoverlay.png" />
+  </Affliction>
+
+  <Affliction name="Blinded" identifier="blind" description="" type="none" limbspecific="false" indicatorlimb="Head" maxstrength="30" showiconthreshold="1000" showicontoothersthreshold="1000">
+    <Effect minstrength="0" maxstrength="20" multiplybymaxvitality="true" strengthchange="-4" minvitalitydecrease="0" maxvitalitydecrease="0" MinAfflictionOverlayAlphaMultiplier="0.0" MaxAfflictionOverlayAlphaMultiplier="0.8" />
+    <Effect minstrength="20" maxstrength="30" multiplybymaxvitality="true" strengthchange="-0.8" minvitalitydecrease="0" maxvitalitydecrease="0" MinAfflictionOverlayAlphaMultiplier="0.8" MaxAfflictionOverlayAlphaMultiplier="1" />
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="128,768,128,128" color="195,136,60,255" origin="0,0" />
+    <AfflictionOverlay texture="Content/UI/blindoverlay.png" />
+  </Affliction>
+
+  <Affliction
+    name=""
+    identifier="mantiscamouflage"
+    isbuff="true"
+    limbspecific="false"
+    showicontoothersthreshold="1000"
+    showinhealthscannerthreshold="1000"
+    maxstrength="10">
+    <icon texture="Content/UI/CommandUIAtlas.png" sourcerect="896,768,128,128" color="10,193,114,255" origin="0,0"/>
+    <Effect minstrength="0" maxstrength="10" mingrainstrength="0.0" maxgrainstrength="1.0" strengthchange="-1.0"
+      minbodytint="150,150,150,0"
+      maxbodytint="150,150,150,255"
+      minspeedmultiplier="1.0"
+      maxspeedmultiplier="5.0">
+      <!-- ^ temporary speed boost when the mantis comes out of camouflage, wears off along with the affliction -->
+    </Effect>
+  </Affliction>
+  
+  <Affliction
+    name="Mind Sense"
+    identifier="mindsense"
+    type="visionbuff"
+    isbuff="true"
+    limbspecific="false"
+    maxstrength="600"
+    MedicalSkillGain="0.01">
+    <Effect minstrength="10" maxstrength="600" strengthchange="-1" ThermalOverlayRange="1500" ThermalOverlayColor="134,182,253,150">
+      <StatusEffect target="Character" interval="1" disabledeltatime="true">
+        <Affliction identifier="psychosis" amount="1" />
+      </StatusEffect>
+    </Effect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="256,896,128,128" color="10,193,114,255" origin="0,0"/>
+  </Affliction>
+</Afflictions>

--- a/healing beds/OutpostItems.xml
+++ b/healing beds/OutpostItems.xml
@@ -1,0 +1,1135 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Items>
+  <Item name="" identifier="op_clowncurtain2" width="199" height="381" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="2,2,199,381" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownmannequin1" width="76" height="259" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="2,763,76,259" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownjukebox" width="149" height="258" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="82,763,149,258" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="20" lightcolor="209,46,158,255" blinkfrequency="1" powerconsumption="0" IsOn="true" castshadows="false" allowingameediting="false">
+      <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="205,95,169,278" depth="0.98" origin="0.5,0.5" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_clowninstrument1" width="151" height="236" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="235,763,151,236" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownball1" width="83" height="223" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="390,763,83,223" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownmic" width="68" height="215" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="477,763,68,215" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownmannequin3" nameidentifier="op_clownmannequin1"  width="135" height="315" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="184,387,135,315" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownsign1" width="212" height="43" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="184,706,212,43" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownmannequin2" nameidentifier="op_clownmannequin1" width="145" height="310" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="400,387,145,310" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownmask2" width="60" height="85" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="323,2,60,85" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownmask3" nameidentifier="op_clownmask2" width="60" height="79" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="323,377,60,79" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownmask4" nameidentifier="op_clownmask2" width="59" height="71" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="323,460,59,71" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownmask1" nameidentifier="op_clownmask2" width="52" height="80" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="323,535,52,80" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownshow1" width="146" height="201" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="378,91,146,201" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownsign3" nameidentifier="op_clownsign1" width="136" height="66" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="378,296,136,66" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownsign2" nameidentifier="op_clownsign1" width="197" height="60" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="387,2,197,60" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownshow2" nameidentifier="op_clownshow1" width="145" height="200" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="528,66,145,200" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownmarquee" width="272" height="149" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="677,2,272,149" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="120" lightcolor="209,127,46,255" flicker="0.1" powerconsumption="0" IsOn="true" castshadows="false" allowingameediting="false">
+      <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="677,155,272,149" depth="0.98" premultiplyalpha="true" origin="0.5,0.5" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_clowninstrument2" width="264" height="191" scale="0.6" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="549,308,264,191" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownball2" width="164" height="163" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="817,462,164,163" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownshow3" nameidentifier="op_clownshow1" width="145" height="200" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="549,503,145,200" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownshow4" nameidentifier="op_clownshow1" width="145" height="200" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="549,707,145,200" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownposter1"  width="143" height="200" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="698,629,143,200" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownposter2" nameidentifier="op_clownposter1" width="142" height="199" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="845,629,142,199" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <!--Separatist Outpost-->
+  <Item name="" identifier="op_sepsandbag" nameidentifier="op_sepsandbag" width="490" height="180" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="2,2,490,180" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_rippedposter" nameidentifier="op_sepsandbag" width="462" height="126" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="496,2,462,126" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sepnoose" nameidentifier="op_sepsandbag" width="39" height="116" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="962,2,39,116" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sepbarbedwire" nameidentifier="op_sepsandbag" width="454" height="83" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="496,132,454,83" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sepdebris1" nameidentifier="op_sepsandbag" width="408" height="157" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="2,186,408,157" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_septent" nameidentifier="op_sepsandbag" width="370" height="278" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="414,219,370,278" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sepdebris3" nameidentifier="op_sepsandbag" width="358" height="203" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="2,347,358,203" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sephologram1" nameidentifier="op_sepsandbag" width="145" height="87" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="788,219,145,87" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sepposter1" nameidentifier="op_sepsandbag" width="136" height="199" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="788,310,136,199" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_septacticalmap" nameidentifier="op_sepsandbag" width="339" height="136" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="364,501,339,136" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sepdebris2" nameidentifier="op_sepsandbag" width="306" height="74" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="707,513,306,74" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sepposter3" nameidentifier="op_sepsandbag" width="333" height="145" scale="0.5" noninteractable="true" category="Decorative">
+ 	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="2,554,333,145" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sepbody" nameidentifier="op_sepsandbag" width="280" height="67" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="707,591,280,67" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sepgraffiti" nameidentifier="op_sepsandbag" width="323" height="202" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="339,641,323,202" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_brokenstatue" nameidentifier="op_sepsandbag" width="121" height="111" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="339,847,121,111" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sephologram2" nameidentifier="op_sepsandbag" width="129" height="80" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="464,847,129,80" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sepdebris4" nameidentifier="op_sepsandbag" width="237" height="211" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="2,703,237,211" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sepposter2" nameidentifier="op_sepsandbag" width="135" height="196" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="666,662,135,196" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <!--Husk District-->
+  <Item name="" identifier="op_husksign" width="139" height="74" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="845,928,139,74" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskposter1" width="99" height="139" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="724,722,99,139" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskposter2" nameidentifier="op_huskposter1" width="120" height="165" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="828,722,120,165" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskposter3" nameidentifier="op_huskposter1" width="99" height="139" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="727,869,100,139" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_husktable" width="549" height="240" scale="0.5" noninteractable="true" category="Decorative">
+  	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="2,2,549,240" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskscribble" width="422" height="246" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="555,2,422,246" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskstatue1" width="271" height="474" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="2,246,271,474" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskstatue4" nameidentifier="op_huskstatue1" width="259" height="187" scale="0.5" noninteractable="true" category="Decorative">
+ 	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="277,246,259,187" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskincubator" width="187" height="264" scale="0.5" noninteractable="true" category="Decorative">
+ 	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="2,724,187,264" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_husklabel" width="140" height="39" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="193,982,140,39" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_husklabel1" width="53" height="35" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="337,982,53,35" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskcloak" width="115" height="232" scale="0.5" noninteractable="true" category="Decorative">
+ 	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="277,437,115,232" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_humantank" width="159" height="331" scale="0.5" noninteractable="true" category="Decorative">
+	<LightComponent range="130" lightcolor="255,0,100,120" pulsefrequency="0.5" pulseamount="0.2" powerconsumption="0" IsOn="true" castshadows="false" allowingameediting="false"/>
+    <sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="394,673,159,331" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="193,724,171,254" depth="0.96" origin="0.5,0.5" offset="0,5" offsetanim="Sine" offsetanimspeed="2" />
+	<DecorativeSprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="557,638,131,316" depth="0.97" />
+  </Item>
+  <Item name="" identifier="op_huskstroller1" width="184" height="197" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="396,437,184,197" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskgraffiti" width="159" height="181" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="540,252,159,181" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskstroller2" nameidentifier="op_huskstroller1" width="254" height="137" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="703,252,254,137" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskphoto2" nameidentifier="op_huskphoto1" width="56" height="70" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="961,252,56,70" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskbody" width="134" height="54" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="584,958,134,54" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskstatue2" nameidentifier="op_huskstatue1" width="224" height="184" scale="0.5" noninteractable="true" category="Decorative">
+  	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="584,437,224,184" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskstatue3" nameidentifier="op_huskstatue1" width="207" height="157" scale="0.5" noninteractable="true" category="Decorative">
+	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="812,393,207,157" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskphoto1" width="205" height="143" scale="0.5" noninteractable="true" category="Decorative">
+  	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="812,554,205,143" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <!--Misc Signs and Decorations-->
+  <Item name="" identifier="windowframecorner" nameidentifier="shop_decoration" width="229" height="232" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/MiningMachine.png" sourcerect="709,728,229,232" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_weaponstoresign" nameidentifier="sign" width="137" height="159" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="297,502,137,159" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_medicalstoresign" nameidentifier="sign" width="242" height="63" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="172,735,242,63" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_electricalstoresign" nameidentifier="sign" width="242" height="63" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="172,815,166,188" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0" lightcolor="213,213,185,255" flicker="0.3" powerconsumption="0" IsOn="true" castshadows="false" allowingameediting="false">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="842,809,166,188" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_storesign1.png" nameidentifier="opdeco_adposter" width="326" height="165" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="2,2,326,165" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="70" lightcolor="213,213,185,120" flicker="0.3" powerconsumption="0" IsOn="true" castshadows="false" allowingameediting="false"/>
+  </Item>
+  <Item name="" identifier="op_shipyardsign2.png" nameidentifier="opdeco_adposter" width="310" height="139" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="2,171,310,139" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="70" lightcolor="213,213,185,120" flicker="0.3" powerconsumption="0" IsOn="true" castshadows="false" allowingameediting="false"/>
+  </Item>
+  <Item name="" identifier="op_shipyardsign1.png" nameidentifier="opdeco_adposter" width="185" height="191" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="316,173,185,191" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0" lightcolor="213,213,185,255" flicker="0.3" powerconsumption="0" IsOn="true" castshadows="false" allowingameediting="false">      
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="332,2,163,167" depth="0.97" premultiplyalpha="false" origin="0.5,0.52" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_jobgraffiti.png" nameidentifier="graffiti1" width="196" height="126" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="2,314,196,126" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_storesign2.png" nameidentifier="sign" width="156" height="87" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="202,368,156,87" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_directionsign.png" nameidentifier="sign" width="142" height="122" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="362,368,142,122" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_hiringsign.png" nameidentifier="sign" width="155" height="193" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="2,444,155,193" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="70" lightcolor="213,213,185,120" flicker="0.3" powerconsumption="0" IsOn="true" castshadows="false" allowingameediting="false"/>
+  </Item>
+  <!-->Item name="" identifier="op_lamppost.png" width="149" height="347" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="2,641,149,347" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="70" lightcolor="213,213,185,120" flicker="0.3" powerconsumption="0" IsOn="true" offset="-100,0" castshadows="false" allowingameediting="false"/>
+  </Item>
+  </!-->
+  <Item name="" identifier="op_circusposter.png" width="127" height="174" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="161,459,127,174" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_plaque.png" width="120" height="85" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="161,637,120,85" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="streetlight" nameidentifier="streetlight" width="56" height="55" scale="0.5" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="757,1,56,55" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="250.0" lightcolor="255,255,255,111" IsOn="true" castshadows="true" allowingameediting="false" powerconsumption="5">
+      <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="815,1,56,55" depth="0.97" premultiplyalpha="false" origin="0.5,0.52" />
+    </LightComponent>
+    <DecorativeSprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" depth="0.961" sourcerect="775,56,22,344" offset="0,-172"/>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="power" displayname="connection.power" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+      <input name="set_color" displayname="connection.setcolor" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" identifier="shop_decoration01" nameidentifier="shop_decoration" width="60" height="82" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ArmoryColonyModule.png" sourcerect="743,262,60,82" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration02" nameidentifier="shop_decoration" width="71" height="108" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ArmoryColonyModule.png" sourcerect="651,302,71,108" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration03" nameidentifier="shop_decoration" width="84" height="52" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ArmoryColonyModule.png" sourcerect="729,360,84,52" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration04" nameidentifier="shop_decoration" width="50" height="90" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ArmoryColonyModule.png" sourcerect="659,417,50,90" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration05" nameidentifier="shop_decoration" width="88" height="86" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ArmoryColonyModule.png" sourcerect="729,417,88,86" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration06" nameidentifier="shop_decoration" width="37" height="133" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ArmoryColonyModule.png" sourcerect="833,374,37,133" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration07" nameidentifier="shop_decoration" width="42" height="84" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ArmoryColonyModule.png" sourcerect="877,369,42,84" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration08" nameidentifier="shop_decoration" width="42" height="84" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ArmoryColonyModule.png" sourcerect="928,369,42,84" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration09" nameidentifier="shop_decoration" width="42" height="84" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ArmoryColonyModule.png" sourcerect="978,369,42,84" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration10" nameidentifier="shop_decoration" width="43" height="44" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/ArmoryColonyModule.png" sourcerect="977,463,43,44" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration11" nameidentifier="shop_decoration" width="96" height="48" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="926,1,96,48" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration12" nameidentifier="shop_decoration" width="126" height="88" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="827,83,126,88" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration13" nameidentifier="shop_decoration" width="61" height="94" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="963,59,61,94" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration14" nameidentifier="shop_decoration" width="63" height="112" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="872,182,63,112" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration15" nameidentifier="shop_decoration" width="70" height="76" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="952,182,70,76" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration16" nameidentifier="shop_decoration" width="31" height="43" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="984,272,31,43" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration17" nameidentifier="shop_decoration" width="133" height="79" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="823,304,133,79" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration18" nameidentifier="shop_decoration" width="52" height="45" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="970,315,52,45" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration19" nameidentifier="shop_decoration" width="78" height="113" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="760,843,78,113" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration20" nameidentifier="shop_decoration" width="54" height="111" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="858,843,54,111" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration21" nameidentifier="shop_decoration" width="75" height="60" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="941,839,75,60" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration22" nameidentifier="shop_decoration" width="82" height="53" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="844,965,82,53" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration23" nameidentifier="shop_decoration" width="91" height="101" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="931,920,91,101" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_shelf4" nameidentifier="shelf" width="301" height="377" texturescale="1.0,1.0" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/GenericWalls2.png" sourcerect="1719,450,301,377" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/GenericWalls2.png" sourcerect="1719,836,301,377" depth="0.95" origin="0.5,0.5"/>
+  </Item>
+  <!--Cafeteria and Garden Assets-->
+  <Item name="" identifier="op_cafeteriawindow" width="600" height="217" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" sourcerect="2,2,600,217" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_gardendistiller" width="370" height="355" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" sourcerect="606,2,370,355" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_cafeteriabench" width="332" height="209" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" sourcerect="2,223,332,209" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_cafeteriatable" width="252" height="172" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" sourcerect="338,223,252,172" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_gardenbags1" nameidentifier="op_gardenbags" width="323" height="195" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" sourcerect="594,361,323,195" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_cafeteriacart" width="191" height="329" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" sourcerect="2,647,191,329" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_gardenbags2" nameidentifier="op_gardenbags" width="282" height="77" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" sourcerect="2,560,282,77" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_gardenplanter" nameidentifier="smallplanter" width="107" height="106" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" sourcerect="2,436,107,106" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_gardenproducebox" width="266" height="250" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" sourcerect="288,524,266,250" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_cafeteriachair" width="152" height="240" scale="0.5" noninteractable="false" category="Decorative" canflipy="false">
+    <sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" sourcerect="197,778,152,240" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <Controller UserPos="10,30" direction="Right" hidehud="false" canbeselected="true" issecondaryitem="true" drawuserbehind="true">
+      <limbposition limb="Head" position="45,40" />
+      <limbposition limb="Torso" position="50,-30" />
+      <limbposition limb="Waist" position="50,-80" />
+      <limbposition limb="RightLeg" position="165,-140" />
+      <limbposition limb="LeftLeg" position="165,-140" />
+      <limbposition limb="RightHand" position="120,-80" allowusinglimb="true" />
+      <limbposition limb="LeftHand" position="120,-80" allowusinglimb="true" />
+    </Controller>
+  </Item>
+
+  <Item name="" identifier="op_gardenplanter2" nameidentifier="smallplanter" width="107" height="106" scale="0.5" noninteractable="true" category="Decorative">
+    <Sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.45" sourcerect="593,696,202,64" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.49" sourcerect="480,789,138,104" offset="0,60" randomrotation="-60,60" randomscale="0.8,1" randomoffset="80,10" origin="0.5,0.5" randomgroupid="1" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.52" sourcerect="619,789,138,104" offset="0,60" randomrotation="-60,60" randomscale="0.8,1" randomoffset="80,10" origin="0.5,0.5" randomgroupid="2" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.48" sourcerect="766,775,121,104" offset="0,60" randomrotation="-60,60" randomscale="0.8,1" randomoffset="80,10" origin="0.5,0.5" randomgroupid="3" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.51" sourcerect="480,789,138,104" offset="0,60" randomrotation="-60,60" randomscale="0.8,1" randomoffset="80,10" origin="0.5,0.5" randomgroupid="2" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.47" sourcerect="619,789,138,104" offset="0,60" randomrotation="-60,60" randomscale="0.8,1" randomoffset="80,10" origin="0.5,0.5" randomgroupid="3" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.50" sourcerect="766,775,121,104" offset="0,60" randomrotation="-60,60" randomscale="0.8,1" randomoffset="80,10" origin="0.5,0.5" randomgroupid="1" />
+  </Item>
+  <Item name="" identifier="op_gardenplanter3" nameidentifier="smallplanter" width="107" height="106" scale="0.5" noninteractable="true" category="Decorative">
+    <Sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.45" sourcerect="919,946,83,59" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.49" sourcerect="497,910,96,100" offset="0,50" randomrotation="-20,20" randomscale="0.5,1" randomoffset="20,20" origin="0.5,0.5" randomgroupid="1" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.48" sourcerect="612,912,96,100" offset="0,50" randomrotation="-20,20" randomscale="0.5,1" randomoffset="20,20" origin="0.5,0.5" randomgroupid="2" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.51" sourcerect="724,912,96,100" offset="0,50" randomrotation="-20,20" randomscale="0.5,1" randomoffset="20,20" origin="0.5,0.5" randomgroupid="3" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.47" sourcerect="497,910,96,100" offset="0,50" randomrotation="-20,20" randomscale="0.5,1" randomoffset="20,20" origin="0.5,0.5" randomgroupid="2" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.50" sourcerect="612,912,96,100" offset="0,50" randomrotation="-20,20" randomscale="0.5,1" randomoffset="20,20" origin="0.5,0.5" randomgroupid="3" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.46" sourcerect="724,912,96,100" offset="0,50" randomrotation="-20,20" randomscale="0.5,1" randomoffset="20,20" origin="0.5,0.5" randomgroupid="1" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.52" sourcerect="919,864,83,82" origin="0.5,0.5" offset="0,70"/>
+  </Item>
+
+  <!--Adminstration and Residential Assets-->
+  <Item name="" identifier="op_freezer" width="273" height="394" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="0,0,273,394" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clothesrack" width="286" height="356" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="274,0,284,356" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <Upgrade gameversion="1.5.0.0" refreshrect="true" />
+  </Item>
+  <Item name="" identifier="op_washingmachine" width="199" height="262" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="273,357,199,262" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="848,627,99,99" depth="0.98" premultiplyalpha="false" origin="0.5,0.5" rotationspeed="-715" />
+  </Item>
+  <Item name="" identifier="op_smallcouch" width="254" height="173" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="0,394,254,173" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_metalchair" width="269" height="162" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="472,357,269,162" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_boxcart" width="177" height="199" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="0,567,177,199" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_janitorcart" width="140" height="242" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="472,519,140,242" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_inkpainting" width="234" height="125" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="559,222,234,125" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_towellocker" width="107" height="236" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="177,619,107,236" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_banner" width="119" height="211" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="284,619,119,211" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_painting2" nameidentifier="op_painting1" width="137" height="176" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="612,519,137,176" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_raptorhead" width="160" height="131" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="612,695,160,131" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_statue" width="124" height="163" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="741,347,124,163" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_painting1" width="150" height="117" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="749,510,150,117" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_shower" width="76" height="159" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="772,627,76,159" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_trophy2" nameidentifier="opdeco_officedisplay1" width="62" height="99" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="767,0,62,99" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sworddisplay" width="183" height="60" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="403,761,183,60" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_trophy3" nameidentifier="opdeco_officedisplay1" width="60" height="106" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="403,619,60,106" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_trophy1" nameidentifier="opdeco_officedisplay1" width="59" height="100" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="848,726,59,100" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_wetsign" width="50" height="116" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="739,103,50,116" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+
+  <!--Flickering hologram displays-->
+  <Item name="" identifier="op_hologramdisplay1" width="157" height="95" texturescale="1.0,1.0" scale="0.5" category="Decorative" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="2,657,157,95" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="10.0" lightcolor="111,199,255,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="1.0">
+      <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="2,657,157,95" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_hologramdisplay2" nameidentifier="op_hologramdisplay1" width="128" height="78" texturescale="1.0,1.0" scale="0.5" category="Decorative" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="160,656,128,78" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="10.0" lightcolor="111,199,255,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="1.0">
+      <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="160,656,128,78" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_hologramdisplay3" nameidentifier="op_hologramdisplay1" width="128" height="80" texturescale="1.0,1.0" scale="0.5" category="Decorative" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="0,752,128,80" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="10.0" lightcolor="111,199,255,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="1.0">
+      <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="0,752,128,80" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_hologramdisplay4" nameidentifier="op_hologramdisplay1" width="129" height="81" texturescale="1.0,1.0" scale="0.5" category="Decorative" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="159,735,129,81" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="10.0" lightcolor="111,199,255,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="1.0">
+      <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="159,735,129,81" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="opdeco_screen01" nameidentifier="opdeco_screen" width="96" height="64" texturescale="1.0,1.0" scale="0.5" category="Decorative" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="752,352,96,64" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="111,199,255,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="0.0">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="752,352,96,64" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="opdeco_screen02" nameidentifier="opdeco_screen" width="96" height="64" texturescale="1.0,1.0" scale="0.5" category="Decorative" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="752,416,96,64" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="60,110,66,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="0.0">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="752,416,96,64" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="opdeco_screen03" nameidentifier="opdeco_screen" width="96" height="64" texturescale="1.0,1.0" scale="0.5" category="Decorative" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="752,480,96,64" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="200,180,60,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="0.0">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="752,480,96,64" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="opdeco_screen04" nameidentifier="opdeco_screen" width="96" height="64" texturescale="1.0,1.0" scale="0.5" category="Decorative" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="304,672,96,64" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="220,95,60,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="0.0">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="304,672,96,64" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <!--Shop containers-->
+  <Item name="" identifier="opdeco_container" width="160" height="336" texturescale="1.0,1.0" scale="0.5" category="Decorative" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/Shop.png" sourcerect="0,0,160,336" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="111,199,175,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="0.0">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/Shop.png" sourcerect="400,672,160,336" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="opdeco_shopsuit1" width="160" height="336" texturescale="1.0,1.0" scale="0.5" category="Decorative" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/Shop.png" sourcerect="160,0,160,336" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="111,199,175,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="0.0">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/Shop.png" sourcerect="560,672,160,336" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="opdeco_shopsuit2" nameidentifier="opdeco_shopsuit1" width="160" height="336" texturescale="1.0,1.0" scale="0.5" category="Decorative" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/Shop.png" sourcerect="320,0,160,336" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="111,199,175,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="0.0">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/Shop.png" sourcerect="720,672,160,336" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <!--Research tanks and monitoring tables-->
+  <Item name="" identifier="op_researchcontainmenttank1" width="414" height="297" texturescale="1.0,1.0" scale="0.5" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/MedicalItemResearch.png" sourcerect="0,6,414,297" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="255,255,255,111" IsOn="true" castshadows="false" allowingameediting="false">
+      <sprite texture="Content/Map/Outposts/Art/MedicalItemResearchLights.png" sourcerect="0,6,414,297" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_researchtable" width="732" height="248" texturescale="1.0,1.0" scale="0.5" category="Decorative" requirecampaigninteract="true">
+    <sprite texture="Content/Map/Outposts/Art/MedicalItemResearch.png" sourcerect="3,311,732,248" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="255,255,255,111" IsOn="true" castshadows="false" allowingameediting="false">
+      <sprite texture="Content/Map/Outposts/Art/MedicalItemResearchLights.png" sourcerect="3,311,732,248" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_researchcontainmenttank2" nameidentifier="op_researchcontainmenttank1" width="201" height="281" texturescale="1.0,1.0" scale="0.5" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/MedicalItemResearch.png" sourcerect="3,567,201,281" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="255,255,255,111" IsOn="true" castshadows="false" allowingameediting="false">
+      <sprite texture="Content/Map/Outposts/Art/MedicalItemResearchLights.png" sourcerect="3,567,201,281" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_researchcontainmenttank3" nameidentifier="op_researchcontainmenttank1" width="221" height="364" texturescale="1.0,1.0" scale="0.5" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/MedicalItemResearch.png" sourcerect="209,562,221,364" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/MedicalItemResearch.png" sourcerect="432,564,222,357" depth="0.98" origin="0.5,0.5"/>
+    <DecorativeSprite texture="Content/Map/Outposts/Art/MedicalItemResearch.png" sourcerect="742,662,63,91" depth="0.975" origin="0.5,0.5" offset="80,80" offsetanim="Noise" rotationanim="Noise" rotation="80" rotationspeed="0.5" offsetanimspeed="0.05" />
+    <LightComponent range="0.0" lightcolor="255,255,255,111" IsOn="true" castshadows="false" allowingameediting="false">
+      <sprite texture="Content/Map/Outposts/Art/MedicalItemResearchLights.png" sourcerect="209,562,221,364" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_vendingmachine1" tags="vendingmachine" width="238" height="396" texturescale="1.0,1.0" scale="0.5" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="1,497,238,396" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <Fabricator canbeselected="true" powerconsumption="0.0" msg="ItemMsgInteractSelect" createbuttontext="campaignstoretab.buy">
+      <GuiFrame relativesize="0.4,0.5" style="ItemUI" anchor="Center" />
+      <sound file="Content/Items/Fabricators/Fabricator.ogg" type="OnActive" range="200.0" loop="true"/>
+    </Fabricator>
+    <ItemContainer capacity="0" canbeselected="false" hideitems="true" slotsperrow="1" uilabel="" allowuioverlap="true"/>
+    <ItemContainer capacity="1" canbeselected="true" hideitems="true" slotsperrow="1" uilabel="" allowuioverlap="true"/>
+    <LightComponent range="0.0" lightcolor="255,255,255,111" IsOn="true" castshadows="false" alphablend="false" allowingameediting="false">
+      <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="241,497,238,396" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_vendingmachine2" nameidentifier="op_vendingmachine1" tags="vendingmachine" width="238" height="396" texturescale="1.0,1.0" scale="0.5" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="481,497,238,396" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <Fabricator canbeselected="true" powerconsumption="0.0" msg="ItemMsgInteractSelect" createbuttontext="campaignstoretab.buy">
+      <GuiFrame relativesize="0.4,0.5" style="ItemUI" anchor="Center" />
+      <sound file="Content/Items/Fabricators/Fabricator.ogg" type="OnActive" range="200.0" loop="true"/>
+    </Fabricator>
+    <ItemContainer capacity="0" canbeselected="false" hideitems="true" slotsperrow="1" uilabel="" allowuioverlap="true"/>
+    <ItemContainer capacity="1" canbeselected="true" hideitems="true" slotsperrow="1" uilabel="" allowuioverlap="true"/>
+    <LightComponent range="0.0" lightcolor="255,255,255,111" IsOn="true" castshadows="false" alphablend="false" allowingameediting="false">
+      <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="721,497,238,396" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_workbenchlamp" width="127" height="119" texturescale="1.0,1.0" scale="0.5" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/Shop.png" sourcerect="96,481,127,119" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="255,117,0,111" IsOn="true" castshadows="false" allowingameediting="false">
+      <sprite texture="Content/Map/Outposts/Art/Shop.png" sourcerect="96,597,127,134" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <!--Dorm-->
+  <Item name="" identifier="opdeco_bunkbeds" width="356" height="264" texturescale="1.0,1.0" scale="0.5" category="Decorative" spritecolor="255,255,255,255">
+    <Upgrade gameversion="0.12.0.0" noninteractable="false" />
+    <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1600,1760,384,264" depth="0.85" premultiplyalpha="false" origin="0.5,0.5" />
+    <Controller UserPos="0,-300" direction="Right" hidehud="false" canbeselected="true" drawuserbehind="true" noninteractablewhenflippedy="true">
+      <!-- don't allow laying in bed when wearing an exosuit -->
+      <RequiredItem items="deepdivinglarge" type="Picked" requireempty="true" />
+      <limbposition limb="Head" position="-26,-170" />
+      <limbposition limb="Torso" position="84,-140" />
+      <limbposition limb="Waist" position="224,-160" />
+      <limbposition limb="RightFoot" position="444,-160" />
+      <limbposition limb="LeftFoot" position="444,-160" />
+      <limbposition limb="RightHand" position="224,-160" allowusinglimb="false" />
+      <limbposition limb="LeftHand" position="224,-160" allowusinglimb="false" />
+      <StatusEffect type="OnActive" target="Character">
+        <reduceaffliction type="damage" strength="0.05" />
+        <reduceaffliction identifier="concussion" strength="0.02" />
+        <reduceaffliction identifier="infection" strength="0.02" />
+        <reduceaffliction identifier="bloodloss" strength="0.05" />
+        <reduceaffliction identifier="bleeding" strength="0.05" />
+        <reduceaffliction identifier="nausea" strength="0.08" />
+        <reduceaffliction identifier="opiatewithdrawal" strength="0.06" />
+        <reduceaffliction identifier="opiateaddiction" strength="0.06" />
+        <reduceaffliction identifier="drunk" strength="0.08" />
+      </StatusEffect>
+    </Controller>
+    <Upgrade gameversion="0.20.8.0">
+      <Controller>
+        <RequiredItem items="deepdivinglarge" type="Picked" requireempty="true" />
+      </Controller>
+    </Upgrade>
+  </Item>
+  <Item name="" identifier="opdeco_bunks1" nameidentifier="opdeco_bunks1" allowattachitems="false" width="463" height="398" texturescale="1.0,1.0" scale="0.5" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1296,1289,463,387" depth="0.85" premultiplyalpha="false" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1390,1126,320,160" depth="0.86" origin="0.5,0.5" offset="40,-95" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1390,1126,320,160" depth="0.86" origin="0.5,0.5" offset="40,105" />
+    <Controller UserPos="0,-300" direction="Right" hidehud="false" canbeselected="true" drawuserbehind="true" noninteractablewhenflippedy="true">
+      <!-- don't allow laying in bed when wearing an exosuit -->
+      <RequiredItem items="deepdivinglarge" type="Picked" requireempty="true" />
+      <limbposition limb="Head" position="14,-300" />
+      <limbposition limb="Torso" position="124,-270" />
+      <limbposition limb="Waist" position="264,-290" />
+      <limbposition limb="RightFoot" position="484,-290" />
+      <limbposition limb="LeftFoot" position="484,-290" />
+      <limbposition limb="RightHand" position="264,-290" allowusinglimb="false" />
+      <limbposition limb="LeftHand" position="264,-290" allowusinglimb="false" />
+      <StatusEffect type="OnActive" target="Character">
+        <reduceaffliction type="damage" strength="0.05" />
+        <reduceaffliction identifier="concussion" strength="0.02" />
+        <reduceaffliction identifier="infection" strength="0.02" />
+        <reduceaffliction identifier="bloodloss" strength="0.05" />
+        <reduceaffliction identifier="bleeding" strength="0.05" />
+        <reduceaffliction identifier="nausea" strength="0.08" />
+        <reduceaffliction identifier="opiatewithdrawal" strength="0.06" />
+        <reduceaffliction identifier="opiateaddiction" strength="0.06" />
+        <reduceaffliction identifier="drunk" strength="0.08" />
+      </StatusEffect>
+    </Controller>
+    <Upgrade gameversion="0.20.8.0">
+      <Controller>
+        <RequiredItem items="deepdivinglarge" type="Picked" requireempty="true" />
+      </Controller>
+    </Upgrade>
+  </Item>
+  <Item name="" identifier="opdeco_hospitalbed" width="416" height="192" texturescale="1.0,1.0" scale="0.5" noninteractable="false" category="Decorative">
+    <Upgrade gameversion="0.12.0.0" noninteractable="false" />
+    <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="96,304,416,192" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <Controller UserPos="0,-300" direction="Right" hidehud="false" issecondaryitem="true" canbeselected="true" noninteractablewhenflippedy="true" drawuserbehind="true">
+      <!-- don't allow laying in bed when wearing an exosuit -->
+      <RequiredItem items="deepdivinglarge" type="Picked" requireempty="true" />
+      <limbposition limb="Head" position="-6,-10" />
+      <limbposition limb="Torso" position="104,0" />
+      <limbposition limb="Waist" position="244,-80" />
+      <limbposition limb="RightFoot" position="380,-20" />
+      <limbposition limb="LeftFoot" position="380,-20" />
+      <limbposition limb="RightHand" position="234,-10" allowusinglimb="false" />
+      <limbposition limb="LeftHand" position="234,-10" allowusinglimb="false" />
+      <StatusEffect type="OnActive" target="Character">
+        <reduceaffliction type="damage" strength="0.075" />
+        <reduceaffliction identifier="concussion" strength="0.025" />
+        <reduceaffliction identifier="infection" strength="0.025" />
+        <reduceaffliction identifier="bloodloss" strength="0.075" />
+        <reduceaffliction identifier="bleeding" strength="0.075" />
+        <reduceaffliction identifier="nausea" strength="0.1" />
+        <reduceaffliction identifier="opiatewithdrawal" strength="0.08" />
+        <reduceaffliction identifier="opiateaddiction" strength="0.08" />
+        <reduceaffliction identifier="drunk" strength="0.1" />
+      </StatusEffect>
+    </Controller>
+    <Upgrade gameversion="0.20.8.0">
+      <Controller>
+        <RequiredItem items="deepdivinglarge" type="Picked" requireempty="true" />
+      </Controller>
+    </Upgrade>
+  </Item>
+  <Item name="" identifier="opdeco_prisonbed" allowattachitems="true" width="384" height="96" texturescale="1.0,1.0" scale="0.5" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="864,1888,384,96" depth="0.98" premultiplyalpha="false" origin="0.5,0.5" />
+    <Controller UserPos="0,-300" direction="Right" hidehud="false" issecondaryitem="true" canbeselected="true" noninteractablewhenflippedy="true" drawuserbehind="true">
+      <!-- don't allow laying in bed when wearing an exosuit -->
+      <RequiredItem items="deepdivinglarge" type="Picked" requireempty="true" />
+      <limbposition limb="Head" position="-6,-10" />
+      <limbposition limb="Torso" position="104,20" />
+      <limbposition limb="Waist" position="244,-60" />
+      <limbposition limb="RightFoot" position="380,0" />
+      <limbposition limb="LeftFoot" position="380,0" />
+      <limbposition limb="RightHand" position="234,10" allowusinglimb="false" />
+      <limbposition limb="LeftHand" position="234,10" allowusinglimb="false" />
+      <StatusEffect type="OnActive" target="Character">
+        <reduceaffliction type="damage" strength="0.05" />
+        <reduceaffliction identifier="concussion" strength="0.02" />
+        <reduceaffliction identifier="infection" strength="0.02" />
+        <reduceaffliction identifier="bloodloss" strength="0.05" />
+        <reduceaffliction identifier="bleeding" strength="0.05" />
+        <reduceaffliction identifier="nausea" strength="0.08" />
+        <reduceaffliction identifier="opiatewithdrawal" strength="0.06" />
+        <reduceaffliction identifier="opiateaddiction" strength="0.06" />
+        <reduceaffliction identifier="drunk" strength="0.08" />
+      </StatusEffect>
+    </Controller>
+    <Upgrade gameversion="0.20.8.0">
+      <Controller>
+        <RequiredItem items="deepdivinglarge" type="Picked" requireempty="true" />
+      </Controller>
+    </Upgrade>
+  </Item>
+
+  <Item name="" identifier="opdeco_heater" width="144" height="336" texturescale="1.0,1.0" scale="0.5" category="Decorative" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1291,1689,144,333" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="246,92,59,0" IsOn="true" castshadows="false" alphablend="false" allowingameediting="false" flicker="0.0" pulseamont="0.2" pulsefrequency="0.2">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <Upgrade gameversion="0.18.13.0" lightcolor="246,92,59,0" />
+      <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1441,1689,144,333" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+    </ConnectionPanel>
+  </Item>
+  <!--Tunnel wall with flickering lights-->
+  <Item name="" identifier="opbg_tunnel3" allowattachitems="true" width="831" height="416" scale="0.5" category="Decorative" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/TunnelWalls.png" sourcerect="0,416,831,416" depth="0.98" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="255,56,56,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="0.1" flickerspeed="0.1" blinkfrequency="1" >      
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/TunnelWalls.png" sourcerect="0,1248,832,372" depth="0.1" origin="0.5,0.55" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <!--Tunnel Light Tower-->
+  <Item name="" identifier="op_lighttower" width="176" height="352" texturescale="1.0,1.0" scale="0.5" category="Decorative" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/TunnelWalls.png" sourcerect="849,1697,176,352" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="160.0" lightcolor="255,234,181,200" IsOn="true" castshadows="false" allowingameediting="false">
+      <sprite texture="Content/Map/Outposts/Art/TunnelWalls.png" sourcerect="671,1697,176,352" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <!--Wall Decorations-->
+  <Item name="" identifier="op_lightbox1" width="163" height="209" texturescale="1.0,1.0" scale="0.5" category="Decorative" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="1337,590,163,209" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="60.0" lightcolor="255,234,181,200" IsOn="true" castshadows="false" allowingameediting="false"/>
+  </Item>
+  <Item name="" identifier="op_lightbox2" nameidentifier="op_lightbox1" width="159" height="206" texturescale="1.0,1.0" scale="0.5" category="Decorative" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="1526,586,159,206" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="60.0" lightcolor="255,234,181,200" IsOn="true" castshadows="false" allowingameediting="false"/>
+  </Item>
+  <Item name="" identifier="op_lightbox3" nameidentifier="op_lightbox1" width="289" height="194" texturescale="1.0,1.0" scale="0.5" category="Decorative" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="1760,394,289,194" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="60.0" lightcolor="255,234,181,200" IsOn="true" castshadows="false" allowingameediting="false"/>
+  </Item>
+  <Item name="" identifier="op_lightbox4" nameidentifier="op_lightbox1" width="145" height="194" texturescale="1.0,1.0" scale="0.5" category="Decorative" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="1759,1607,145,194" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="60.0" lightcolor="255,234,181,200" IsOn="true" castshadows="false" allowingameediting="false"/>
+  </Item>
+  <Item name="" identifier="op_lightbox5" nameidentifier="op_lightbox1" width="145" height="194" texturescale="1.0,1.0" scale="0.5" category="Decorative" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="1903,1607,144,194" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="60.0" lightcolor="255,234,181,200" IsOn="true" castshadows="false" allowingameediting="false"/>
+  </Item>
+  <!-- Medical -->
+  <Item name="" identifier="opdeco_mountedmonitor1" nameidentifier="medicalmonitor" width="96" height="128" texturescale="1.0,1.0" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="0,0,96,128" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="255,255,255,255" IsOn="true" castshadows="false" allowingameediting="false">
+      <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="96,0,96,128" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="opdeco_medcompartment1" nameidentifier="medicalcompartment" tags="container,suppliescontainer" linkable="true" width="80" height="80" texturescale="1.0,1.0" scale="0.5" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="192,0,80,80" depth="0.84" premultiplyalpha="false" origin="0.5,0.5" />
+    <ItemContainer capacity="3" slotsperrow="3" canbeselected="true" hideitems="true" msg="ItemMsgInteractSelect">
+      <GuiFrame relativesize="0.15,0.2" anchor="Center" style="ItemUI" />
+      <Containable items="smallitem,mediumitem" excludedidentifiers="mobilecontainer" />
+    </ItemContainer>
+  </Item>
+  <Item name="" identifier="opdeco_medcompartment2" nameidentifier="medicalcompartment" tags="container,suppliescontainer" linkable="true" width="48" height="80" texturescale="1.0,1.0" scale="0.5" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="272,0,48,80" depth="0.84" premultiplyalpha="false" origin="0.5,0.5" />
+    <ItemContainer capacity="2" slotsperrow="3" canbeselected="true" hideitems="true" msg="ItemMsgInteractSelect">
+      <GuiFrame relativesize="0.15,0.16" anchor="Center" style="ItemUI" />
+      <Containable items="smallitem,mediumitem" excludedidentifiers="mobilecontainer" />
+    </ItemContainer>
+  </Item>
+  <Item name="" identifier="opdeco_medcompartment3" nameidentifier="medicalcompartment" tags="container,suppliescontainer" linkable="true" width="80" height="128" texturescale="1.0,1.0" scale="0.5" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="400,0,80,128" depth="0.84" premultiplyalpha="false" origin="0.5,0.5" />
+    <ItemContainer capacity="6" slotsperrow="3" canbeselected="true" hideitems="true" msg="ItemMsgInteractSelect">
+      <GuiFrame relativesize="0.18,0.25" anchor="Center" style="ItemUI" />
+      <Containable items="smallitem,mediumitem" excludedidentifiers="mobilecontainer" />
+    </ItemContainer>
+  </Item>
+  <Item name="" identifier="opdeco_surgicallights" width="272" height="128" texturescale="1.0,1.0" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="752,0,272,128" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="255,255,255,0" IsOn="true" castshadows="false" alphablend="false" allowingameediting="false">
+      <Upgrade gameversion="0.18.12.0" lightcolor="255,255,255,0" />
+      <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="480,0,272,128" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="opdeco_xrayscreen" width="208" height="144" texturescale="1.0,1.0" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="304,160,208,144" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="255,255,255,0" IsOn="true" castshadows="false" alphablend="false" allowingameediting="false" flicker="0.1" pulsefrequency="0.5" pulseamount="0.2">      
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <Upgrade gameversion="0.18.12.0" lightcolor="255,255,255,0" />
+      <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="96,160,208,144" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="opdeco_xrayscreen2" nameidentifier="opdeco_xrayscreen" width="369" height="133" texturescale="1.0,1.0" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/MedicalColonyAssets.png" sourcerect="0,0,369,133" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="255,255,255,0" IsOn="true" castshadows="false" alphablend="false" allowingameediting="false" flicker="0.1" pulsefrequency="0.5" pulseamount="0.2">      
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <Upgrade gameversion="0.18.12.0" lightcolor="255,255,255,0" />
+      <sprite texture="Content/Map/Outposts/Art/MedicalColonyAssets.png" sourcerect="0,133,369,133" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="opdeco_xrayscreen3" nameidentifier="opdeco_xrayscreen" width="192" height="208" texturescale="1.0,1.0" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/MedicalColonyAssets.png" sourcerect="199,266,192,208" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="255,255,255,0" IsOn="true" castshadows="false" alphablend="false" allowingameediting="false" flicker="0.1" pulsefrequency="0.5" pulseamount="0.2">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <Upgrade gameversion="0.18.12.0" lightcolor="255,255,255,0" />
+      <sprite texture="Content/Map/Outposts/Art/MedicalColonyAssets.png" sourcerect="0,267,192,208" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="opdeco_wheelchair2" nameidentifier="opdeco_wheelchair1" tags="chair" allowattachitems="false" texturescale="1.0,1.0" scale="0.5" category="Decorative" canflipy="false">
+    <sprite texture="Content/Map/Outposts/Art/MedicalColonyAssets.png" sourcerect="452,781,249,225" depth="0.55" premultiplyalpha="false" origin="0.5,0.5" />
+    <Controller UserPos="10,30" direction="Right" hidehud="false" canbeselected="true" issecondaryitem="true" drawuserbehind="true">
+      <limbposition limb="Head" position="70,45" />
+      <limbposition limb="Torso" position="90,-30" />
+      <limbposition limb="Waist" position="95,-85" />
+      <limbposition limb="RightFoot" position="180,-220" />
+      <limbposition limb="LeftFoot" position="180,-220" />
+      <limbposition limb="RightHand" position="130,-100" allowusinglimb="true" />
+      <limbposition limb="LeftHand" position="130,-100" allowusinglimb="true" />
+    </Controller>
+  </Item>
+
+  <!--Outpost Machines-->
+  <Item name="" nameidentifier="reactor1" identifier="outpostreactor" tags="reactor" type="Reactor" linkable="true" category="Machine" damagedbyexplosions="true" scale="0.5" explosiondamagemultiplier="0.2">
+    <trigger />
+    <sprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="38,336,575,849" depth="0.8" origin="0.5,0.5" />
+    <UpgradePreviewSprite scale="3.0" texture="Content/UI/WeaponUI.png" sourcerect="0,960,64,64" origin="0.5,0.45" />
+    <BrokenSprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="473,1197,502,655" depth="0.79" maxcondition="50" offset="0,0" fadein="true" />
+    <BrokenSprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="975,1197,502,690" depth="0.79" maxcondition="10" offset="0,0" fadein="true" />
+    <aitarget sightrange="500" soundrange="7500" />
+    <Reactor canbeselected="true" firedelay="20" meltdowndelay="120" maxpoweroutput="20000" fuelconsumptionrate="0.2" vulnerabletoemp="false" msg="ItemMsgInteractSelect">
+      <StatusEffect type="InWater" target="This" condition="-0.5">
+        <Conditional condition="gt 10" />
+      </StatusEffect>
+      <GuiFrame relativesize="0.5,0.45" minsize="700,350" maxsize="2688,1166" anchor="Center" relativeoffset="0.1,0" style="ItemUI" />
+      <GraphLine texture="Content/Items/Reactor/graphLine.png">
+        <Sprite name="ReactorGraphLine" texture="Content/Items/Reactor/graphLine.png" sourcerect="0,0,32,32" />
+      </GraphLine>
+      <FissionRateMeter>
+        <Sprite name="FissionRateMeter" texture="Content/Items/Reactor/reactor.png" sourcerect="544,770,441,240" origin="0.5,1" />
+      </FissionRateMeter>
+      <TurbineOutputMeter>
+        <Sprite name="TurbineOutputMeter" texture="Content/Items/Reactor/reactor.png" sourcerect="544,770,441,240" origin="0.5,1" />
+      </TurbineOutputMeter>
+      <MeterPointer>
+        <Sprite name="MeterPointer" texture="Content/UI/UIAtlasDevices.png" sourcerect="938,846,31,167 " origin="0.5,0.9" />
+      </MeterPointer>
+      <SectorSprite>
+        <Sprite name="SectorSprite" texture="Content/UI/UIAtlasDevices.png" sourcerect="769,326,238,455" origin="0.95,0.5" />
+      </SectorSprite>
+      <TempMeterFrame>
+        <Sprite name="TempMeterFrame" texture="Content/UI/UIAtlasDevices.png" sourcerect="92,517,59,265" origin="0,0" size="0.5,1" />
+      </TempMeterFrame>
+      <TempMeterBar>
+        <Sprite name="TempMeterBar" texture="Content/UI/UIAtlasDevices.png" sourcerect="270,414,106,47" origin="0.5,0" />
+      </TempMeterBar>
+      <TempRangeIndicator>
+        <Sprite name="TempRangeIndicator" texture="Content/UI/UIAtlasDevices.png" sourcerect="31,614,52,25" origin="0.5,0.5" size="0.6,0.6" />
+      </TempRangeIndicator>
+      <RequiredSkill identifier="electrical" level="50" />
+      <RequiredItem items="idcard" type="Picked" msg="ItemMsgUnauthorizedAccess" ignoreineditor="true" />
+      <sound file="Content/Items/Reactor/Reactor.ogg" type="OnActive" range="2000.0" volumeproperty="FissionRate" volume="0.02" loop="true" />
+      <StatusEffect type="OnBroken" target="This" FissionRate="0.0" disabledeltatime="true">
+        <sound file="Content/Items/Weapons/ExplosionLarge2.ogg" type="OnUse" volume="10" selectionmode="Random" range="50000" dontmuffle="true" />
+        <sound file="Content/Items/Weapons/ExplosionDebris5.ogg" range="8000" />
+        <Explosion range="750" ballastfloradamage="1000" structuredamage="300" itemdamage="500" force="25.0" camerashake="0" debris="true" flashrange="10000" flashduration="5.0" screencolor="255,255,255,255" screencolorrange="5000" screencolorduration="3.0" decal="explosion" decalsize="1">
+          <Affliction identifier="explosiondamage" strength="500" />
+          <Affliction identifier="burn" strength="500" />
+          <Affliction identifier="stun" strength="15" />
+        </Explosion>
+        <Explosion range="2000" force="0.0" camerashake="200" camerashakerange="50000" showEffects="false" empstrength="1.25" applyfireeffects="false" ignorecover="true">
+          <Affliction identifier="radiationsickness" strength="75" />
+          <Affliction identifier="emp" strength="50" multiplybymaxvitality="true" />
+        </Explosion>
+        <ParticleEmitter particle="underwaterexplosion" anglemin="0" anglemax="360" particleamount="3" velocitymin="0" velocitymax="0" scalemin="15" scalemax="15" />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="Contained" Condition="0.0" setvalue="true" />
+    </Reactor>
+    <LightComponent range="300.0" lightcolor="255,186,152,119" powerconsumption="0" IsOn="false" castshadows="false" allowingameediting="false">
+      <IsActive targetitemcomponent="Reactor" temperature="gt 2" />
+      <sprite texture="Content/Map/Outposts/Art/GenericAssets2.png" depth="0.025" sourcerect="649,336,575,849" alphablend="false" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+    <LightComponent range="400" lightcolor="255,0,0,250" powerconsumption="0" IsOn="false" castshadows="false" allowingameediting="false" blinkfrequency="1">
+      <IsActive targetitemcomponent="Reactor" temperaturecritical="eq true" />
+    </LightComponent>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.3,0.35" minsize="400,350" maxsize="480,460" anchor="Center" style="ConnectionPanel" />
+      <RequiredSkill identifier="electrical" level="70" />
+      <StatusEffect type="OnFailure" target="Character" targetlimbs="LeftHand,RightHand" AllowWhenBroken="true">
+        <Sound file="Content/Sounds/Damage/Electrocution1.ogg" range="1000" />
+        <Explosion range="100.0" force="1.0" flames="false" shockwave="false" sparks="true" underwaterbubble="false" />
+        <Affliction identifier="stun" strength="4" probability="0.5" />
+        <Affliction identifier="electricshock" strength="60"/>
+        <Affliction identifier="burn" strength="5" />
+        <ParticleEmitter particle="ElectricShock" DistanceMin="10" DistanceMax="25" ParticleAmount="5" ScaleMin="0.1" ScaleMax="0.12" />
+      </StatusEffect>
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <output name="power_out" displayname="connection.powerout" maxwires="1" />
+      <output name="temperature_out" displayname="connection.temperatureout" />
+      <input name="shutdown" displayname="connection.shutdown" />
+      <input name="set_fissionrate" displayname="connection.setfissionrate" />
+      <input name="set_turbineoutput" displayname="connection.setturbineoutput" />
+      <output name="meltdown_warning" displayname="connection.meltdownwarning">
+        <StatusEffect type="OnUse" target="This">
+          <ParticleEmitter particle="smoke" particlespersecond="2" scalemin="1" scalemax="2.5" anglemax="360" velocitymin="-50" velocitymax="50" mincondition="15.0" maxcondition="50.0" />
+          <ParticleEmitter particle="swirlysmoke" particlespersecond="3" scalemin="1" scalemax="2" anglemin="0" anglemax="360" velocitymin="0" velocitymax="10" />
+          <sound file="Content/Items/Reactor/ReactorOverheatAlarm.ogg" type="OnUse" range="10000.0" loop="true" volume="1.0" />
+        </StatusEffect>
+      </output>
+      <output name="power_value_out" displayname="connection.powervalueout" />
+      <output name="load_value_out" displayname="connection.loadvalueout" />
+      <output name="fuel_out" displayname="connection.availablefuelout" />
+      <output name="condition_out" displayname="connection.conditionout" />
+      <output name="fuel_percentage_left" displayname="connection.fuelpercentageout" />
+    </ConnectionPanel>
+    <ItemContainer capacity="4" maxstacksize="1" canbeselected="true" hudpos="0.5,0.15" slotsperrow="1" uilabel="FuelRods">
+      <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="192,448,64,64" origin="0.5,0.5" />
+      <SlotIcon slotindex="1" texture="Content/UI/StatusMonitorUI.png" sourcerect="192,448,64,64" origin="0.5,0.5" />
+      <SlotIcon slotindex="2" texture="Content/UI/StatusMonitorUI.png" sourcerect="192,448,64,64" origin="0.5,0.5" />
+      <SlotIcon slotindex="3" texture="Content/UI/StatusMonitorUI.png" sourcerect="192,448,64,64" origin="0.5,0.5" />
+      <RequiredItem items="idcard" type="Picked" msg="ItemMsgUnauthorizedAccess" ignoreineditor="true" />
+      <Containable items="fuelrod">
+        <StatusEffect type="OnContaining" target="This" AvailableFuel="80.0" disabledeltatime="true" />
+      </Containable>
+      <Containable items="fulguriumfuelrod">
+        <StatusEffect type="OnContaining" target="This" AvailableFuel="150.0" disabledeltatime="true" />
+      </Containable>
+      <Containable items="thoriumfuelrod">
+        <StatusEffect type="OnContaining" target="This" AvailableFuel="100.0" disabledeltatime="true" />
+      </Containable>
+      <Containable items="fulguriumfuelrodvolatile">
+        <StatusEffect type="OnContaining" target="This" AvailableFuel="150.0" disabledeltatime="true" />
+      </Containable>
+      <Containable items="huskfigurine">
+        <StatusEffect type="OnContaining" target="This" AvailableFuel="0" disabledeltatime="true" />
+      </Containable>
+    </ItemContainer>
+    <Repairable selectkey="Action" header="electricalrepairsheader" deteriorationspeed="0.125" mindeteriorationdelay="120" maxdeteriorationdelay="720" MinDeteriorationCondition="10" minsabotagecondition="10" AIRepairThreshold="50" fixDurationHighSkill="5" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI" />
+      <RequiredSkill identifier="electrical" level="55" />
+      <RequiredItem items="wrench" type="equipped" />
+      <ParticleEmitter particle="damagebubbles" particlespersecond="2" scalemin="0.5" scalemax="1.5" anglemax="360" velocitymin="-10" velocitymax="10" mincondition="0.0" maxcondition="50.0" />
+      <ParticleEmitter particle="smoke" particlespersecond="2" scalemin="1" scalemax="2.5" anglemax="360" velocitymin="-50" velocitymax="50" mincondition="15.0" maxcondition="50.0" />
+      <ParticleEmitter particle="heavysmoke" particlespersecond="2" scalemin="1.0" scalemax="2.5" anglemax="360" distancemax="60" mincondition="0.0" maxcondition="15.0" />
+      <StatusEffect type="OnFailure" target="Character" targetlimbs="LeftHand,RightHand" AllowWhenBroken="true">
+        <Sound file="Content/Sounds/Damage/Electrocution1.ogg" range="1000" />
+        <Explosion range="100.0" force="1.0" flames="false" shockwave="false" sparks="true" underwaterbubble="false" />
+        <Affliction identifier="stun" strength="4" probability="0.5" />
+        <Affliction identifier="electricshock" strength="60"/>
+        <Affliction identifier="burn" strength="5" />
+        <ParticleEmitter particle="ElectricShock" DistanceMin="10" DistanceMax="25" ParticleAmount="5" ScaleMin="0.1" ScaleMax="0.12" />
+      </StatusEffect>
+    </Repairable>
+    <SkillRequirementHint identifier="electrical" level="50" />
+  </Item>
+  <Item name="" nameidentifier="oxygenerator" identifier="outpostoxygenerator" tags="oxygengenerator" category="Machine" linkable="true" allowedlinks="vent" damagedbyexplosions="true" scale="0.5" explosiondamagemultiplier="0.2">
+    <Sprite texture="Content/Map/Outposts/Art/GenericAssets2.png" depth="0.8" sourcerect="52,1197,360,410" origin="0.5,0.5" />
+    <BrokenSprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="2,1607,240,302" depth="0.79" origin="0.5,0.5" offset="100,0" maxcondition="80" fadein="true" />
+    <BrokenSprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="243,1629,213,286" depth="0.79" origin="0.5,0.5" offset="100,0" maxcondition="10" fadein="true" />
+    <UpgradePreviewSprite scale="2.5" texture="Content/UI/WeaponUI.png" sourcerect="384,960,64,64" origin="0.5,0.45" />
+    <OxygenGenerator powerconsumption="1000.0" minvoltage="0.5" generatedamount="5000" canbeselected="true" msg="ItemMsgInteractSelect">
+      <poweronsound file="Content/Items/PowerOnLight2.ogg" range="1500" loop="false" />
+      <sound file="Content/Items/OxygenGenerator/OxygenGenerator.ogg" type="OnActive" range="1000.0" volumeproperty="CurrFlow" volume="0.001" loop="true" />
+      <StatusEffect type="OnFire" target="This" Condition="-0.5" />
+      <StatusEffect type="OnActive" targettype="Contained" targets="oxygentank" Condition="2.0" />
+      <StatusEffect type="OnBroken" targettype="This" disabledeltatime="true">
+        <sound file="Content/Items/Weapons/ExplosionMedium1.ogg" range="3000" />
+        <sound file="Content/Items/Weapons/ExplosionMedium2.ogg" range="3000" />
+        <sound file="Content/Items/Weapons/ExplosionMedium3.ogg" range="3000" />
+        <Explosion range="50" stun="0" force="3.0" flames="false" shockwave="false" sparks="true" debris="true" underwaterbubble="false" />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="This">
+        <sound file="Content/Items/Weapons/ExplosionDebris3.ogg" range="2000" />
+      </StatusEffect>
+    </OxygenGenerator>
+    <trigger />
+    <ItemContainer capacity="5" maxstacksize="1" canbeselected="true" hideitems="false" itempos="163,-290" iteminterval="42,0" msg="ItemMsgOxygenRefill">
+      <GuiFrame relativesize="0.25,0.2" anchor="Center" style="ItemUI" />
+      <Containable items="oxygentank" />
+    </ItemContainer>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="power_in" displayname="connection.powerin" />
+      <output name="condition_out" displayname="connection.conditionout" />
+    </ConnectionPanel>
+    <Repairable selectkey="Action" header="mechanicalrepairsheader" deteriorationspeed="0.125" mindeteriorationdelay="120" maxdeteriorationdelay="750" mindeteriorationcondition="0" AIRepairThreshold="50" fixDurationHighSkill="5" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI" />
+      <RequiredSkill identifier="mechanical" level="55" />
+      <RequiredItem items="wrench" type="equipped" />
+      <ParticleEmitter particle="damagebubbles" particlespersecond="2" scalemin="0.5" scalemax="1.5" anglemax="360" velocitymin="-10" velocitymax="10" mincondition="0.0" maxcondition="50.0" />
+      <ParticleEmitter particle="smoke" particlespersecond="2" scalemin="1" scalemax="2.5" anglemax="360" velocitymin="-50" velocitymax="50" mincondition="15.0" maxcondition="50.0" />
+      <ParticleEmitter particle="heavysmoke" particlespersecond="2" scalemin="1.0" scalemax="2.5" anglemax="360" distancemax="60" maxcondition="15.0" />
+      <StatusEffect type="OnFailure" target="Character" targetlimbs="LeftHand,RightHand" AllowWhenBroken="true">
+        <Sound file="Content/Items/MechanicalRepairFail.ogg" range="1000" />
+        <Affliction identifier="lacerations" strength="5" />
+        <Affliction identifier="stun" strength="4" />
+      </StatusEffect>
+    </Repairable>
+  </Item>
+  <Item name="" identifier="outpostterminal" category="Machine" Tags="smallitem" cargocontaineridentifier="metalcrate" scale="0.5" impactsoundtag="impact_metal_light" isshootable="true">
+    <Upgrade gameversion="0.10.0.0" scale="0.5" />
+    <Sprite texture="Content/Map/Outposts/Art/Storage.png" depth="0.8" sourcerect="1544,506,142,149" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="255,255,255,0" powerconsumption="0" IsOn="true" castshadows="false" alphablend="false" allowingameediting="false">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/Storage.png" depth="0.025" sourcerect="1709,506,142,149" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+    <LightComponent range="0.0" lightcolor="255,255,255,0" powerconsumption="0" IsOn="true" castshadows="false" alphablend="false" allowingameediting="false" blinkfrequency="1">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/Storage.png" depth="0.025" sourcerect="1869,506,142,149" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+    <OutpostTerminal canbeselected="true" msg="ItemMsgInteractSelect" AllowInGameEditing="false" />
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem identifier="screwdriver" type="Equipped" />
+      <input name="signal_in" displayname="connection.signalin" />
+      <output name="signal_out" displayname="connection.signalout" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" identifier="opdeco_officechair" tags="chair" allowattachitems="false" texturescale="1.0,1.0" scale="0.45" category="Decorative" canflipy="false">
+    <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="570,341,180,267" depth="0.55" premultiplyalpha="false" origin="0.5,0.5" />
+    <Controller UserPos="10,30" direction="Right" hidehud="false" canbeselected="true" issecondaryitem="true" drawuserbehind="true">
+      <limbposition limb="Head" position="90,15" />
+      <limbposition limb="Torso" position="85,-60" />
+      <limbposition limb="Waist" position="90,-130" />
+      <limbposition limb="RightFoot" position="140,-250" />
+      <limbposition limb="LeftFoot" position="140,-250" />
+      <limbposition limb="RightHand" position="140,-105" allowusinglimb="true" />
+      <limbposition limb="LeftHand" position="140,-105" allowusinglimb="true" />
+    </Controller>
+  </Item>
+  <Item name="" identifier="opdeco_chair1" nameidentifier="opdeco_officechair" tags="chair" allowattachitems="true" texturescale="1.0,1.0" scale="0.5" category="Decorative" canflipy="false">
+    <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1233,31,144,240" depth="0.55" premultiplyalpha="false" origin="0.5,0.5" />
+    <Controller UserPos="-10,30" direction="Left" hidehud="false" canbeselected="true" issecondaryitem="true" drawuserbehind="true">
+      <limbposition limb="Head" position="82,18" />
+      <limbposition limb="Torso" position="80,-52" />
+      <limbposition limb="Waist" position="73,-105" />
+      <limbposition limb="RightFoot" position="-10,-230" />
+      <limbposition limb="LeftFoot" position="-10,-230" />
+      <limbposition limb="RightHand" position="40,-120" allowusinglimb="true" />
+      <limbposition limb="LeftHand" position="40,-120" allowusinglimb="true" />
+    </Controller>
+  </Item>
+  <Item name="" identifier="opdeco_chair2" nameidentifier="opdeco_officechair" tags="chair" allowattachitems="true" texturescale="1.0,1.0" scale="0.5" category="Decorative" canflipy="false">
+    <sprite texture="Content/Map/Outposts/Art/MedicalColonyAssets.png" sourcerect="744,784,144,240" depth="0.55" premultiplyalpha="false" origin="0.5,0.5" />
+    <Controller UserPos="10,30" direction="Right" hidehud="false" canbeselected="true" issecondaryitem="true" drawuserbehind="true">
+      <limbposition limb="Head" position="40,15" />
+      <limbposition limb="Torso" position="55,-60" />
+      <limbposition limb="Waist" position="60,-130" />
+      <limbposition limb="RightFoot" position="100,-230" />
+      <limbposition limb="LeftFoot" position="100,-230" />
+      <limbposition limb="RightHand" position="100,-100" allowusinglimb="true" />
+      <limbposition limb="LeftHand" position="100,-100" allowusinglimb="true" />
+    </Controller>
+  </Item>
+  <Item name="" identifier="opdeco_cabinetsdorm" allowattachitems="false" width="110" height="398" texturescale="1.0,1.0" scale="0.5" category="Decorative">
+    <Upgrade gameversion="0.16.2.0" refreshrect="true" PositionY="-88" />
+    <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1760,1360,117,309" depth="0.84" premultiplyalpha="false" origin="0.5,0.5" />
+    <ItemContainer capacity="6" slotsperrow="3" canbeselected="true" hideitems="true" msg="ItemMsgInteractSelect">
+      <GuiFrame relativesize="0.16,0.22" anchor="Center" style="ItemUI" />
+      <Containable items="smallitem,mediumitem" excludedidentifiers="mobilecontainer" />
+    </ItemContainer>
+    <!-- backwards compatibility for older versions in which mobile containers like storage containers were containable in any cabinet -->
+    <Upgrade gameversion="1.1.0.0" campaignsaveonly="true">
+      <ItemContainer>
+        <Containable items="smallitem,mediumitem" />
+        <ClearSubContainerRestrictions />
+      </ItemContainer>
+    </Upgrade>
+  </Item>
+  <Item name="" identifier="opdeco_trashcan" tags="outposttrashcan" width="122" height="201" texturescale="1.0,1.0" scale="0.5" category="Decorative" AllowStealingContainedItems="true">
+    <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1662,914,125,205" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <ItemContainer capacity="3" slotsperrow="3" canbeselected="true" hideitems="true" msg="ItemMsgInteractSelect">
+      <GuiFrame relativesize="0.18,0.25" anchor="Center" style="ItemUI" />
+      <Containable items="smallitem,mediumitem" />
+    </ItemContainer>
+  </Item>
+  <Item name="" identifier="opdeco_hrflyers" requirecampaigninteract="true" allowattachitems="true" width="416" height="224" texturescale="1.0,1.0" scale="0.5" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/HumanResourcesAssets.png" sourcerect="0,672,416,224" depth="0.98" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="opdeco_medcurtain" aliases="opdeco_medcurtainclosed,opdeco_medcurtainopen" category="Decorative" width="416" height="32" scale="0.5">
+    <Sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="96,128,416,32" depth="0.49" premultiplyalpha="false" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="512,128,384,368" depth="0.48" premultiplyalpha="false" origin="0.5,0.05">
+      <Conditional targetitemcomponent="Controller" State="eq true" />
+    </DecorativeSprite>
+    <DecorativeSprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="896,128,128,368" depth="0.48" premultiplyalpha="false" origin="1.5,0.05">
+      <Conditional targetitemcomponent="Controller" State="ne true" />
+    </DecorativeSprite>
+    <Controller direction="None" canbepicked="true" istoggle="true" msg="ItemMsgPressSelect" />
+  </Item>
+  <Item name="" identifier="opdeco_medcurtain2" aliases="opdeco_medcurtainclosed,opdeco_medcurtainopen" nameidentifier="opdeco_medcurtain" category="Decorative" width="416" height="32" scale="0.5">
+    <Sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="96,128,416,32" depth="0.49" premultiplyalpha="false" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/MedicalColonyAssets.png" sourcerect="391,0,373,364" depth="0.48" premultiplyalpha="false" origin="0.5,0.05">
+      <Conditional targetitemcomponent="Controller" State="eq true" />
+    </DecorativeSprite>
+    <DecorativeSprite texture="Content/Map/Outposts/Art/MedicalColonyAssets.png" sourcerect="764,0,104,364" depth="0.48" premultiplyalpha="false" origin="1.5,0.05">
+      <Conditional targetitemcomponent="Controller" State="ne true" />
+    </DecorativeSprite>
+    <Controller direction="None" canbepicked="true" istoggle="true" msg="ItemMsgPressSelect" />
+  </Item>
+  <Item name="" identifier="defendableposition" tags="defendable" type="Controller" HiddenInGame="true" width="63" height="112" scale="0.5" category="Weapon">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="872,182,63,112" depth="0.0" premultiplyalpha="false" origin="0.5,0.5" />
+    <Controller allowingameediting="false" UserPos="5.0, -50.0" direction="Right" canbeselected="true"
+                AllowSelectingWhenSelectedByBot="false" AllowSelectingWhenSelectedByOther="true" msg="ItemMsgInteractSelect" />
+  </Item>  
+</Items>

--- a/healing beds/OutpostItems.xml
+++ b/healing beds/OutpostItems.xml
@@ -602,7 +602,7 @@
     </LightComponent>
   </Item>
   <!--Dorm-->
-  <Item name="" identifier="opdeco_bunkbeds" width="356" height="264" texturescale="1.0,1.0" scale="0.5" category="Decorative" spritecolor="255,255,255,255">
+  <Item name="" identifier="opdeco_bunkbeds" tags="bed" width="356" height="264" texturescale="1.0,1.0" scale="0.5" category="Decorative" spritecolor="255,255,255,255">
     <Upgrade gameversion="0.12.0.0" noninteractable="false" />
     <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1600,1760,384,264" depth="0.85" premultiplyalpha="false" origin="0.5,0.5" />
     <Controller UserPos="0,-300" direction="Right" hidehud="false" canbeselected="true" drawuserbehind="true" noninteractablewhenflippedy="true">
@@ -616,7 +616,6 @@
       <limbposition limb="RightHand" position="224,-160" allowusinglimb="false" />
       <limbposition limb="LeftHand" position="224,-160" allowusinglimb="false" />
       <StatusEffect type="OnActive" target="Character">
-        <reduceaffliction type="damage" strength="0.05" />
         <reduceaffliction identifier="concussion" strength="0.02" />
         <reduceaffliction identifier="infection" strength="0.02" />
         <reduceaffliction identifier="bloodloss" strength="0.05" />
@@ -625,6 +624,8 @@
         <reduceaffliction identifier="opiatewithdrawal" strength="0.06" />
         <reduceaffliction identifier="opiateaddiction" strength="0.06" />
         <reduceaffliction identifier="drunk" strength="0.08" />
+        <!-- gives resting -->
+        <Affliction identifier="resting" strength="31"/>
       </StatusEffect>
     </Controller>
     <Upgrade gameversion="0.20.8.0">
@@ -633,7 +634,7 @@
       </Controller>
     </Upgrade>
   </Item>
-  <Item name="" identifier="opdeco_bunks1" nameidentifier="opdeco_bunks1" allowattachitems="false" width="463" height="398" texturescale="1.0,1.0" scale="0.5" category="Decorative">
+  <Item name="" identifier="opdeco_bunks1" tags="bed" nameidentifier="opdeco_bunks1" allowattachitems="false" width="463" height="398" texturescale="1.0,1.0" scale="0.5" category="Decorative">
     <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1296,1289,463,387" depth="0.85" premultiplyalpha="false" origin="0.5,0.5" />
     <DecorativeSprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1390,1126,320,160" depth="0.86" origin="0.5,0.5" offset="40,-95" />
     <DecorativeSprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1390,1126,320,160" depth="0.86" origin="0.5,0.5" offset="40,105" />
@@ -657,6 +658,8 @@
         <reduceaffliction identifier="opiatewithdrawal" strength="0.06" />
         <reduceaffliction identifier="opiateaddiction" strength="0.06" />
         <reduceaffliction identifier="drunk" strength="0.08" />
+        <!-- gives resting -->
+        <Affliction identifier="resting" strength="31"/>
       </StatusEffect>
     </Controller>
     <Upgrade gameversion="0.20.8.0">
@@ -665,7 +668,7 @@
       </Controller>
     </Upgrade>
   </Item>
-  <Item name="" identifier="opdeco_hospitalbed" width="416" height="192" texturescale="1.0,1.0" scale="0.5" noninteractable="false" category="Decorative">
+  <Item name="" identifier="opdeco_hospitalbed" tags="bed,medbed" width="416" height="192" texturescale="1.0,1.0" scale="0.5" noninteractable="false" category="Decorative">
     <Upgrade gameversion="0.12.0.0" noninteractable="false" />
     <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="96,304,416,192" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
     <Controller UserPos="0,-300" direction="Right" hidehud="false" issecondaryitem="true" canbeselected="true" noninteractablewhenflippedy="true" drawuserbehind="true">
@@ -688,6 +691,8 @@
         <reduceaffliction identifier="opiatewithdrawal" strength="0.08" />
         <reduceaffliction identifier="opiateaddiction" strength="0.08" />
         <reduceaffliction identifier="drunk" strength="0.1" />
+        <!-- gives resting faster -->
+        <Affliction identifier="resting" strength="32"/>
       </StatusEffect>
     </Controller>
     <Upgrade gameversion="0.20.8.0">
@@ -696,7 +701,7 @@
       </Controller>
     </Upgrade>
   </Item>
-  <Item name="" identifier="opdeco_prisonbed" allowattachitems="true" width="384" height="96" texturescale="1.0,1.0" scale="0.5" category="Decorative">
+  <Item name="" identifier="opdeco_prisonbed" tags="bed" allowattachitems="true" width="384" height="96" texturescale="1.0,1.0" scale="0.5" category="Decorative">
     <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="864,1888,384,96" depth="0.98" premultiplyalpha="false" origin="0.5,0.5" />
     <Controller UserPos="0,-300" direction="Right" hidehud="false" issecondaryitem="true" canbeselected="true" noninteractablewhenflippedy="true" drawuserbehind="true">
       <!-- don't allow laying in bed when wearing an exosuit -->
@@ -718,6 +723,8 @@
         <reduceaffliction identifier="opiatewithdrawal" strength="0.06" />
         <reduceaffliction identifier="opiateaddiction" strength="0.06" />
         <reduceaffliction identifier="drunk" strength="0.08" />
+        <!-- gives resting -->
+        <Affliction identifier="resting" strength="31"/>
       </StatusEffect>
     </Controller>
     <Upgrade gameversion="0.20.8.0">

--- a/healing beds/OutpostItems.xml
+++ b/healing beds/OutpostItems.xml
@@ -621,7 +621,7 @@
         <reduceaffliction identifier="infection" strength="0.02" />
         <reduceaffliction identifier="bloodloss" strength="0.05" />
         <reduceaffliction identifier="bleeding" strength="0.05" />
-        <reduceaffliction identifier="nausea" strength="0.08" />
+        <reduceaffliction identifier="nausea" strength="1" />
         <reduceaffliction identifier="opiatewithdrawal" strength="0.06" />
         <reduceaffliction identifier="opiateaddiction" strength="0.06" />
         <reduceaffliction identifier="drunk" strength="0.08" />
@@ -655,7 +655,7 @@
         <reduceaffliction identifier="infection" strength="0.02" />
         <reduceaffliction identifier="bloodloss" strength="0.05" />
         <reduceaffliction identifier="bleeding" strength="0.05" />
-        <reduceaffliction identifier="nausea" strength="0.08" />
+        <reduceaffliction identifier="nausea" strength="1" />
         <reduceaffliction identifier="opiatewithdrawal" strength="0.06" />
         <reduceaffliction identifier="opiateaddiction" strength="0.06" />
         <reduceaffliction identifier="drunk" strength="0.08" />
@@ -688,7 +688,7 @@
         <reduceaffliction identifier="infection" strength="0.025" />
         <reduceaffliction identifier="bloodloss" strength="0.075" />
         <reduceaffliction identifier="bleeding" strength="0.075" />
-        <reduceaffliction identifier="nausea" strength="0.1" />
+        <reduceaffliction identifier="nausea" strength="1" />
         <reduceaffliction identifier="opiatewithdrawal" strength="0.08" />
         <reduceaffliction identifier="opiateaddiction" strength="0.08" />
         <reduceaffliction identifier="drunk" strength="0.1" />
@@ -720,7 +720,7 @@
         <reduceaffliction identifier="infection" strength="0.02" />
         <reduceaffliction identifier="bloodloss" strength="0.05" />
         <reduceaffliction identifier="bleeding" strength="0.05" />
-        <reduceaffliction identifier="nausea" strength="0.08" />
+        <reduceaffliction identifier="nausea" strength="1" />
         <reduceaffliction identifier="opiatewithdrawal" strength="0.06" />
         <reduceaffliction identifier="opiateaddiction" strength="0.06" />
         <reduceaffliction identifier="drunk" strength="0.08" />

--- a/healing beds/OutpostItems.xml
+++ b/healing beds/OutpostItems.xml
@@ -616,6 +616,7 @@
       <limbposition limb="RightHand" position="224,-160" allowusinglimb="false" />
       <limbposition limb="LeftHand" position="224,-160" allowusinglimb="false" />
       <StatusEffect type="OnActive" target="Character">
+        <reduceaffliction type="damage" strength="0.05" />
         <reduceaffliction identifier="concussion" strength="0.02" />
         <reduceaffliction identifier="infection" strength="0.02" />
         <reduceaffliction identifier="bloodloss" strength="0.05" />


### PR DESCRIPTION
Beds currently heal very (too) slowly, so they feel somewhat pointless

**Changes:**
Beds now apply the "resting" affliction
Resting increases the effectiveness of medical items, up to 30% based on how long the character has been resting (up to 30s)


![image](https://github.com/FakeFishGames/Barotrauma/assets/73229309/f78b0fff-9ed0-4c04-8e15-03c783ae5507)

