### PR TITLE
Options to Display ItemComponents' Msg in Inventories

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Inventory.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Inventory.cs
@@ -339,6 +339,17 @@ namespace Barotrauma
                         toolTip += $"‖color:{conditionColorStr}‖ ({(int)item.ConditionPercentage} %)‖color:end‖";
                     }
                     if (!description.IsNullOrEmpty()) { toolTip += '\n' + description; }
+
+                    bool isOwnInventory = item.ParentInventory.Owner == Character.Controlled;
+                    foreach (ItemComponent component in item.Components)
+                    {
+                        if (isOwnInventory && component.ShowMsgInOwnInventory || component.ShowMsgInOtherInventory)
+                        {
+                            Color color = component.HasRequiredItems(character, false) ? Color.Cyan : Color.Gray;
+                            toolTip += $"\n‖color:{color.ToStringHex()}‖{component.DisplayMsg}‖color:end‖";
+                        }
+                    }
+
                     if (item.Prefab.ContentPackage != GameMain.VanillaContent && item.Prefab.ContentPackage != null)
                     {
                         colorStr = XMLExtensions.ToStringHex(Color.MediumPurple);

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/ItemComponent.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/ItemComponent.cs
@@ -255,6 +255,20 @@ namespace Barotrauma.Items.Components
             set;
         }
 
+        [Serialize(false, IsPropertySaveable.Yes, description: "If set to true, the component's message will also be displayed while in the controlled character's inventory.")]
+        public bool ShowMsgInOwnInventory
+        {
+            get;
+            set;
+        }
+
+        [Serialize(false, IsPropertySaveable.Yes, description: "If set to true, the component's message will also be displayed while in an inventory not owned by the controlled character.")]
+        public bool ShowMsgInOtherInventory
+        {
+            get;
+            set;
+        }
+
         public LocalizedString DisplayMsg
         {
             get;


### PR DESCRIPTION
This PR adds two new properties to `ItemComponent`:
- `ShowMsgInOwnInventory`: If set to `true`, the component's message will also be displayed while in the controlled character's inventory.
- `ShowMsgInOtherInventory`: If set to `true`, the component's message will also be displayed while in an inventory not owned by the controlled character.