### PR TITLE
Holdable 'Swing' Refactor

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Animation/AnimController.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Animation/AnimController.cs
@@ -431,7 +431,7 @@ namespace Barotrauma
         private Direction previousDirection;
         private readonly Vector2[] transformedHandlePos = new Vector2[2];
         //TODO: refactor this method, it's way too convoluted
-        public void HoldItem(float deltaTime, Item item, Vector2[] handlePos, Vector2 itemPos, bool aim, float holdAngle, float itemAngleRelativeToHoldAngle = 0.0f, bool aimMelee = false, Vector2? targetPos = null)
+        public void HoldItem(float deltaTime, Item item, Vector2[] handlePos, Vector2 itemPos, bool aim, float holdAngle, float itemAngleRelativeToHoldAngle = 0.0f, bool aimMelee = false, Vector2? targetPos = null, float armAngle = 0f)
         {
             aimingMelee = aimMelee;
             if (character.Stun > 0.0f || character.IsIncapacitated)
@@ -473,7 +473,7 @@ namespace Barotrauma
                     MathUtils.RotatePoint(Vector2.UnitX, torsoRotation);
                 
                 holdAngle = MathUtils.VectorToAngle(new Vector2(diff.X, diff.Y * Dir)) - torsoRotation * Dir;
-                holdAngle += GetAimWobble(rightHand, leftHand, item);
+                holdAngle += armAngle + GetAimWobble(rightHand, leftHand, item);
                 itemAngle = torsoRotation + holdAngle * Dir;
 
                 if (holdable.ControlPose)
@@ -490,6 +490,7 @@ namespace Barotrauma
             }
             else
             {
+                holdAngle += armAngle;
                 if (holdable.UseHandRotationForHoldAngle)
                 {
                     if (equippedInRightHand)

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Holdable/Holdable.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Holdable/Holdable.cs
@@ -34,8 +34,6 @@ namespace Barotrauma.Items.Components
         private LocalizedString prevMsg;
         private Dictionary<RelatedItem.RelationType, List<RelatedItem>> prevRequiredItems;
 
-        private float swingState;
-
         private Character prevEquipper;
 
         public override bool IsAttached => Attached;
@@ -145,11 +143,7 @@ namespace Barotrauma.Items.Components
         protected Vector2 aimPos;
 
         protected float holdAngle;
-#if DEBUG
-        [Editable, Serialize(0.0f, IsPropertySaveable.No, description: "The rotation at which the character holds the item (in degrees, relative to the rotation of the character's hand).")]
-#else
-        [Serialize(0.0f, IsPropertySaveable.No)] 
-#endif
+        [Serialize(0f, IsPropertySaveable.No, description: "The rotation at which the character holds the item (in degrees, relative to the rotation of the character's hand).")] 
         public float HoldAngle
         {
             get { return MathHelper.ToDegrees(holdAngle); }
@@ -157,11 +151,7 @@ namespace Barotrauma.Items.Components
         }
 
         protected float aimAngle;
-#if DEBUG
-        [Editable, Serialize(0.0f, IsPropertySaveable.No, description: "The rotation at which the character holds the item while aiming (in degrees, relative to the rotation of the character's hand).")]
-#else
-        [Serialize(0.0f, IsPropertySaveable.No)] 
-#endif
+        [Serialize(0f, IsPropertySaveable.No, description: "The rotation at which the character holds the item while aiming (in degrees, relative to the rotation of the character's hand).")] 
         public float AimAngle
         {
             get { return MathHelper.ToDegrees(aimAngle); }
@@ -169,50 +159,34 @@ namespace Barotrauma.Items.Components
         }
 
         private Vector2 swingAmount;
-#if DEBUG
-        [Editable, Serialize("0.0,0.0", IsPropertySaveable.No, description: "How much the item swings around when aiming/holding it (in pixels, as an offset from AimPos/HoldPos).")]
-#else
-        [Serialize("0.0,0.0", IsPropertySaveable.No)] 
-#endif
+        [Serialize("0,0", IsPropertySaveable.No, description: "How much the item swings around when aiming/holding it (in pixels, as an offset from AimPos/HoldPos).")] 
         public Vector2 SwingAmount
         {
-            get { return ConvertUnits.ToDisplayUnits(swingAmount); }
-            set { swingAmount = ConvertUnits.ToSimUnits(value); }
+            get => ConvertUnits.ToDisplayUnits(swingAmount);
+            set => swingAmount = ConvertUnits.ToSimUnits(value);
         }
-#if DEBUG
-        [Editable, Serialize(0.0f, IsPropertySaveable.No, description: "How fast the item swings around when aiming/holding it (only valid if SwingAmount is set).")]
-#else
-        [Serialize(0.0f, IsPropertySaveable.No)]
-#endif
 
+        private float swingRotation;
+        [Serialize(0f, IsPropertySaveable.No, description: "How much the item swings around while aiming/holding it (in degrees, as an offset from the angle between the shoulder and the cursor.")]
+        public float SwingRotation
+        {
+            get => MathHelper.ToDegrees(swingRotation);
+            set => swingRotation = MathHelper.ToRadians(value);
+        }
+
+        [Serialize(1f, IsPropertySaveable.No, description: "How fast the item swings around when aiming/holding it (only valid if SwingAmount is set).")]
         public float SwingSpeed { get; set; }
 
-#if DEBUG
-        [Editable, Serialize(false, IsPropertySaveable.No, description: "Should the item swing around when it's being held.")]
-#else
-        [Serialize(false, IsPropertySaveable.No)]
-#endif
+        [Serialize(false, IsPropertySaveable.No, description: "Should the item swing around when it's being held.")]
         public bool SwingWhenHolding { get; set; }
 
-#if DEBUG
-        [Editable, Serialize(false, IsPropertySaveable.No, description: "Should the item swing around when it's being aimed.")]
-#else
-        [Serialize(false, IsPropertySaveable.No)]
-#endif
+        [Serialize(false, IsPropertySaveable.No, description: "Should the item swing around when it's being aimed.")]
         public bool SwingWhenAiming { get; set; }
 
-#if DEBUG
-        [Editable, Serialize(false, IsPropertySaveable.No, description: "Should the item swing around when it's being used (for example, when firing a weapon or a welding tool).")]
-#else
-        [Serialize(false, IsPropertySaveable.No)]
-#endif
+        [Serialize(false, IsPropertySaveable.No, description: "Should the item swing around when it's being used (for example, when firing a weapon or a welding tool).")]
         public bool SwingWhenUsing { get; set; }
 
-#if DEBUG
-        [Editable, Serialize(false, IsPropertySaveable.No)]
-#else
         [Serialize(false, IsPropertySaveable.No)]
-#endif
         public bool DisableHeadRotation { get; set; }
 
         [Serialize(false, IsPropertySaveable.No, description: "If true, this item can't be used if the character is also holding a ranged weapon.")]
@@ -921,7 +895,7 @@ namespace Barotrauma.Items.Components
                 Drawable = true;
             }
 
-            UpdateSwingPos(deltaTime, out Vector2 swingPos);
+            UpdateSwing(deltaTime, out Vector2 swingPos, out float swingAngle);
             if (item.body.Dir != picker.AnimController.Dir) 
             {
                 item.FlipX(relativeToSub: false);
@@ -943,12 +917,12 @@ namespace Barotrauma.Items.Components
                     }
                     else
                     {
-                        picker.AnimController.HoldItem(deltaTime, item, scaledHandlePos, itemPos: aimPos + swingPos, aim: true, holdAngle, aimAngle);   
+                        picker.AnimController.HoldItem(deltaTime, item, scaledHandlePos, itemPos: aimPos + swingPos, aim: true, holdAngle, aimAngle, armAngle: swingAngle);   
                     }
                 }
                 else
                 {
-                    picker.AnimController.HoldItem(deltaTime, item, scaledHandlePos, itemPos: holdPos + swingPos, aim: false, holdAngle);
+                    picker.AnimController.HoldItem(deltaTime, item, scaledHandlePos, itemPos: holdPos + swingPos, aim: false, holdAngle, armAngle: swingAngle);
                     if (GetRope() is { SnapWhenNotAimed: true } rope)
                     {
                         if (rope.Item.ParentInventory == null)
@@ -985,20 +959,21 @@ namespace Barotrauma.Items.Components
             }
         }
 
-        public void UpdateSwingPos(float deltaTime, out Vector2 swingPos)
+        public void UpdateSwing(float deltaTime, out Vector2 swingPos, out float swingAngle)
         {
             swingPos = Vector2.Zero;
-            if (swingAmount != Vector2.Zero && !picker.IsUnconscious && picker.Stun <= 0.0f)
+            swingAngle = 0f;
+            if (!picker.IsUnconscious && picker.Stun <= 0f && (SwingWhenHolding || SwingWhenAiming && picker.IsKeyDown(InputType.Aim) || SwingWhenUsing && picker.IsKeyDown(InputType.Aim) && picker.IsKeyDown(InputType.Shoot)))
             {
-                swingState += deltaTime;
-                swingState %= 1.0f;
-                if (SwingWhenHolding ||
-                    (SwingWhenAiming && picker.IsKeyDown(InputType.Aim)) ||
-                    (SwingWhenUsing && picker.IsKeyDown(InputType.Aim) && picker.IsKeyDown(InputType.Shoot)))
+                float noisePos = (float)Timing.TotalTimeUnpaused * SwingSpeed * deltaTime;
+                if (swingAmount != Vector2.Zero)
                 {
-                    swingPos = swingAmount * new Vector2(
-                        PerlinNoise.GetPerlin(swingState * SwingSpeed * 0.1f, swingState * SwingSpeed * 0.1f) - 0.5f,
-                        PerlinNoise.GetPerlin(swingState * SwingSpeed * 0.1f + 0.5f, swingState * SwingSpeed * 0.1f + 0.5f) - 0.5f);
+                    swingPos.X = MathHelper.Lerp(-swingAmount.X, swingAmount.X, PerlinNoise.GetPerlin(noisePos, noisePos));
+                    swingPos.Y = MathHelper.Lerp(-swingAmount.Y, swingAmount.Y, PerlinNoise.GetPerlin(noisePos - 0.5f, noisePos - 0.5f));
+                }
+                if (swingRotation != 0f)
+                {
+                    swingAngle = MathHelper.Lerp(-swingRotation, swingRotation, PerlinNoise.GetPerlin(noisePos, noisePos));
                 }
             }
         }

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Holdable/MeleeWeapon.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Holdable/MeleeWeapon.cs
@@ -1,4 +1,5 @@
-﻿using FarseerPhysics;
+﻿using Barotrauma.Extensions;
+using FarseerPhysics;
 using FarseerPhysics.Dynamics;
 using FarseerPhysics.Dynamics.Contacts;
 using Microsoft.Xna.Framework;
@@ -223,9 +224,9 @@ namespace Barotrauma.Items.Components
                 bool aim = item.RequireAimToUse && picker.AllowInput && picker.IsKeyDown(InputType.Aim) && reloadTimer <= 0 && picker.CanAim && !UsageDisabledByRangedWeapon(picker);
                 if (aim)
                 {
-                    UpdateSwingPos(deltaTime, out Vector2 swingPos);
+                    UpdateSwing(deltaTime, out Vector2 swingPos, out float swingAngle);
                     hitPos = MathUtils.WrapAnglePi(Math.Min(hitPos + deltaTime * 3f, MathHelper.PiOver4));
-                    ac.HoldItem(deltaTime, item, handlePos, itemPos: aimPos + swingPos, aim: false, hitPos, holdAngle + hitPos + aimAngle, aimMelee: true);
+                    ac.HoldItem(deltaTime, item, handlePos, itemPos: aimPos + swingPos, aim: false, hitPos, holdAngle + hitPos + aimAngle, aimMelee: true, armAngle: swingAngle);
                     if (ac.InWater)
                     {
                         ac.LockFlipping();


### PR DESCRIPTION
This PR adds a new property to Holdable and cleans up some code.

The SwingRotation property allows modders to add random arm rotation to items in addition to the random item position from SwingAmount.

Additionally, this PR cleans up part of the Holdable class related to swing:
- Removes the unneccessary debug-build-only property descriptions, allowing the documentator to read them.
- Standardizes and simplifies the swing noise logic.