### PR TITLE
Fix duplicate message box when using forcesay in multiplayer

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/StatusEffects/StatusEffect.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/StatusEffects/StatusEffect.cs
@@ -1977,8 +1977,11 @@ namespace Barotrauma
 #if SERVER
                         GameMain.Server?.SendChatMessage(messageToSay.Value, messageType, senderClient: null, targetCharacter);
 #elif CLIENT
-                        AIChatMessage message = new AIChatMessage(messageToSay.Value, messageType);
-                        targetCharacter.SendSinglePlayerMessage(message, canUseRadio, radio);
+                        if (isNotClient)
+                        {
+                            AIChatMessage message = new AIChatMessage(messageToSay.Value, messageType);
+                            targetCharacter.SendSinglePlayerMessage(message, canUseRadio, radio);
+                        }
 #endif
                     }
                 }


### PR DESCRIPTION
Since the messages are replicated to all players in multiplayer anyway, we don't need to run the clientside message code at all unless it's singleplayer.

Fixes https://github.com/FakeFishGames/Barotrauma/discussions/15395