### PR TITLE
Make damagedsprite affected by ragdoll texturescale

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Characters/Limb.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Characters/Limb.cs
@@ -967,7 +967,7 @@ namespace Barotrauma
                         new Vector2(body.DrawPosition.X, -body.DrawPosition.Y),
                         colorWithoutTint * damageOverlayStrength, activeSprite.Origin,
                         -body.DrawRotation,
-                        Scale, spriteEffect, activeSprite.Depth - depthStep * Math.Max(1, WearingItems.Count * 2)); // Multiply by 2 to get rid of z-fighting with some clothing combos
+                        Scale * TextureScale, spriteEffect, activeSprite.Depth - depthStep * Math.Max(1, WearingItems.Count * 2)); // Multiply by 2 to get rid of z-fighting with some clothing combos
                 }
             }
 


### PR DESCRIPTION
Fixes https://github.com/FakeFishGames/Barotrauma/discussions/15201

![image](https://github.com/user-attachments/assets/72d82310-543c-4c2c-8c51-689dbe8aeba8)
