### PR TITLE
Fix typo in item version update logic

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Serialization/SerializableProperty/SerializableProperty.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Serialization/SerializableProperty/SerializableProperty.cs
@@ -1082,7 +1082,7 @@ namespace Barotrauma
                 {
                     var componentElement = subElement.FirstElement();
                     if (componentElement == null) { continue; }
-                    ItemComponent itemComponent = item2.Components.First(c => c.Name == componentElement.Name.ToString());
+                    ItemComponent itemComponent = item2.Components.FirstOrDefault(c => c.Name == componentElement.Name.ToString());
                     if (itemComponent == null) { continue; }
                     foreach (XAttribute attribute in componentElement.Attributes())
                     {


### PR DESCRIPTION
Current code uses `.First` instead of `.FirstOrDefault` as was likely the intention, given the null check. Not 100% sure what exact XML causes this to bug happen, but this was hit with a heavily modded game.

![image](https://github.com/user-attachments/assets/c66ebd29-e6d6-4f95-8001-6f59dbfbe375)

mod list:
[lex!.xml.txt](https://github.com/user-attachments/files/16706977/lex.xml.txt)
