### PR TITLE
Fix custom sprite deformation not mirroring when character flips

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Characters/Limb.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Characters/Limb.cs
@@ -824,11 +824,11 @@ namespace Barotrauma
                 {
                     if (ActiveDeformations.Any())
                     {
-                        var deformation = SpriteDeformation.GetDeformation(ActiveDeformations, deformSprite.Size);
+                        var deformation = SpriteDeformation.GetDeformation(ActiveDeformations, deformSprite.Size, isFlipped: IsFlipped);
                         deformSprite.Deform(deformation);
                         if (LightSource != null && LightSource.DeformableLightSprite != null)
                         {
-                            deformation = SpriteDeformation.GetDeformation(ActiveDeformations, deformSprite.Size, dir == Direction.Left);
+                            deformation = SpriteDeformation.GetDeformation(ActiveDeformations, deformSprite.Size, dir == Direction.Left, isFlipped: IsFlipped);
                             LightSource.DeformableLightSprite.Deform(deformation);
                         }
                     }
@@ -879,7 +879,7 @@ namespace Barotrauma
                         var defSprite = conditionalSprite.DeformableSprite;
                         if (ActiveDeformations.Any())
                         {
-                            var deformation = SpriteDeformation.GetDeformation(ActiveDeformations, defSprite.Size);
+                            var deformation = SpriteDeformation.GetDeformation(ActiveDeformations, defSprite.Size, isFlipped: IsFlipped);
                             defSprite.Deform(deformation);
                         }
                         else

--- a/Barotrauma/BarotraumaClient/ClientSource/Sprite/DeformAnimations/CustomDeformation.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Sprite/DeformAnimations/CustomDeformation.cs
@@ -38,6 +38,8 @@ namespace Barotrauma.SpriteDeformations
         }
         private float phase;
 
+        private Vector2[,] FlippedDeformation;
+
         public CustomDeformation(XElement element) : base(element, new CustomDeformationParams(element))
         {
             phase = Rand.Range(0.0f, MathHelper.TwoPi);
@@ -107,25 +109,24 @@ namespace Barotrauma.SpriteDeformations
                         (normalizedY % divY) / divY);
                 }
             }
+            int width = Deformation.GetLength(0);
+            int height = Deformation.GetLength(1);
+            FlippedDeformation = new Vector2[width, height];
+
+            for (int x = 0; x < width; x++)
+            {
+                for (int y = 0; y < height; y++)
+                {
+                    FlippedDeformation[x, y] = Deformation[width - x - 1, y]; // read the rows from right to left
+                }
+            }
         }
 
         protected override void GetDeformation(out Vector2[,] deformation, out float multiplier, bool inverse, bool isFlipped = false)
         {
             if (isFlipped)
             {
-                Vector2[,] flippedDeformation = new Vector2[Deformation.GetLength(0), Deformation.GetLength(1)];
-
-                int width = Deformation.GetLength(0);
-                int height = Deformation.GetLength(1);
-
-                for (int x = 0; x < width; x++)
-                {
-                    for (int y = 0; y < height; y++)
-                    {
-                        flippedDeformation[x, y] = Deformation[width - x - 1, y]; // read the rows from right to left
-                    }
-                }
-                deformation = flippedDeformation;
+                deformation = FlippedDeformation;
             }
             else
             {

--- a/Barotrauma/BarotraumaClient/ClientSource/Sprite/DeformAnimations/CustomDeformation.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Sprite/DeformAnimations/CustomDeformation.cs
@@ -109,9 +109,28 @@ namespace Barotrauma.SpriteDeformations
             }
         }
 
-        protected override void GetDeformation(out Vector2[,] deformation, out float multiplier, bool inverse)
+        protected override void GetDeformation(out Vector2[,] deformation, out float multiplier, bool inverse, bool isFlipped = false)
         {
-            deformation = Deformation;
+            if (isFlipped)
+            {
+                Vector2[,] flippedDeformation = new Vector2[Deformation.GetLength(0), Deformation.GetLength(1)];
+
+                int width = Deformation.GetLength(0);
+                int height = Deformation.GetLength(1);
+
+                for (int x = 0; x < width; x++)
+                {
+                    for (int y = 0; y < height; y++)
+                    {
+                        flippedDeformation[x, y] = Deformation[width - x - 1, y]; // read the rows from right to left
+                    }
+                }
+                deformation = flippedDeformation;
+            }
+            else
+            {
+                deformation = Deformation;
+            }
             multiplier = CustomDeformationParams.Frequency <= 0.0f ? 
                 CustomDeformationParams.Amplitude : 
                 (float)Math.Sin(inverse ? -phase : phase) * CustomDeformationParams.Amplitude;

--- a/Barotrauma/BarotraumaClient/ClientSource/Sprite/DeformAnimations/CustomDeformation.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Sprite/DeformAnimations/CustomDeformation.cs
@@ -109,15 +109,13 @@ namespace Barotrauma.SpriteDeformations
                         (normalizedY % divY) / divY);
                 }
             }
-            int width = Deformation.GetLength(0);
-            int height = Deformation.GetLength(1);
-            FlippedDeformation = new Vector2[width, height];
+            FlippedDeformation = new Vector2[Resolution.X, Resolution.Y];
 
-            for (int x = 0; x < width; x++)
+            for (int x = 0; x < Resolution.X; x++)
             {
-                for (int y = 0; y < height; y++)
+                for (int y = 0; y < Resolution.Y; y++)
                 {
-                    FlippedDeformation[x, y] = Deformation[width - x - 1, y]; // read the rows from right to left
+                    FlippedDeformation[x, y] = Deformation[Resolution.X - x - 1, y]; // read the rows from right to left
                 }
             }
         }

--- a/Barotrauma/BarotraumaClient/ClientSource/Sprite/DeformAnimations/Inflate.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Sprite/DeformAnimations/Inflate.cs
@@ -54,7 +54,7 @@ namespace Barotrauma.SpriteDeformations
             phase = Rand.Range(0.0f, MathHelper.TwoPi);
         }
 
-        protected override void GetDeformation(out Vector2[,] deformation, out float multiplier, bool inverse)
+        protected override void GetDeformation(out Vector2[,] deformation, out float multiplier, bool inverse, bool isFlipped = false)
         {
             deformation = this.deformation;
             multiplier = InflateParams.Frequency <= 0.0f ? InflateParams.Scale : (float)(Math.Sin(phase) + 1.0f) / 2.0f * InflateParams.Scale;

--- a/Barotrauma/BarotraumaClient/ClientSource/Sprite/DeformAnimations/JointBendDeformation.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Sprite/DeformAnimations/JointBendDeformation.cs
@@ -56,7 +56,7 @@ namespace Barotrauma.SpriteDeformations
 
         public JointBendDeformation(XElement element) : base(element, new JointBendDeformationParams(element)) { }
 
-        protected override void GetDeformation(out Vector2[,] deformation, out float multiplier, bool inverse)
+        protected override void GetDeformation(out Vector2[,] deformation, out float multiplier, bool inverse, bool isFlipped = false)
         {
             deformation = Deformation;
             multiplier = 1.0f;// this.multiplier;

--- a/Barotrauma/BarotraumaClient/ClientSource/Sprite/DeformAnimations/NoiseDeformation.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Sprite/DeformAnimations/NoiseDeformation.cs
@@ -47,7 +47,7 @@ namespace Barotrauma.SpriteDeformations
             }
         }
 
-        protected override void GetDeformation(out Vector2[,] deformation, out float multiplier, bool inverse)
+        protected override void GetDeformation(out Vector2[,] deformation, out float multiplier, bool inverse, bool isFlipped = false)
         {
             deformation = Deformation;
             multiplier = NoiseDeformationParams.Amplitude * Params.Strength;

--- a/Barotrauma/BarotraumaClient/ClientSource/Sprite/DeformAnimations/PositionalDeformation.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Sprite/DeformAnimations/PositionalDeformation.cs
@@ -100,7 +100,7 @@ namespace Barotrauma.SpriteDeformations
             }            
         }
 
-        protected override void GetDeformation(out Vector2[,] deformation, out float multiplier, bool inverse)
+        protected override void GetDeformation(out Vector2[,] deformation, out float multiplier, bool inverse, bool isFlipped = false)
         {
             deformation = Deformation;
             multiplier = 1.0f;

--- a/Barotrauma/BarotraumaClient/ClientSource/Sprite/DeformAnimations/SpriteDeformation.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Sprite/DeformAnimations/SpriteDeformation.cs
@@ -195,12 +195,12 @@ namespace Barotrauma.SpriteDeformations
             Deformation = new Vector2[Params.Resolution.X, Params.Resolution.Y];
         }
 
-        protected abstract void GetDeformation(out Vector2[,] deformation, out float multiplier, bool inverse);
+        protected abstract void GetDeformation(out Vector2[,] deformation, out float multiplier, bool inverse, bool isFlipped = false);
 
         public abstract void Update(float deltaTime);
 
         private static readonly List<int> yValues = new List<int>();
-        public static Vector2[,] GetDeformation(IEnumerable<SpriteDeformation> animations, Vector2 scale, bool inverseY = false)
+        public static Vector2[,] GetDeformation(IEnumerable<SpriteDeformation> animations, Vector2 scale, bool inverseY = false, bool isFlipped = false)
         {
             foreach (SpriteDeformation animation in animations)
             {
@@ -231,7 +231,7 @@ namespace Barotrauma.SpriteDeformations
                 {
                     yValues.Reverse();
                 }
-                animation.GetDeformation(out Vector2[,] animDeformation, out float multiplier, inverseY);
+                animation.GetDeformation(out Vector2[,] animDeformation, out float multiplier, inverseY, isFlipped);
                 for (int x = 0; x < resolution.X; x++)
                 {
                     for (int y = 0; y < resolution.Y; y++)


### PR DESCRIPTION
Adds "isFlipped" parameter to all "GetDeformation" methods, only used in "CustomDeformation" for now to read the deformation rows in an inverse order when the character is flipped

Fixes https://github.com/FakeFishGames/Barotrauma/discussions/15434

https://github.com/user-attachments/assets/cc04ced6-b605-4693-b7a7-662ad6b39cf5



Without the fix ↓:



https://github.com/user-attachments/assets/090ec2e5-c7c1-459f-8caa-d12b96c7603b

