### PR TITLE
Make singleplayer player swap characters if their character is removed

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/AfflictionHusk.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Health/Afflictions/AfflictionHusk.cs
@@ -296,7 +296,6 @@ namespace Barotrauma
             var client = GameMain.Server?.ConnectedClients.FirstOrDefault(c => c.Character == character);
 #endif
             character.Enabled = false;
-            Entity.Spawner.AddEntityToRemoveQueue(character);
             UnsubscribeFromDeathEvent();
 
             Identifier huskedSpeciesName = GetHuskedSpeciesName(character.Params, Prefab as AfflictionPrefabHusk);
@@ -385,6 +384,7 @@ namespace Barotrauma
             }
 
             husk.SetStun(5);
+            Entity.Spawner.AddEntityToRemoveQueue(character);
             yield return new WaitForSeconds(5, false);
 #if CLIENT
             husk?.PlaySound(CharacterSound.SoundType.Idle);

--- a/Barotrauma/BarotraumaShared/SharedSource/Networking/EntitySpawner.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Networking/EntitySpawner.cs
@@ -367,6 +367,12 @@ namespace Barotrauma
                     if (client != null) GameMain.Server.SetClientCharacter(client, null);
                 }
 #endif
+#if CLIENT
+                if (GameMain.IsSingleplayer && character != null && Character.Controlled == character && character.IsOnPlayerTeam)
+                {
+                    GameMain.GameSession.CrewManager.SelectNextCharacter();
+                }
+#endif
             }
 
             spawnOrRemoveQueue.Enqueue(entity);


### PR DESCRIPTION
Fixes https://github.com/FakeFishGames/Barotrauma/discussions/15264

AddEntityToRemoveQueue now automatically calls "SelectNextCharacter" if the entity being removed is the player's currently controlled crew member in singleplayer as to not put them in spectator mode

Moved "AddEntityToRemoveQueue" call on husk infection's "CreateAIHusk" function to the end of the function to not interfere with "controlhusk"'s functionality in singleplayer

Demonstration: https://www.youtube.com/watch?v=x2r389_srfc