### PR TITLE
Character flipping fixes and enhancements

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Characters/CharacterNetworking.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Characters/CharacterNetworking.cs
@@ -220,7 +220,16 @@ namespace Barotrauma
                 keys[(int)InputType.Ragdoll].Held = ragdollInput;
                 keys[(int)InputType.Ragdoll].SetState(false, ragdollInput);
 
-                facingRight = msg.ReadBoolean();
+            }
+
+            facingRight = msg.ReadBoolean();
+
+            if (AnimController.IsFlipped == facingRight)
+            {
+                if((AnimController is HumanoidAnimController && !CanMove) || AnimController is FishAnimController)
+                {
+                    TryFlipCharacter();
+                }
             }
 
             bool entitySelected = msg.ReadBoolean();

--- a/Barotrauma/BarotraumaServer/ServerSource/Characters/CharacterNetworking.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Characters/CharacterNetworking.cs
@@ -386,8 +386,9 @@ namespace Barotrauma
 
                 tempBuffer.WriteBoolean(IsRagdolled || Stun > 0.0f || IsDead || IsIncapacitated);
 
-                tempBuffer.WriteBoolean(AnimController.Dir > 0.0f);
             }
+
+            tempBuffer.WriteBoolean(AnimController.Dir > 0.0f);
 
             if (SelectedCharacter != null || HasSelectedAnyItem)
             {

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Animation/FishAnimController.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Animation/FishAnimController.cs
@@ -281,7 +281,7 @@ namespace Barotrauma
                 }
             }
 
-            if (!IsStuck && CurrentFishAnimation.Flip && character.AIController is not { CanFlip: false })
+            if (!IsStuck && CurrentFishAnimation.Flip && character.AIController is not { CanFlip: false } && (GameMain.NetworkMember == null || !GameMain.NetworkMember.IsClient))
             {
                 flipCooldown -= deltaTime;
                 if (TargetDir != Direction.None && TargetDir != dir)
@@ -296,14 +296,9 @@ namespace Barotrauma
                     }
                     bool isMovingFastEnough = Math.Abs(MainLimb.LinearVelocity.X) > requiredSpeed;
                     bool isTryingToMoveHorizontally = Math.Abs(TargetMovement.X) > Math.Abs(TargetMovement.Y);
-                    if ((flipTimer > CurrentFishAnimation.FlipDelay && flipCooldown <= 0.0f && ((isMovingFastEnough && isTryingToMoveHorizontally) || IsMovingBackwards))
-                        || character.IsRemotePlayer)
+                    if ((flipTimer > CurrentFishAnimation.FlipDelay && flipCooldown <= 0.0f) && ((isMovingFastEnough && isTryingToMoveHorizontally) || IsMovingBackwards))
                     {
                         Flip();
-                        if (!inWater || (CurrentSwimParams != null && CurrentSwimParams.Mirror))
-                        {
-                            Mirror(CurrentSwimParams != null ? CurrentSwimParams.MirrorLerp : true);
-                        }
                         flipTimer = 0.0f;
                         flipCooldown = CurrentFishAnimation.FlipCooldown;
                     }
@@ -1028,6 +1023,10 @@ namespace Barotrauma
 				}
                 //no need to do anything when flipping vertically oriented limbs
                 //the sprite gets flipped horizontally, which does the job
+            }
+            if (!inWater || (CurrentSwimParams != null && CurrentSwimParams.Mirror))
+            {
+                Mirror(CurrentSwimParams != null ? CurrentSwimParams.MirrorLerp : true);
             }
         }
 

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
@@ -2111,11 +2111,7 @@ namespace Barotrauma
                 ((!IsClimbing && AnimController.OnGround) || (IsClimbing && IsKeyDown(InputType.Aim))) && 
                 !AnimController.InWater)
             {
-                if (dontFollowCursor)
-                {
-                    AnimController.TargetDir = Direction.Right;
-                }
-                else
+                if (AnimController is not FishAnimController)
                 {
                     if (CursorPosition.X < AnimController.Collider.Position.X - cursorFollowMargin)
                     {
@@ -2125,6 +2121,10 @@ namespace Barotrauma
                     {
                         AnimController.TargetDir = Direction.Right;
                     }
+                }
+                if (AnimController is HumanoidAnimController && dontFollowCursor) // For character editor
+                {
+                    AnimController.TargetDir = Direction.Right;
                 }
             }
 
@@ -5807,6 +5807,25 @@ namespace Barotrauma
         {
             AnimController.StopClimbing();
             ReleaseSecondaryItem();
+        }
+
+        public void TryFlipCharacter()
+        {
+            if (AnimController is FishAnimController fishAnimController)
+            {
+                if (fishAnimController.CurrentFishAnimation.Flip)
+                {
+                    fishAnimController.Flip();
+                }
+            }
+            else
+            {
+                AnimController.TargetDir = (AnimController.TargetDir == Direction.Left) ? Direction.Right : Direction.Left;
+                if (!CanMove)
+                {
+                    AnimController.Flip();
+                }
+            }
         }
     }
 

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/AfflictionHusk.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/AfflictionHusk.cs
@@ -372,6 +372,10 @@ namespace Barotrauma
             }
 
             husk.SetStun(5);
+            if (character.IsFlipped)
+            {
+                husk.TryFlipCharacter();
+            }
             yield return new WaitForSeconds(5, false);
 #if CLIENT
             husk?.PlaySound(CharacterSound.SoundType.Idle);


### PR DESCRIPTION
```
Made changes to networking to properly sync characters' flipped state in a multiplayer server

Made player controlled monsters not turn in the direction of the mouse or turn instantly in multiplayer, instead they will need to walk in the opposite direction and wait for the animation's flip timers before turning around.

Added "flipcharacter" status effect command to make a character flip. Mainly only useful for non-humanoids, for example, to make them spawn already flipped through some conditions.

Made "spawncharacter" status effect command and husk infection spawn the new characters already flipped if the target character is also flipped.
```

Example video showcasing the changes including a modded status effect that transforms a crawler into a crawlerhusk on death, as well as showing what happens in the current stable build of the game:
https://youtu.be/bLEClFpJtZ0