### PR TITLE
Add OnInserted and OnRemoved StatusEffect ActionTypes.

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Enums.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Enums.cs
@@ -112,9 +112,17 @@ namespace Barotrauma
         /// </summary>
         OnSuccess = 22,
         /// <summary>
-        /// Executes when an Ability (an effect from a talent) triggers the status effect. Only valid in Abilities, the target can be either a character or an item depending on the type of Ability.
+        /// Executes when an item is placed inside a container. Only valid in Abilities, the target can be either a character or an item depending on the type of Ability.
         /// </summary>
         OnAbility = 23,
+        /// <summary>
+        /// Executes once when a specific Containable is placed inside an ItemContainer. Only valid for Containables defined in an ItemContainer component.
+        /// </summary>
+        OnInserted = 24,
+        /// <summary>
+        /// Executes once when a specific Containable is removed from an ItemContainer. Only valid for Containables defined in an ItemContainer component.
+        /// </summary>
+        OnRemoved = 25,
         /// <summary>
         /// Executes when the character dies. Only valid for characters.
         /// </summary>

--- a/Barotrauma/BarotraumaShared/SharedSource/Enums.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Enums.cs
@@ -112,7 +112,7 @@ namespace Barotrauma
         /// </summary>
         OnSuccess = 22,
         /// <summary>
-        /// Executes when an item is placed inside a container. Only valid in Abilities, the target can be either a character or an item depending on the type of Ability.
+        /// Executes when an Ability (an effect from a talent) triggers the status effect. Only valid in Abilities, the target can be either a character or an item depending on the type of Ability.
         /// </summary>
         OnAbility = 23,
         /// <summary>

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/ItemContainer.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/ItemContainer.cs
@@ -424,8 +424,8 @@ namespace Barotrauma.Items.Components
                             ActiveContainedItem activeContainedItem = new(containedItem, effect, containableItem.ExcludeBroken, containableItem.ExcludeFullCondition, containableItem.BlameEquipperForDeath);
                             activeContainedItems.Add(activeContainedItem);
 
-                            if (!TryProcessActiveContainedItem(activeContainedItem)) continue;
-                            activeContainedItem.StatusEffect.Apply(ActionType.OnInserted, 1, item, targets);
+                            if (!CheckActiveContainedItemAndSetTargets(activeContainedItem)) { continue; }
+                            activeContainedItem.StatusEffect.Apply(ActionType.OnInserted, deltaTime: 1, item, targets);
                         }
                     }
                 }
@@ -493,8 +493,8 @@ namespace Barotrauma.Items.Components
         {
             foreach (ActiveContainedItem activeContainedItem in activeContainedItems)
             {
-                if (activeContainedItem.Item != containedItem || !TryProcessActiveContainedItem(activeContainedItem)) continue;
-                activeContainedItem.StatusEffect.Apply(ActionType.OnRemoved, 1, item, targets);
+                if (activeContainedItem.Item != containedItem || !CheckActiveContainedItemAndSetTargets(activeContainedItem)) { continue; }
+                activeContainedItem.StatusEffect.Apply(ActionType.OnRemoved, deltaTime: 1, item, targets);
             }
 
             activeContainedItems.RemoveAll(i => i.Item == containedItem);
@@ -664,7 +664,7 @@ namespace Barotrauma.Items.Components
 
             foreach (ActiveContainedItem activeContainedItem in activeContainedItems)
             {
-                if (!TryProcessActiveContainedItem(activeContainedItem)) continue;
+                if (!CheckActiveContainedItemAndSetTargets(activeContainedItem)) continue;
 
                 StatusEffect effect = activeContainedItem.StatusEffect;
                 effect.Apply(ActionType.OnActive, deltaTime, item, targets);
@@ -676,12 +676,14 @@ namespace Barotrauma.Items.Components
             }
         }
 
-        private bool TryProcessActiveContainedItem(ActiveContainedItem activeContainedItem)
+        /// <summary>
+        /// Return true and set targets if the item's effect should apply, otherwise return false.
+        /// </summary>
+        private bool CheckActiveContainedItemAndSetTargets(ActiveContainedItem activeContainedItem)
         {
             Item contained = activeContainedItem.Item;
-
-            if (activeContainedItem.ExcludeBroken && contained.Condition <= 0) return false;
-            if (activeContainedItem.ExcludeFullCondition && contained.IsFullCondition) return false;
+            if (activeContainedItem.ExcludeBroken && contained.Condition <= 0) { return false; }
+            if (activeContainedItem.ExcludeFullCondition && contained.IsFullCondition) { return false; }
             StatusEffect effect = activeContainedItem.StatusEffect;
 
             targets.Clear();

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/ItemContainer.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/ItemContainer.cs
@@ -424,7 +424,7 @@ namespace Barotrauma.Items.Components
                             ActiveContainedItem activeContainedItem = new(containedItem, effect, containableItem.ExcludeBroken, containableItem.ExcludeFullCondition, containableItem.BlameEquipperForDeath);
                             activeContainedItems.Add(activeContainedItem);
 
-                            if (!CheckActiveContainedItemAndSetTargets(activeContainedItem)) { continue; }
+                            if (!ShouldApplyEffects(activeContainedItem)) { continue; }
                             activeContainedItem.StatusEffect.Apply(ActionType.OnInserted, deltaTime: 1, item, targets);
                         }
                     }
@@ -493,7 +493,7 @@ namespace Barotrauma.Items.Components
         {
             foreach (ActiveContainedItem activeContainedItem in activeContainedItems)
             {
-                if (activeContainedItem.Item != containedItem || !CheckActiveContainedItemAndSetTargets(activeContainedItem)) { continue; }
+                if (activeContainedItem.Item != containedItem || !ShouldApplyEffects(activeContainedItem)) { continue; }
                 activeContainedItem.StatusEffect.Apply(ActionType.OnRemoved, deltaTime: 1, item, targets);
             }
 
@@ -664,7 +664,7 @@ namespace Barotrauma.Items.Components
 
             foreach (ActiveContainedItem activeContainedItem in activeContainedItems)
             {
-                if (!CheckActiveContainedItemAndSetTargets(activeContainedItem)) continue;
+                if (!ShouldApplyEffects(activeContainedItem)) continue;
 
                 StatusEffect effect = activeContainedItem.StatusEffect;
                 effect.Apply(ActionType.OnActive, deltaTime, item, targets);
@@ -676,10 +676,7 @@ namespace Barotrauma.Items.Components
             }
         }
 
-        /// <summary>
-        /// Return true and set targets if the item's effect should apply, otherwise return false.
-        /// </summary>
-        private bool CheckActiveContainedItemAndSetTargets(ActiveContainedItem activeContainedItem)
+        private bool ShouldApplyEffects(ActiveContainedItem activeContainedItem)
         {
             Item contained = activeContainedItem.Item;
             if (activeContainedItem.ExcludeBroken && contained.Condition <= 0) { return false; }


### PR DESCRIPTION
This PR adds two new ActionTypes for StatusEffects:
- `OnInserted`
  - Executes once when a specific Containable is placed inside an ItemContainer.
  - Only valid for Containables defined in an ItemContainer component.
- `OnRemoved`
  - Executes once when a specific Containable is removed from an ItemContainer.
  - Only valid for Containables defined in an ItemContainer component.