### PR TITLE
Singleplayer Crew Setup UI Refactor

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Characters/CharacterInfo.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Characters/CharacterInfo.cs
@@ -589,11 +589,10 @@ namespace Barotrauma
             return ch;
         }
 
-        public void CreateIcon(RectTransform rectT)
+        public GUICustomComponent CreateIcon(RectTransform rectT)
         {
             LoadHeadAttachments();
-            new GUICustomComponent(rectT,
-                onDraw: (sb, component) => DrawIcon(sb, component.Rect.Center.ToVector2(), targetAreaSize: component.Rect.Size.ToVector2()));
+            return new GUICustomComponent(rectT, onDraw: (sb, component) => DrawIcon(sb, component.Rect.Center.ToVector2(), targetAreaSize: component.Rect.Size.ToVector2()));
         }
 
         public class AppearanceCustomizationMenu : IDisposable


### PR DESCRIPTION
This PR aims to improve the look of the singleplayer crew setup UI, and add some functionality.
Aside from the visual changes, job variants can now be selected like in multiplayer.

**Preview:**
![image](https://github.com/user-attachments/assets/1dcdfabe-b6e3-4897-b419-9bba02ae24e0)
