### PR TITLE
Add optional corepackage custom client-side files

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/ContentManagement/ContentFile/CustomFilesFile.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/ContentManagement/ContentFile/CustomFilesFile.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Barotrauma.IO;
+
+namespace Barotrauma
+{
+    sealed class CustomFilesFile : OtherFile
+    {
+        public CustomFilesFile(ContentPackage contentPackage, ContentPath path) : base(contentPackage, path) { }
+
+        public static ContentPath MutateContentPath(ContentPath path)
+        {
+            if (File.Exists(path.FullPath)) { return path; }
+
+            string rawValueWithoutExtension()
+                => Barotrauma.IO.Path.Combine(
+                    Barotrauma.IO.Path.GetDirectoryName(path.RawValue ?? ""),
+                    Barotrauma.IO.Path.GetFileNameWithoutExtension(path.RawValue ?? "")).CleanUpPath();
+            
+            path = ContentPath.FromRaw(path.ContentPackage, rawValueWithoutExtension());
+            if (File.Exists(path.FullPath)) { return path; }
+            
+            path = ContentPath.FromRaw(path.ContentPackage,
+                rawValueWithoutExtension() + ".zip");
+            return path;
+        }
+    }
+}

--- a/Barotrauma/BarotraumaShared/SharedSource/ContentManagement/ContentPackage/CorePackage.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/ContentManagement/ContentPackage/CorePackage.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Xml.Linq;
+using System.IO.Compression;
 
 namespace Barotrauma
 {
@@ -42,6 +43,41 @@ namespace Barotrauma
             AssertCondition(!missingFileTypes.Any(),
                     "Core package requires at least one of the following content types: " +
                             string.Join(", ", missingFileTypes.Select(t => t.Type.Name)));
+        }
+
+        public void TryToInstallCustomFiles()
+        {
+#if CLIENT
+            string customFilesZip = Files.OfType<CustomFilesFile>().FirstOrDefault()?.Path?.FullPath;
+            if (!customFilesZip.IsNullOrEmpty())
+            {
+                // Convert these LocalizedStrings to normal strings so if the corepackage
+                // that's being switched over to changed one of these texts or one of them are missing it wont't sync.
+
+                var warningBox = new GUIMessageBox(headerText: TextManager.Get("Warning").ToString(),
+                    text: TextManager.Get("ModCustomClientFilesAtYourOwnRisk").ToString(),
+                    new LocalizedString[] { TextManager.Get("Yes").ToString(), TextManager.Get("No").ToString() });
+                warningBox.Buttons[0].OnClicked = (_, __) =>
+                {
+                    ZipFile.ExtractToDirectory(customFilesZip, AppDomain.CurrentDomain.BaseDirectory, true);
+                    warningBox.Close();
+
+                    var restartBox = new GUIMessageBox(TextManager.Get("restartrequiredlabel"), TextManager.Get("restartrequiredgeneric"));
+                    restartBox.Buttons[0].OnClicked += (btn, userdata) =>
+                    {
+                        restartBox.Close();
+                        return true;
+                    };
+
+                    return false;
+                };
+                warningBox.Buttons[1].OnClicked = (_, __) =>
+                {
+                    warningBox.Close();
+                    return false;
+                };
+            }
+#endif
         }
     }
 }

--- a/Barotrauma/BarotraumaShared/SharedSource/ContentManagement/ContentPackage/CorePackage.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/ContentManagement/ContentPackage/CorePackage.cs
@@ -59,8 +59,16 @@ namespace Barotrauma
                     new LocalizedString[] { TextManager.Get("Yes").ToString(), TextManager.Get("No").ToString() });
                 warningBox.Buttons[0].OnClicked = (_, __) =>
                 {
-                    ZipFile.ExtractToDirectory(customFilesZip, AppDomain.CurrentDomain.BaseDirectory, true);
                     warningBox.Close();
+                    try
+                    {
+                        ZipFile.ExtractToDirectory(customFilesZip, AppDomain.CurrentDomain.BaseDirectory, true);
+                    }
+                    catch (Exception e) 
+                    {
+                        DebugConsole.ThrowError($"An error occured while trying to install files: {e.Message}\n{e.StackTrace}");
+                        return false;
+                    }
 
                     var restartBox = new GUIMessageBox(TextManager.Get("restartrequiredlabel"), TextManager.Get("restartrequiredgeneric"));
                     restartBox.Buttons[0].OnClicked += (btn, userdata) =>

--- a/Barotrauma/BarotraumaShared/SharedSource/ContentManagement/ContentPackageManager.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/ContentManagement/ContentPackageManager.cs
@@ -48,7 +48,12 @@ namespace Barotrauma
                 public static ImmutableArray<RegularPackage>? Regular;
             }
 
-            public static void SetCore(CorePackage newCore) => SetCoreEnumerable(newCore).Consume();
+            public static void SetCore(CorePackage newCore)
+            {
+                newCore.TryToInstallCustomFiles();
+
+                SetCoreEnumerable(newCore).Consume();
+            }
             
             public static IEnumerable<LoadProgress> SetCoreEnumerable(CorePackage newCore)
             {


### PR DESCRIPTION
This PR aims to simplify source code modding so you don't have to run a command on a custom dedicated server or manually install client-side files. 

How it works is when you switch your corepackage it will check the new one for a CustomFiles ContentFile, if one is found the player is prompted asking if they want to install the client files. If the player says yes, the files are installed.

A sample mod that changes the unstable main menu background and the warning texts for the installation prompt are attached.

[ClientFilesWarningText.zip](https://github.com/user-attachments/files/16808810/ClientFilesWarningText.zip)
[Test Corepackage.zip](https://github.com/user-attachments/files/16808811/Test.Corepackage.zip)
