### PR TITLE
Burst-Fire Weapons

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Holdable/RangedWeapon.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Holdable/RangedWeapon.cs
@@ -221,7 +221,7 @@ namespace Barotrauma.Items.Components
 
         public void ClientEventRead(IReadMessage msg, float sendingTime)
         {
-            burstIndex = msg.ReadInt32();
+            BurstIndex = msg.ReadInt32();
         }
     }
 }

--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Holdable/RangedWeapon.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Holdable/RangedWeapon.cs
@@ -1,4 +1,5 @@
-﻿using Barotrauma.Particles;
+﻿using Barotrauma.Networking;
+using Barotrauma.Particles;
 using Barotrauma.Sounds;
 using FarseerPhysics;
 using Microsoft.Xna.Framework;
@@ -9,7 +10,7 @@ using System.Linq;
 
 namespace Barotrauma.Items.Components
 {
-    partial class RangedWeapon : ItemComponent
+    partial class RangedWeapon : ItemComponent, IServerSerializable
     {
         protected Sprite crosshairSprite, crosshairPointerSprite;
 
@@ -20,7 +21,7 @@ namespace Barotrauma.Items.Components
         private RoundSound chargeSound;
 
         private SoundChannel chargeSoundChannel;
-        
+
         [Serialize(defaultValue: "0.5, 1.5", IsPropertySaveable.No, description: "Pitch slides from X to Y over the charge time")]
         public Vector2 ChargeSoundWindupPitchSlide
         {
@@ -28,7 +29,7 @@ namespace Barotrauma.Items.Components
             set
             {
                 _chargeSoundWindupPitchSlide = new Vector2(
-                        Math.Max(value.X, SoundChannel.MinFrequencyMultiplier), 
+                        Math.Max(value.X, SoundChannel.MinFrequencyMultiplier),
                         Math.Min(value.Y, SoundChannel.MaxFrequencyMultiplier));
             }
         }
@@ -179,7 +180,7 @@ namespace Barotrauma.Items.Components
 
             GUI.HideCursor = (crosshairSprite != null || crosshairPointerSprite != null) &&
                 GUI.MouseOn == null && !Inventory.IsMouseOnInventory && !GameMain.Instance.Paused;
-            
+
             if (GUI.HideCursor && !character.AnimController.IsHoldingToRope)
             {
                 if (crossHairPosDirtyTimer <= 0.0f)
@@ -202,7 +203,7 @@ namespace Barotrauma.Items.Components
         {
             Vector2 particlePos = item.WorldPosition + ConvertUnits.ToDisplayUnits(TransformedBarrelPos);
             float rotation = item.body.Rotation;
-			if (item.body.Dir < 0.0f) { rotation += MathHelper.Pi; }
+            if (item.body.Dir < 0.0f) { rotation += MathHelper.Pi; }
             foreach (ParticleEmitter emitter in particleEmitters)
             {
                 emitter.Emit(1.0f, particlePos, hullGuess: item.CurrentHull, angle: rotation, particleRotation: -rotation);
@@ -216,6 +217,11 @@ namespace Barotrauma.Items.Components
             crosshairSprite = null;
             crosshairPointerSprite?.Remove();
             crosshairSprite = null;
+        }
+
+        public void ClientEventRead(IReadMessage msg, float sendingTime)
+        {
+            burstIndex = msg.ReadInt32();
         }
     }
 }

--- a/Barotrauma/BarotraumaServer/ServerSource/Items/Components/Holdable/RangedWeapon.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Items/Components/Holdable/RangedWeapon.cs
@@ -1,0 +1,12 @@
+﻿using Barotrauma.Networking;
+
+namespace Barotrauma.Items.Components
+{
+    partial class RangedWeapon : ItemComponent, IServerSerializable
+    {
+        public void ServerEventWrite(IWriteMessage msg, Client c, NetEntityEvent.IData extraData = null)
+        {
+            msg.WriteInt32(burstIndex);
+        }
+    }
+}

--- a/Barotrauma/BarotraumaServer/ServerSource/Items/Components/Holdable/RangedWeapon.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Items/Components/Holdable/RangedWeapon.cs
@@ -6,7 +6,7 @@ namespace Barotrauma.Items.Components
     {
         public void ServerEventWrite(IWriteMessage msg, Client c, NetEntityEvent.IData extraData = null)
         {
-            msg.WriteInt32(burstIndex);
+            msg.WriteInt32(BurstIndex);
         }
     }
 }

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Holdable/RangedWeapon.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Holdable/RangedWeapon.cs
@@ -184,7 +184,8 @@ namespace Barotrauma.Items.Components
         private bool tryingToCharge;
 
         private Character prevUser;
-        private int burstPos;
+        private int burstIndex;
+        private bool ShouldForceFire => BurstMode == BurstType.Forced && burstIndex > 0;
 
         public RangedWeapon(Item item, ContentXElement element)
             : base(item, element)
@@ -228,11 +229,11 @@ namespace Barotrauma.Items.Components
             if (ReloadTimer < 0.0f)
             {
                 ReloadTimer = 0.0f;
-                if (BurstMode == BurstType.Forced && burstPos > 0)
+                if (ShouldForceFire)
                 {
                     if (!HasRequiredContainedItems(prevUser, false))
                     {
-                        burstPos = 0;
+                        burstIndex = 0;
                     }
                     else if (Use(deltaTime, prevUser))
                     {
@@ -330,14 +331,14 @@ namespace Barotrauma.Items.Components
         private readonly List<Body> ignoredBodies = new List<Body>();
         public override bool Use(float deltaTime, Character character = null)
         {
-            if (character == null || character.Removed) return false;
-            if (ReloadTimer > 0) return false;
+            if (character == null || character.Removed) { return false; }
+            if (ReloadTimer > 0) { return false; }
 
-            if (BurstMode != BurstType.Forced || burstPos <= 0)
+            if (!ShouldForceFire)
             {
                 tryingToCharge = true;
-                if (item.RequireAimToUse && !character.IsKeyDown(InputType.Aim)) return false;
-                if (currentChargeTime < MaxChargeTime) return false;
+                if (item.RequireAimToUse && !character.IsKeyDown(InputType.Aim)) { return false; }
+                if (currentChargeTime < MaxChargeTime) { return false; }
             }
 
             IsActive = true;
@@ -416,10 +417,10 @@ namespace Barotrauma.Items.Components
 
             if (BurstMode != BurstType.None)
             {
-                burstPos++;
-                if (burstPos >= BurstCount)
+                burstIndex++;
+                if (burstIndex >= BurstCount)
                 {
-                    burstPos = 0;
+                    burstIndex = 0;
                     SetReloadTimer(character, BurstReload, BurstReloadNoSkill);
                 }
             }

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Holdable/RangedWeapon.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Holdable/RangedWeapon.cs
@@ -71,8 +71,17 @@ namespace Barotrauma.Items.Components
             set;
         }
 
+        private BurstType burstMode;
         [Serialize("None", IsPropertySaveable.No, description: "The type of burst the weapon performs.")]
-        public BurstType BurstMode { get; set; }
+        public BurstType BurstMode
+        {
+            get => burstMode;
+            set
+            {
+                burstMode = value;
+                BurstIndex = 0;
+            }
+        }
 
         [Serialize(0, IsPropertySaveable.No, description: "The amount of shots fired in a single burst.")]
         public int BurstCount { get; set; }
@@ -266,7 +275,7 @@ namespace Barotrauma.Items.Components
                         return;
                     }
                 }
-                if (MaxChargeTime <= 0f)
+                if (MaxChargeTime <= 0f && !waitingForTriggerRelease)
                 {
                     IsActive = false;
                     return;

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Holdable/RangedWeapon.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Holdable/RangedWeapon.cs
@@ -16,15 +16,19 @@ namespace Barotrauma.Items.Components
             /// <summary>
             /// The weapon will not perform a burst.
             /// </summary>
-            None = 0,
+            None,
             /// <summary>
-            /// The burst count will not reset when the trigger is released.
+            /// The burst index will reset when the trigger is released.
             /// </summary>
-            Save = 1,
+            Reset,
+            /// <summary>
+            /// The burst index will not reset when the trigger is released.
+            /// </summary>
+            Save,
             /// <summary>
             /// The burst will continue even if the trigger is released.
             /// </summary>
-            Forced = 2
+            Forced
         }
 
         private float reload;
@@ -229,6 +233,10 @@ namespace Barotrauma.Items.Components
             if (ReloadTimer < 0.0f)
             {
                 ReloadTimer = 0.0f;
+                if (BurstMode == BurstType.Reset && !prevUser.HeldItems.Contains(Item) || !prevUser.IsKeyDown(InputType.Aim))
+                {
+                    burstIndex = 0;
+                }
                 if (ShouldForceFire)
                 {
                     if (!HasRequiredContainedItems(prevUser, false))

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Holdable/RangedWeapon.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Holdable/RangedWeapon.cs
@@ -333,7 +333,7 @@ namespace Barotrauma.Items.Components
             if (character == null || character.Removed) return false;
             if (ReloadTimer > 0) return false;
 
-            if (!forceFireOnReload)
+            if (BurstMode != BurstType.Forced || burstPos <= 0)
             {
                 tryingToCharge = true;
                 if (item.RequireAimToUse && !character.IsKeyDown(InputType.Aim)) return false;


### PR DESCRIPTION
This PR implements two types of burst-fire weapons:
- **Save**: The burst count will not reset when the trigger is released.
- **Forced**: The burst will continue even if the trigger is released.

They can be added to a RangedWeapon component using the following properties:
- **BurstMode** (BurstType) - The type of burst the weapon performs.
- **BurstCount** (int) - The amount of shots fired in a single burst.
- **BurstReload** (float) - How long the user has to wait before they can fire the weapon again after a burst (in seconds).
- **BurstReloadNoSkill** (float) - Burst reload time at 0 skill level. Reload time scales with skill level up to the Weapons skill requirement.