### PR TITLE
Hand Move Offset enhancements

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Animation/HumanoidAnimController.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Animation/HumanoidAnimController.cs
@@ -721,6 +721,7 @@ namespace Barotrauma
             }
 
             Vector2 waistPos = waist != null ? waist.SimPosition : torso.SimPosition;
+            int currentDirectionSign = character.IsFlipped ? -1 : 1;
 
             if (movingHorizontally)
             {
@@ -776,29 +777,6 @@ namespace Barotrauma
                             currentGroundedParams.LegBendTorque, currentGroundedParams.FootTorque, currentGroundedParams.FootAngleInRadians);
                     }
                 }
-
-                //calculate the positions of hands
-                handPos = torso.SimPosition;
-                handPos.X = -walkPosX * currentGroundedParams.HandMoveAmount.X;
-
-                float lowerY = currentGroundedParams.HandClampY;
-
-                handPos.Y = lowerY + (float)(Math.Abs(Math.Sin(WalkPos - Math.PI * 1.5f) * currentGroundedParams.HandMoveAmount.Y));
-
-                Vector2 posAddition = new Vector2(Math.Sign(movement.X) * HandMoveOffset.X, HandMoveOffset.Y);
-
-                if (rightHand != null && !rightHand.Disabled)
-                {
-                    HandIK(rightHand,
-                        torso.SimPosition + posAddition + new Vector2(-handPos.X, (Math.Sign(walkPosX) == Math.Sign(Dir)) ? handPos.Y : lowerY),
-                        currentGroundedParams.ArmMoveStrength, currentGroundedParams.HandMoveStrength);
-                }
-                if (leftHand != null && !leftHand.Disabled)
-                {
-                    HandIK(leftHand,
-                        torso.SimPosition + posAddition + new Vector2(handPos.X, (Math.Sign(walkPosX) == Math.Sign(-Dir)) ? handPos.Y : lowerY),
-                        currentGroundedParams.ArmMoveStrength, currentGroundedParams.HandMoveStrength);
-                }
             }
             else
             {
@@ -845,7 +823,10 @@ namespace Barotrauma
                         FootIK(foot, footPos, legBendTorque, currentGroundedParams.FootTorque, currentGroundedParams.FootAngleInRadians);
                     }
                 }
+            }
 
+            if(!movingHorizontally && !currentGroundedParams.ApplyHandMoveOffsetWhenStationary)
+            {
                 for (int i = 0; i < 2; i++)
                 {
                     var hand = i == 0 ? rightHand : leftHand;
@@ -878,6 +859,31 @@ namespace Barotrauma
                     {
                         hand.body.ApplyTorque(MathHelper.Clamp(-wrist.JointAngle, -MathHelper.PiOver2, MathHelper.PiOver2) * hand.Mass * 100f * currentGroundedParams.HandMoveStrength);
                     }
+                }
+            }
+            else
+            {
+                //calculate the positions of hands
+                handPos = torso.SimPosition;
+                handPos.X = -walkPosX * currentGroundedParams.HandMoveAmount.X;
+
+                float lowerY = currentGroundedParams.HandClampY;
+
+                handPos.Y = lowerY + (float)(Math.Abs(Math.Sin(WalkPos - Math.PI * 1.5f) * currentGroundedParams.HandMoveAmount.Y));
+
+                Vector2 posAddition = new Vector2(currentDirectionSign * HandMoveOffset.X, HandMoveOffset.Y);
+
+                if (rightHand != null && !rightHand.Disabled)
+                {
+                    HandIK(rightHand,
+                        torso.SimPosition + posAddition + new Vector2(-handPos.X, (currentDirectionSign == Math.Sign(Dir)) ? handPos.Y : lowerY),
+                        currentGroundedParams.ArmMoveStrength, currentGroundedParams.HandMoveStrength);
+                }
+                if (leftHand != null && !leftHand.Disabled)
+                {
+                    HandIK(leftHand,
+                        torso.SimPosition + posAddition + new Vector2(handPos.X, (currentDirectionSign == Math.Sign(-Dir)) ? handPos.Y : lowerY),
+                        currentGroundedParams.ArmMoveStrength, currentGroundedParams.HandMoveStrength);
                 }
             }
         }

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Params/Animation/HumanoidAnimations.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Params/Animation/HumanoidAnimations.cs
@@ -165,6 +165,9 @@ namespace Barotrauma
         [Serialize("-0.15, 0.0", IsPropertySaveable.Yes, description: "Added to the calculated hand positions, e.g. a value of {-1.0, 0.0f} would make the character \"drag\" their hands one unit behind them."), Editable(DecimalCount = 2)]
         public Vector2 HandMoveOffset { get; set; }
 
+        [Serialize(false, IsPropertySaveable.Yes, description: "Should the Hand Move Offset values affect the hands even when stationary?"), Editable]
+        public bool ApplyHandMoveOffsetWhenStationary { get; set; }
+
         [Serialize(-1.0f, IsPropertySaveable.Yes, description: "The position of the hands is clamped below this (relative to the position of the character's torso)."), Editable(DecimalCount = 2)]
         public float HandClampY { get; set; }
 


### PR DESCRIPTION
```
Walk/Run/Crouch animations have a new boolean parameter: "ApplyHandMoveOffsetWhenStationary", set to false by default

When set to true, the hands of the character will move into the position defined by "HandMoveOffset" even when it is standing still.

Additionally, the horizontal value of the Hand Move Offset parameter no longer changes sign when the character moves backwards.
```

To elaborate on that change mentioned at the bottom of the commit message, this is currently happens on the public Barotrauma branch when you decide you want to make a humanoid character walk with their arms forwards

https://github.com/user-attachments/assets/487c1ffa-b2f5-414e-8306-2885529a8d40

While here's what happens with the modifications made in this PR (namely, checking to see if the character is flipped to decide the horizontal sign of the hand offset instead of the sign of the horizontal movement value)

https://github.com/user-attachments/assets/527e22a1-ad11-40d8-b838-0eca53d9b973


And finally, an example of the new "ApplyHandMoveOffsetWhenStationary" parameter at work:


https://github.com/user-attachments/assets/5ed53e19-db22-4704-9960-824a24037a56



