### PR TITLE
Hidden Extra Talents

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Characters/Character.cs
@@ -1435,7 +1435,10 @@ namespace Barotrauma
 
         partial void OnTalentGiven(TalentPrefab talentPrefab)
         {
-            AddMessage(TextManager.Get("talentname." + talentPrefab.Identifier).Value, GUIStyle.Yellow, playSound: this == Controlled);
+            if (!talentPrefab.IsHiddenExtraTalent)
+            {
+                AddMessage(TextManager.Get("talentname." + talentPrefab.Identifier).Value, GUIStyle.Yellow, playSound: this == Controlled);
+            }
         }
     }
 }

--- a/Barotrauma/BarotraumaClient/ClientSource/GUI/TalentMenu.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GUI/TalentMenu.cs
@@ -299,7 +299,7 @@ namespace Barotrauma
             }
 
             ImmutableHashSet<TalentPrefab?> talentsOutsideTree = info.GetUnlockedTalentsOutsideTree().Select(static e => TalentPrefab.TalentPrefabs.Find(c => c.Identifier == e)).ToImmutableHashSet();
-            if (talentsOutsideTree.Any())
+            if (talentsOutsideTree.Any(t => t != null && !t.IsHiddenExtraTalent))
             {
                 //spacing
                 new GUIFrame(new RectTransform(new Vector2(1.0f, 0.01f), nameLayout.RectTransform), style: null);
@@ -324,6 +324,7 @@ namespace Barotrauma
                 foreach (var extraTalent in talentsOutsideTree)
                 {
                     if (extraTalent is null) { continue; }
+                    if (extraTalent.IsHiddenExtraTalent) { continue; }
                     GUIImage talentImg = new GUIImage(new RectTransform(Vector2.One, extraTalentList.Content.RectTransform, scaleBasis: ScaleBasis.BothHeight), sprite: extraTalent.Icon, scaleToFit: true)
                     {
                         ToolTip = RichString.Rich($"‖color:{Color.White.ToStringHex()}‖{extraTalent.DisplayName}‖color:end‖" + "\n\n" + ToolBox.ExtendColorToPercentageSigns(extraTalent.Description.Value)),

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Talents/TalentPrefab.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Talents/TalentPrefab.cs
@@ -23,6 +23,11 @@ namespace Barotrauma
         public readonly Sprite Icon;
 
         /// <summary>
+        /// When set to true, this talent will not be visible in the "Extra Talents" panel if it is not part of the character's job skill tree.
+        /// </summary>
+        public readonly bool IsHiddenExtraTalent;
+
+        /// <summary>
         /// When set to a value the talent tooltip will display a text showing the current value of the stat and the max value.
         /// For example "Progress: 37/100".
         /// </summary>
@@ -61,6 +66,8 @@ namespace Barotrauma
             {
                 DisplayName = TextManager.Get(nameIdentifier).Fallback(Identifier.Value);
             }
+
+            IsHiddenExtraTalent = element.GetAttributeBool("ishiddenextratalent", false);
 
             Description = string.Empty;
 

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Talents/TalentPrefab.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Talents/TalentPrefab.cs
@@ -23,7 +23,7 @@ namespace Barotrauma
         public readonly Sprite Icon;
 
         /// <summary>
-        /// When set to true, this talent will not be visible in the "Extra Talents" panel if it is not part of the character's job skill tree.
+        /// When set to true, this talent will not be visible in the "Extra Talents" panel if it is not part of the character's job talent tree.
         /// </summary>
         public readonly bool IsHiddenExtraTalent;
 


### PR DESCRIPTION
Adds "IsHiddenExtraTalent" bool to talents, when set to true it will make the talent not be visible in the "extra talents" panel of a character.


For the demonstration videos, I've set "phdinnuclearphysics"'s "IsHiddenExtraTalent" bool to true, making it not show up in the extra talents panel when giving it to myself as a medical doctor while still functioning as intended.

Demonstration 1: https://www.youtube.com/watch?v=b6n2UhNz9f8

Demonstration 2: https://www.youtube.com/watch?v=pSgLWKtFW4E

(Demonstrations don't show the most recent change to this PR which makes hidden talents not show a message / play a sound when unlocked)