### PR TITLE
Add "night vision" and "ability-to-see submarine icon" character parameters

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Map/Lights/LightManager.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Map/Lights/LightManager.cs
@@ -531,9 +531,17 @@ namespace Barotrauma.Lights
                 //ambient light decreases the brightness of the halo (no need for a bright halo if the ambient light is bright enough)
                 float ambientBrightness = (AmbientLight.R + AmbientLight.B + AmbientLight.G) / 255.0f / 3.0f;
                 Color haloColor = Color.White.Multiply(0.3f - ambientBrightness);
+                if (character.HasNightVision)
+                {
+                    haloColor.A = +100;
+                }
                 if (haloColor.A > 0)
                 {
                     float scale = 512.0f / LightSource.LightTexture.Width;
+                    if (character.HasNightVision)
+                    {
+                        scale = 5120.0f;
+                    }
                     spriteBatch.Draw(
                         LightSource.LightTexture, haloDrawPos, null, haloColor, 0.0f,
                         new Vector2(LightSource.LightTexture.Width, LightSource.LightTexture.Height) / 2, scale, SpriteEffects.None, 0.0f);

--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/GameScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/GameScreen.cs
@@ -131,7 +131,7 @@ namespace Barotrauma
 
             if (GameMain.GameSession != null) { GameMain.GameSession.Draw(spriteBatch); }
 
-            if (Character.Controlled == null && !GUI.DisableHUD)
+            if ((Character.Controlled == null || Character.Controlled.CanSeeSubmarineIcon) && !GUI.DisableHUD)
             {
                 for (int i = 0; i < Submarine.MainSubs.Length; i++)
                 {
@@ -143,7 +143,7 @@ namespace Barotrauma
                     Color indicatorColor = i == 0 ? Color.LightBlue * 0.5f : GUIStyle.Red * 0.5f;
                     GUI.DrawIndicator(
                         spriteBatch, position, cam, 
-                        Math.Max(Submarine.MainSub.Borders.Width, Submarine.MainSub.Borders.Height), 
+                        (Math.Max(Submarine.MainSub.Borders.Width, Submarine.MainSub.Borders.Height) * 0.6f), 
                         GUIStyle.SubmarineLocationIcon.Value.Sprite, indicatorColor); 
                 }
             }

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
@@ -435,6 +435,18 @@ namespace Barotrauma
             set => Params.CanSpeak = value;
         }
 
+        public bool CanSeeSubmarineIcon
+        {
+            get => Params.CanSeeSubmarineIcon;
+            set => Params.CanSeeSubmarineIcon = value;
+        }
+
+        public bool HasNightVision
+        {
+            get => Params.HasNightVision;
+            set => Params.HasNightVision = value;
+        }
+
         public bool NeedsAir
         {
             get => Params.NeedsAir;

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Params/CharacterParams.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Params/CharacterParams.cs
@@ -125,6 +125,12 @@ namespace Barotrauma
         [Serialize("", IsPropertySaveable.Yes, description: "Identifier or tag of the item the character's items are placed inside when the character despawns."), Editable]
         public Identifier DespawnContainer { get; private set; }
 
+        [Serialize(false, IsPropertySaveable.Yes, description: "Is the character able to see submarine icons when player controlled?"), Editable]
+        public bool CanSeeSubmarineIcon { get; set; }
+
+        [Serialize(false, IsPropertySaveable.Yes, description: "Does this character have night vision when player controlled?"), Editable]
+        public bool HasNightVision { get; set; }
+
         public readonly CharacterFile File;
 
         public XDocument VariantFile { get; private set; }


### PR DESCRIPTION
```
Added "CanSeeSubmarineIcon" and "HasNightVision" character boolean parameters, both false by default.

CanSeeSubmarineIcon allows the character to find submarines exactly like a spectator would.

HasNightVision increases the range of small passive light circle that players will see around their own characters and makes it brighten up the environment more, replicating a "night vision" effect, allowing them to see everything without needing light sources.

Reduced the threshold for hiding the submarine icon in order to make it disappear just as the submarine itself comes into view when approaching it as a small character.
```

No night vision in a dark room in multiplayer (human)
![](https://github.com/user-attachments/assets/c16f1f68-ba7d-4c34-993b-cfcade72d9e4)
Night vision in same room (crawler)
![](https://github.com/user-attachments/assets/45839422-7f65-4316-adf7-f791496fa2f8)

https://github.com/user-attachments/assets/e55c57e4-af8d-4e72-978b-3e321ecacbc9