### PR TITLE
Animation specific limb constant angles

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Animation/AnimController.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Animation/AnimController.cs
@@ -319,14 +319,24 @@ namespace Barotrauma
         
         protected void UpdateConstantTorque(float deltaTime)
         {
+            if (character.IsIncapacitated) { return; }
+            if (character.Stun > 0.01f) { return; }
             foreach (var limb in Limbs)
             {
                 if (limb.IsSevered) { continue; }
-                if (Math.Abs(limb.Params.ConstantTorque) > 0)
+                float angleToApply = limb.Params.ConstantAngle;
+                float torqueToApply = limb.Params.ConstantTorque;
+                float movementFactor = Math.Max(character.AnimController.Collider.LinearVelocity.Length() * 0.5f, 1);
+                if (CurrentAnimationParams.LimbConstantAnglesData.ContainsKey(limb.Params.ID))
                 {
-                    // TODO: not sure if this works on ground
-                    float movementFactor = Math.Max(character.AnimController.Collider.LinearVelocity.Length() * 0.5f, 1);
-                    limb.body.SmoothRotate(MainLimb.Rotation + MathHelper.ToRadians(limb.Params.ConstantAngle) * Dir, limb.Mass * limb.Params.ConstantTorque * movementFactor, wrapAngle: true);
+                    var constantAngleData = CurrentAnimationParams.LimbConstantAnglesData[limb.Params.ID];
+
+                    angleToApply = constantAngleData.ConstantAngle;
+                    torqueToApply = constantAngleData.ConstantTorque;
+                }
+                if (torqueToApply > 0f) 
+                {
+                    limb.body.SmoothRotate(MainLimb.Rotation + MathHelper.ToRadians(angleToApply) * Dir, limb.Mass * torqueToApply * movementFactor, wrapAngle: true);
                 }
             }
         }


### PR DESCRIPTION
Adds a new character animation property "LimbConstantAngles" which is formatted like this: "limbID: constantangle;constanttorque, limbID2: constantangle2;constanttorque2, ..."

This allows specific limbs to assume certain angles with certain torque depending on the currently selected animation, allowing more control over how a character's limbs are posed, especially for non humanoid ones

Limb-defined constantangles and constanttorques will be used if there aren't any animation specific ones for that limb

Constanttorque is no longer applied to limbs if the character is stunned / unconscious (will probably add a way to circumvent this later, maybe with a limb specific boolean property and/or even an animation-wide one to allow things like custom death poses by swapping animation set after death)

[Example demonstration video](https://youtu.be/qMdbG9t7wx4)
[Example mod overriding husk chimera to add some custom constant torque during run animation](https://github.com/user-attachments/files/18143398/animationconstantangletest.zip)