### PR TITLE
Make smaller subs accelerate faster

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/Engine.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/Engine.cs
@@ -3,6 +3,7 @@ using System;
 using System.Globalization;
 using System.Xml.Linq;
 using Barotrauma.Networking;
+using FarseerPhysics.Dynamics;
 
 namespace Barotrauma.Items.Components
 {
@@ -144,6 +145,12 @@ namespace Barotrauma.Items.Components
                 UpdateAITargets(noise);
                 //arbitrary multiplier that was added to changes in submarine mass without having to readjust all engines
                 float forceMultiplier = 0.1f;
+                if (item.Submarine.SubBody.Body != null)
+                {
+                    float mass = item.Submarine.SubBody.Body.Mass;
+                    float newDragCorrectionFactor = MathF.Pow(mass / SubmarineBody.InertiaReferenceMass, SubmarineBody.MassToAreaExponent) * SubmarineBody.InertiaReferenceMass / mass;
+                    forceMultiplier *= newDragCorrectionFactor;
+                }
                 if (User != null)
                 {
                     forceMultiplier *= MathHelper.Lerp(0.5f, 2.0f, (float)Math.Sqrt(User.GetSkillLevel("helm") / 100));

--- a/Barotrauma/BarotraumaShared/SharedSource/Map/SubmarineBody.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Map/SubmarineBody.cs
@@ -61,6 +61,10 @@ namespace Barotrauma
         private float forceUpwardsTimer;
         private const float ForceUpwardsDelay = 30.0f;
 
+        // submarines greater than "InertialReferenceMass" will accelerate slower, and vica versa. 30000 is about the size of the Humpback.
+        public const float InertiaReferenceMass = 30000f;
+        public const float MassToAreaExponent = 2f/3f;
+
         struct Impact
         {
             public Fixture Target;
@@ -449,12 +453,13 @@ namespace Barotrauma
 
                     jointEdge = jointEdge.Next;
                 }
-                
+                float surfaceArea = MathF.Pow(Body.Mass / InertiaReferenceMass, MassToAreaExponent) * InertiaReferenceMass;
+
                 float horizontalDragCoefficient = MathHelper.Clamp(HorizontalDrag + attachedMass / 5000.0f, 0.0f, MaxDrag);
-                totalForce.X -= Math.Sign(Body.LinearVelocity.X) * Body.LinearVelocity.X * Body.LinearVelocity.X * horizontalDragCoefficient * Body.Mass;
-                
+                totalForce.X -= Math.Sign(Body.LinearVelocity.X) * Body.LinearVelocity.X * Body.LinearVelocity.X * horizontalDragCoefficient * surfaceArea;
+
                 float verticalDragCoefficient = MathHelper.Clamp(VerticalDrag + attachedMass / 5000.0f, 0.0f, MaxDrag);
-                totalForce.Y -= Math.Sign(Body.LinearVelocity.Y) * Body.LinearVelocity.Y * Body.LinearVelocity.Y * verticalDragCoefficient * Body.Mass;
+                totalForce.Y -= Math.Sign(Body.LinearVelocity.Y) * Body.LinearVelocity.Y * Body.LinearVelocity.Y * verticalDragCoefficient * surfaceArea;
             }
 
             ApplyForce(totalForce);


### PR DESCRIPTION
Every submarine in Barotrauma accelerates at the same rate because drag is calculated directly off the submarine's mass.
This is quite counter intuitive: I would definitely expect a tiny drone to achieve top speed much earlier than a container ship. It also makes shuttles drive like aßß, to which the suggested solution is to increase thrust, but that has an unwanted effect of raising the top speed.

To overcome these limitations, this change scales how hydrodynamic drag is calculated. It simply uses mass^⅔ and scales down the forces to remain 100% compatible.

Disclamer: I know that Update() is not the best place to calculate these factors, but I'd rather you gave it a try how the changes make the game feel before I spent more time researching a better place for it.

<details>
  <summary>(spoiler)</summary>

`horizontalDragCoefficient` and `verticalDragCoefficient`? They do absolutely nothing and are always 0.1

</details>
