### PR TITLE
StatusEffect Container Heirarchy Extensions

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Attack.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Attack.cs
@@ -569,8 +569,7 @@ namespace Barotrauma
                 }
                 if (target is Entity targetEntity)
                 {
-                    if (effect.HasTargetType(StatusEffect.TargetType.NearbyItems) ||
-                        effect.HasTargetType(StatusEffect.TargetType.NearbyCharacters))
+                    if (effect.HasTargetType(StatusEffect.TargetType.NearbyEntities))
                     {
                         targets.Clear();
                         effect.AddNearbyTargets(worldPosition, targets);
@@ -589,10 +588,10 @@ namespace Barotrauma
                         effect.Apply(additionalEffectType, deltaTime, targetEntity, targetEntity as ISerializableEntity, worldPosition);
                     }
                 }
-                if (effect.HasTargetType(StatusEffect.TargetType.Contained))
+                if (effect.HasTargetType(StatusEffect.TargetType.Descendants))
                 {
                     targets.Clear();
-                    targets.AddRange(attacker.Inventory.AllItems);
+                    targets.AddRange(effect.GetContainedItems(attacker));
                     if (additionalEffectType != ActionType.OnEating)
                     {
                         effect.Apply(conditionalEffectType, deltaTime, attacker, targets);
@@ -668,18 +667,17 @@ namespace Barotrauma
                     effect.Apply(conditionalEffectType, deltaTime, targetLimb.character, targets);
                     effect.Apply(ActionType.OnUse, deltaTime, targetLimb.character, targets);
                 }
-                if (effect.HasTargetType(StatusEffect.TargetType.NearbyItems) ||
-                    effect.HasTargetType(StatusEffect.TargetType.NearbyCharacters))
+                if (effect.HasTargetType(StatusEffect.TargetType.NearbyEntities))
                 {
                     targets.Clear();
                     effect.AddNearbyTargets(worldPosition, targets);                
                     effect.Apply(conditionalEffectType, deltaTime, targetLimb.character, targets);
                     effect.Apply(ActionType.OnUse, deltaTime, targetLimb.character, targets);
                 }
-                if (effect.HasTargetType(StatusEffect.TargetType.Contained))
+                if (effect.HasTargetType(StatusEffect.TargetType.Descendants))
                 {
                     targets.Clear();
-                    targets.AddRange(attacker.Inventory.AllItems);
+                    targets.AddRange(effect.GetContainedItems(attacker));
                     effect.Apply(conditionalEffectType, deltaTime, attacker, targets);
                     effect.Apply(ActionType.OnUse, deltaTime, attacker, targets);
                 }

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Attack.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Attack.cs
@@ -588,7 +588,7 @@ namespace Barotrauma
                         effect.Apply(additionalEffectType, deltaTime, targetEntity, targetEntity as ISerializableEntity, worldPosition);
                     }
                 }
-                if (effect.HasTargetType(StatusEffect.TargetType.Descendants))
+                if (effect.HasTargetType(StatusEffect.TargetType.Contained))
                 {
                     targets.Clear();
                     targets.AddRange(effect.GetContainedItems(attacker));
@@ -674,7 +674,7 @@ namespace Barotrauma
                     effect.Apply(conditionalEffectType, deltaTime, targetLimb.character, targets);
                     effect.Apply(ActionType.OnUse, deltaTime, targetLimb.character, targets);
                 }
-                if (effect.HasTargetType(StatusEffect.TargetType.Descendants))
+                if (effect.HasTargetType(StatusEffect.TargetType.Contained))
                 {
                     targets.Clear();
                     targets.AddRange(effect.GetContainedItems(attacker));

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
@@ -4673,8 +4673,7 @@ namespace Barotrauma
                             }
                         }
                     }
-                    if (statusEffect.HasTargetType(StatusEffect.TargetType.NearbyItems) ||
-                        statusEffect.HasTargetType(StatusEffect.TargetType.NearbyCharacters))
+                    if (statusEffect.HasTargetType(StatusEffect.TargetType.NearbyEntities))
                     {
                         targets.Clear();
                         statusEffect.AddNearbyTargets(WorldPosition, targets);

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/Affliction.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/Affliction.cs
@@ -487,8 +487,7 @@ namespace Barotrauma
             {
                 statusEffect.Apply(type, deltaTime, characterHealth.Character, targets: characterHealth.Character.AnimController.Limbs);
             }
-            if (statusEffect.HasTargetType(StatusEffect.TargetType.NearbyItems) ||
-                statusEffect.HasTargetType(StatusEffect.TargetType.NearbyCharacters))
+            if (statusEffect.HasTargetType(StatusEffect.TargetType.NearbyEntities))
             {
                 targets.Clear();
                 statusEffect.AddNearbyTargets(characterHealth.Character.WorldPosition, targets);

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Limb.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Limb.cs
@@ -1279,8 +1279,7 @@ namespace Barotrauma
                         }
                     }
                 }
-                if (statusEffect.HasTargetType(StatusEffect.TargetType.NearbyItems) ||
-                    statusEffect.HasTargetType(StatusEffect.TargetType.NearbyCharacters))
+                if (statusEffect.HasTargetType(StatusEffect.TargetType.NearbyEntities))
                 {
                     targets.Clear();
                     statusEffect.AddNearbyTargets(WorldPosition, targets);

--- a/Barotrauma/BarotraumaShared/SharedSource/Extensions/GenericExtensions.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Extensions/GenericExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Barotrauma.Extensions
+{
+    public static class GenericExtensions
+    {
+        public static IEnumerable<T> SelectManyRecursive<T>(this T source, Func<T, T> selector)
+        {
+            IEnumerable<T> result = new List<T>();
+            T child = selector.Invoke(source);
+
+            while (child != null)
+            {
+                result.Append(child);
+                child = selector.Invoke(child);
+            }
+            return result;
+        }
+
+        public static IEnumerable<T> SelectManyRecursive<T>(this T source, Func<T, T> selector, int maxDepth, int minDepth = 1)
+        {
+            minDepth = Math.Max(minDepth, 1);
+            maxDepth = Math.Max(maxDepth, minDepth);
+
+            IEnumerable<T> result = new List<T>();
+            T child = selector.Invoke(source);
+
+            int depth = 1;
+            while (child != null && depth <= maxDepth)
+            {
+                if (depth >= minDepth) { result.Append(child); }
+                child = selector.Invoke(child);
+                depth++;
+            }
+            return result;
+        }
+    }
+}

--- a/Barotrauma/BarotraumaShared/SharedSource/Extensions/IEnumerableExtensions.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Extensions/IEnumerableExtensions.cs
@@ -172,12 +172,22 @@ namespace Barotrauma.Extensions
         // source: https://stackoverflow.com/questions/19237868/get-all-children-to-one-list-recursive-c-sharp
         public static IEnumerable<T> SelectManyRecursive<T>(this IEnumerable<T> source, Func<T, IEnumerable<T>> selector)
         {
-            var result = source.SelectMany(selector);
-            if (!result.Any())
+            IEnumerable<T> result = source.SelectMany(selector);
+            return result.Any() ? result.Concat(result.SelectManyRecursive(selector)) : result;
+        }
+
+        public static IEnumerable<T> SelectManyRecursive<T>(this IEnumerable<T> source, Func<T, IEnumerable<T>> selector, int maxDepth, int minDepth = 1)
+        {
+            minDepth = Math.Max(minDepth, 1);
+            maxDepth = Math.Max(maxDepth, minDepth);
+
+            return RecursiveSearch(source, selector, minDepth, maxDepth, 1);
+
+            static IEnumerable<T> RecursiveSearch(IEnumerable<T> source, Func<T, IEnumerable<T>> selector, int minDepth, int maxDepth, int depth)
             {
-                return result;
+                IEnumerable<T> result = source.SelectMany(selector);
+                return result.Any() && depth <= maxDepth ? depth < minDepth ? RecursiveSearch(result, selector, minDepth, maxDepth, depth + 1) : result.Concat(RecursiveSearch(result, selector, minDepth, maxDepth, depth + 1)) : result;
             }
-            return result.Concat(result.SelectManyRecursive(selector));
         }
 
         public static void AddIfNotNull<T>(this IList<T> source, T value)

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/ItemContainer.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/ItemContainer.cs
@@ -671,16 +671,15 @@ namespace Barotrauma.Items.Components
                 {
                     targets.AddRange(item.AllPropertyObjects);
                 }
-                if (effect.HasTargetType(StatusEffect.TargetType.Contained))
+                if (effect.HasTargetType(StatusEffect.TargetType.Descendants))
                 {
-                    targets.AddRange(contained.AllPropertyObjects);
+                    targets.AddRange(effect.GetContainedItems(contained, true).SelectMany(item => item.AllPropertyObjects));
                 }
                 if (effect.HasTargetType(StatusEffect.TargetType.Character) && item.ParentInventory?.Owner is Character character)
                 {
                     targets.Add(character);
                 }
-                if (effect.HasTargetType(StatusEffect.TargetType.NearbyItems) ||
-                    effect.HasTargetType(StatusEffect.TargetType.NearbyCharacters))
+                if (effect.HasTargetType(StatusEffect.TargetType.NearbyEntities))
                 {
                     effect.AddNearbyTargets(item.WorldPosition, targets);
                 }

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/ItemContainer.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/ItemContainer.cs
@@ -671,7 +671,7 @@ namespace Barotrauma.Items.Components
                 {
                     targets.AddRange(item.AllPropertyObjects);
                 }
-                if (effect.HasTargetType(StatusEffect.TargetType.Descendants))
+                if (effect.HasTargetType(StatusEffect.TargetType.Contained))
                 {
                     targets.AddRange(effect.GetContainedItems(contained, true).SelectMany(item => item.AllPropertyObjects));
                 }

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Projectile.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Projectile.cs
@@ -1111,8 +1111,7 @@ namespace Barotrauma.Items.Components
                                 {
                                     effect.Apply(effect.type, 1.0f, targetLimb.character, targetLimb);
                                 }
-                                if (effect.HasTargetType(StatusEffect.TargetType.NearbyItems) ||
-                                    effect.HasTargetType(StatusEffect.TargetType.NearbyCharacters))
+                                if (effect.HasTargetType(StatusEffect.TargetType.NearbyEntities))
                                 {
                                     targets.Clear();
                                     effect.AddNearbyTargets(targetLimb.WorldPosition, targets);

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Item.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Item.cs
@@ -1977,7 +1977,7 @@ namespace Barotrauma
 
             targets.Clear();
 
-            if (effect.HasTargetType(StatusEffect.TargetType.Descendants))
+            if (effect.HasTargetType(StatusEffect.TargetType.Contained))
             {
                 foreach (Item containedItem in effect.GetContainedItems(this))
                 {
@@ -2051,7 +2051,7 @@ namespace Barotrauma
                 targets.Add(limb);
             }
 
-            if (effect.HasTargetType(StatusEffect.TargetType.Parents))
+            if (effect.HasTargetType(StatusEffect.TargetType.Parent))
             {
                 targets.AddRange(effect.GetParentItems(this).SelectMany(item => item.AllPropertyObjects));
             }

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Item.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Item.cs
@@ -1977,20 +1977,13 @@ namespace Barotrauma
 
             targets.Clear();
 
-            if (effect.HasTargetType(StatusEffect.TargetType.Contained))
+            if (effect.HasTargetType(StatusEffect.TargetType.Descendants))
             {
-                foreach (Item containedItem in ContainedItems)
+                foreach (Item containedItem in effect.GetContainedItems(this))
                 {
-                    if (effect.TargetIdentifiers != null &&
-                        !effect.TargetIdentifiers.Contains(((MapEntity)containedItem).Prefab.Identifier) &&
-                        !effect.TargetIdentifiers.Any(id => containedItem.HasTag(id)))
+                    if (effect.TargetIdentifiers != null && !effect.TargetIdentifiers.Contains(containedItem.Prefab.Identifier) && !effect.TargetIdentifiers.Any(containedItem.HasTag))
                     {
                         continue;
-                    }
-
-                    if (effect.TargetSlot > -1)
-                    {
-                        if (!OwnInventory.GetItemsAt(effect.TargetSlot).Contains(containedItem)) { continue; }
                     }
 
                     hasTargets = true;
@@ -1998,7 +1991,7 @@ namespace Barotrauma
                 }
             }
 
-            if (effect.HasTargetType(StatusEffect.TargetType.NearbyCharacters) || effect.HasTargetType(StatusEffect.TargetType.NearbyItems))
+            if (effect.HasTargetType(StatusEffect.TargetType.NearbyEntities))
             {
                 effect.AddNearbyTargets(WorldPosition, targets);
                 if (targets.Count > 0)
@@ -2058,8 +2051,11 @@ namespace Barotrauma
                 targets.Add(limb);
             }
 
-            if (Container != null && effect.HasTargetType(StatusEffect.TargetType.Parent)) { targets.AddRange(Container.AllPropertyObjects); }
-            
+            if (effect.HasTargetType(StatusEffect.TargetType.Parents))
+            {
+                targets.AddRange(effect.GetParentItems(this).SelectMany(item => item.AllPropertyObjects));
+            }
+
             effect.Apply(type, deltaTime, this, targets, worldPosition);            
         }
 

--- a/Barotrauma/BarotraumaShared/SharedSource/Map/Levels/LevelObjects/LevelTrigger.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Map/Levels/LevelObjects/LevelTrigger.cs
@@ -662,7 +662,7 @@ namespace Barotrauma
                 if (triggerer is Character character)
                 {
                     effect.Apply(effect.type, deltaTime, triggerer, character, position);
-                    if (effect.HasTargetType(StatusEffect.TargetType.Descendants))
+                    if (effect.HasTargetType(StatusEffect.TargetType.Contained))
                     {
                         effect.Apply(effect.type, deltaTime, triggerer, effect.GetContainedItems(character).SelectMany(item => item.AllPropertyObjects).ToList(), position);
                     }

--- a/Barotrauma/BarotraumaShared/SharedSource/Map/Levels/LevelObjects/LevelTrigger.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Map/Levels/LevelObjects/LevelTrigger.cs
@@ -662,16 +662,9 @@ namespace Barotrauma
                 if (triggerer is Character character)
                 {
                     effect.Apply(effect.type, deltaTime, triggerer, character, position);
-                    if (effect.HasTargetType(StatusEffect.TargetType.Contained) && character.Inventory != null)
+                    if (effect.HasTargetType(StatusEffect.TargetType.Descendants))
                     {
-                        foreach (Item item in character.Inventory.AllItemsMod)
-                        {
-                            if (item.ContainedItems == null) { continue; }
-                            foreach (Item containedItem in item.ContainedItems)
-                            {
-                                effect.Apply(effect.type, deltaTime, triggerer, containedItem.AllPropertyObjects, position);
-                            }
-                        }
+                        effect.Apply(effect.type, deltaTime, triggerer, effect.GetContainedItems(character).SelectMany(item => item.AllPropertyObjects).ToList(), position);
                     }
                 }
                 else if (triggerer is Item item)
@@ -682,7 +675,7 @@ namespace Barotrauma
                 {
                     effect.Apply(effect.type, deltaTime, sub, Array.Empty<ISerializableEntity>(), position);
                 }
-                if (effect.HasTargetType(StatusEffect.TargetType.NearbyItems) || effect.HasTargetType(StatusEffect.TargetType.NearbyCharacters))
+                if (effect.HasTargetType(StatusEffect.TargetType.NearbyEntities))
                 {
                     targets.Clear();
                     effect.AddNearbyTargets(worldPosition, targets);

--- a/Barotrauma/BarotraumaShared/SharedSource/StatusEffects/StatusEffect.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/StatusEffects/StatusEffect.cs
@@ -124,29 +124,9 @@ namespace Barotrauma
             /// </summary>
             LastLimb = 1024,
             /// <summary>
-            /// The container of the container the item is inside (if any).
-            /// </summary>
-            GrandParent = 2048,
-            /// <summary>
-            /// The item(s) contained in the inventories of the item(s) contained in the inventory of the entity the StatusEffect is defined in.
-            /// </summary>
-            GrandChildren = 4096,
-            /// <summary>
             /// Same as NearbyCharacters and NearbyItems.
             /// </summary>
-            NearbyEntities = NearbyCharacters | NearbyItems,
-            /// <summary>
-            /// Same as Parent with RecursiveSearch.
-            /// </summary>
-            Parents = Parent | GrandParent,
-            /// <summary>
-            /// Same as Contained with RecursiveSearch.
-            /// </summary>
-            Descendants = Contained | GrandChildren,
-            /// <summary>
-            /// Same as This, Parents, and Descendants.
-            /// </summary>
-            Heirarchy = This | Parents | Descendants
+            NearbyEntities = NearbyCharacters | NearbyItems
         }
 
         /// <summary>
@@ -871,10 +851,6 @@ namespace Barotrauma
                 else
                 {
                     targetTypes |= targetType;
-                    if (targetType is TargetType.Parents or TargetType.Descendants or TargetType.Heirarchy)
-                    {
-                        RecursiveSearch = true;
-                    }
                 }
             }
             if (targetTypes == 0)
@@ -1318,25 +1294,13 @@ namespace Barotrauma
 
             if (HasTargetType(TargetType.Contained))
             {
-                if (ProcessChildren()) { return targets; }
-            }
-            if (HasTargetType(TargetType.GrandChildren))
-            {
-                children = children.SelectMany(item => item.ContainedItems);
-                if (ProcessChildren()) { return targets; }
-            }
-            return targets;
-
-            bool ProcessChildren()
-            {
                 targets.AddRange(children);
                 if (RecursiveSearch)
                 {
                     targets.AddRange(children.SelectManyRecursive(item => item.ContainedItems, MinSearchDepth, MaxSearchDepth));
-                    return true;
                 }
-                return false;
             }
+            return targets;
         }
 
         public List<Item> GetParentItems(Item item)
@@ -1346,25 +1310,13 @@ namespace Barotrauma
 
             if (HasTargetType(TargetType.Parent) && parent != null)
             {
-                if (ProcessParent()) { return targets; }
-            }
-            if (HasTargetType(TargetType.GrandParent) && parent?.Container != null)
-            {
-                parent = parent.Container;
-                if (ProcessParent()) { return targets; }
-            }
-            return targets;
-
-            bool ProcessParent()
-            {
                 targets.Add(parent);
                 if (RecursiveSearch)
                 {
                     targets.AddRange(parent.SelectManyRecursive(item => item.Container, MaxSearchDepth, MinSearchDepth));
-                    return true;
                 }
-                return false;
             }
+            return targets;
         }
 
         public bool HasRequiredConditions(IReadOnlyList<ISerializableEntity> targets)


### PR DESCRIPTION
This PR adds 3 new properties and 1 new TargetType to StatusEffects.

New Properties:
- `RecursiveSearch`: Whether to search recursively when finding parent/child items.
- `MinSearchDepth`: Sets the minimum depth at which recursive searches take place.
- `MaxSearchDepth`: Sets the maximum depth at which recursive searches take place.

New TargetTypes:
- `NearbyEntities`: Same as NearbyCharacters and NearbyItems.
The new TargetType is used to simplify the logic for adding targets in code, but can also be used for modding purposes.