### PR TITLE
Add LocalMods to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,9 @@ Barotrauma/BarotraumaShared/Content/*
 Barotrauma/**/GameAnalyticsKeys.cs
 .github/ISSUE_TEMPLATE/release-checklist.md
 
+# Local mods
+Barotrauma/BarotraumaShared/LocalMods/*
+!Barotrauma/BarotraumaShared/LocalMods/info.txt
+
 #Rider
 *.DotSettings.user


### PR DESCRIPTION
This PR adds the content of the `Barotrauma/BarotraumaShared/LocalMods` folder to the .gitignore (excluding info.txt).

This helps with testing changes that require additional xml, without needing to about manually copy files to each output folder each time a change is made.