### PR TITLE
Add "hideifnorecipe" bool to fabrication recipes

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Fabricator.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/Fabricator.cs
@@ -771,6 +771,18 @@ namespace Barotrauma.Items.Components
                     }
                 }
 
+                if (recipe.RequiresRecipe && recipe.HideIfNoRecipe)
+                {
+                    if (Character.Controlled != null)
+                    {
+                        if (!AnyOneHasRecipeForItem(Character.Controlled, recipe.TargetItem))
+                        {
+                            child.Visible = false;
+                            continue;
+                        }
+                    }
+                }
+
                 child.Visible =
                     (string.IsNullOrWhiteSpace(filter) || recipe.DisplayName.Contains(filter, StringComparison.OrdinalIgnoreCase)) &&
                     (!category.HasValue || recipe.TargetItem.Category.HasFlag(category.Value));

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/ItemPrefab.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/ItemPrefab.cs
@@ -217,6 +217,7 @@ namespace Barotrauma
         public readonly float RequiredTime;
         public readonly int RequiredMoney;
         public readonly bool RequiresRecipe;
+        public readonly bool HideIfNoRecipe;
         public readonly float OutCondition; //Percentage-based from 0 to 1
         public readonly ImmutableArray<Skill> RequiredSkills;
         public readonly uint RecipeHash;
@@ -250,6 +251,7 @@ namespace Barotrauma
             }
             var requiredItems = new List<RequiredItem>();
             RequiresRecipe = element.GetAttributeBool("requiresrecipe", false);
+            HideIfNoRecipe = element.GetAttributeBool("hideifnorecipe", false);
             Amount = element.GetAttributeInt("amount", 1);
 
             int limitDefault = element.GetAttributeInt("fabricationlimit", -1);


### PR DESCRIPTION
Adds "hideifnorecipe" boolean to fabrication recipe parameters, which, if set to true, makes the recipe not show up in fabricator recipe list if the character and anybody in their crew doesn't have the recipe unlocked through a talent. Only relevant if "requiresrecipe" is set to true.


(For the demonstrations, I set "hideifnorecipe" to true for the Funbringer "clownexosuit")
Demonstration 1: https://youtu.be/BIjkKoS6wag
Demonstration 2: https://youtu.be/CJD9t-N3ZDQ
