### PR TITLE
Submarine Editor Transform Tool

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/GUI/Widget.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GUI/Widget.cs
@@ -112,8 +112,7 @@ namespace Barotrauma
         {
             PreUpdate?.Invoke(deltaTime);
             if (!enabled) { return; }
-            if (IsMouseOver) { Hovered?.Invoke(); }
-            if (PlayerInput.PrimaryMouseButtonHeld() && (IsMouseOver || !RequireMouseOn && SelectedWidgets.Contains(this)))
+            if (IsMouseOver || (!RequireMouseOn && SelectedWidgets.Contains(this) && PlayerInput.PrimaryMouseButtonHeld()))
             {
                 if (RequireMouseOn || PlayerInput.PrimaryMouseButtonDown())
                 {

--- a/Barotrauma/BarotraumaClient/ClientSource/GUI/Widget.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GUI/Widget.cs
@@ -112,9 +112,9 @@ namespace Barotrauma
         {
             PreUpdate?.Invoke(deltaTime);
             if (!enabled) { return; }
+            if (IsMouseOver) { Hovered?.Invoke(); }
             if (PlayerInput.PrimaryMouseButtonHeld() && (IsMouseOver || !RequireMouseOn && SelectedWidgets.Contains(this)))
             {
-                Hovered?.Invoke();
                 if (RequireMouseOn || PlayerInput.PrimaryMouseButtonDown())
                 {
                     if ((multiselect && !SelectedWidgets.Contains(this)) || SelectedWidgets.None())

--- a/Barotrauma/BarotraumaClient/ClientSource/GUI/Widget.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GUI/Widget.cs
@@ -112,7 +112,7 @@ namespace Barotrauma
         {
             PreUpdate?.Invoke(deltaTime);
             if (!enabled) { return; }
-            if (IsMouseOver || (!RequireMouseOn && SelectedWidgets.Contains(this) && PlayerInput.PrimaryMouseButtonHeld()))
+            if (PlayerInput.PrimaryMouseButtonHeld() && (IsMouseOver || !RequireMouseOn && SelectedWidgets.Contains(this)))
             {
                 Hovered?.Invoke();
                 if (RequireMouseOn || PlayerInput.PrimaryMouseButtonDown())

--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/SubEditorScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/SubEditorScreen.cs
@@ -8,6 +8,7 @@ using Microsoft.Xna.Framework.Input;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Xml.Linq;
@@ -23,6 +24,8 @@ namespace Barotrauma
         public const int MaxLights = 600;
         public const int MaxShadowCastingLights = 100;
 
+        private const float TransformToolWidgetOffset = 300f;
+
         private static Submarine MainSub
         {
             get => Submarine.MainSub;
@@ -35,6 +38,131 @@ namespace Barotrauma
         {
             Default,
             Wiring
+        }
+        
+        private GUITickBox RotateToolToggle, ScaleToolToggle;
+        
+        private static Vector2 SelectionCenter
+        {
+            get
+            {
+                List<MapEntity> nonWireEntities = MapEntity.FilteredSelectedList.Where(entity => (entity as Item)?.GetComponent<Wire>() == null).ToList();
+                return nonWireEntities.Any()
+                    ? Vector2.Lerp((nonWireEntities.Min(entity => entity.DrawPosition.X), nonWireEntities.Min(entity => entity.DrawPosition.Y)), (nonWireEntities.Max(entity => entity.DrawPosition.X), nonWireEntities.Max(entity => entity.DrawPosition.Y)), 0.5f)
+                    : Vector2.Zero;
+            }
+        }
+
+        private Vector2 oldSelectionCenter;
+
+        private record struct TransformData(float scale, float rotation, Vector2 pos, Rectangle rect, Vector2? texOffset, Dictionary<Wire, (List<Vector2> nodes, float width)> wires, Dictionary<ItemLabel, float> textScales, Dictionary<LightComponent, float> lightRanges);
+        private Dictionary<MapEntity, TransformData> oldTransformData;
+        
+        private Widget transformWidget;
+        private Widget TransformWidget
+        {
+            get
+            {
+                if (transformWidget != null) { return transformWidget; }
+
+                int size = GUI.IntScale(16f);
+                transformWidget = new("scale", size, WidgetShape.Rectangle)
+                {
+                    Enabled = false,
+                    Color = GUIStyle.Yellow,
+                    InputAreaMargin = 20,
+                    RequireMouseOn = false,
+                    TooltipOffset = (size / 2f, -size / 2f)
+                };
+                transformWidget.Selected += () =>
+                {
+                    transformWidget.Color = GUIStyle.Green;
+                    
+                    oldTransformData = MapEntity.SelectedList.ToDictionary(entity => entity, entity =>
+                    {
+                        Item item = entity as Item;
+                        Structure structure = entity as Structure;
+                        
+                        float rotation = entity switch
+                        {
+                            Structure => MathHelper.ToRadians(structure.Rotation),
+                            Item => item.RotationRad,
+                            _ => 0f
+                        };
+                        return new TransformData(entity.Scale, rotation, entity.DrawPosition, entity.Rect, structure?.TextureOffset,
+                                                 item?.GetComponents<Wire>().ToDictionary(wire => wire, wire => (wire.GetNodes(), wire.Width)),
+                                                 item?.GetComponents<ItemLabel>().ToDictionary(label => label, label => label.TextScale),
+                                                item?.GetComponents<LightComponent>().ToDictionary(light => light, light => light.Range));
+                    });
+                    
+                    oldSelectionCenter = SelectionCenter;
+                };
+                transformWidget.Deselected += () => transformWidget.Color = Color.Yellow;
+                transformWidget.PreUpdate += _ => transformWidget.Enabled = MapEntity.FilteredSelectedList.Any() && (RotateToolToggle.Selected || ScaleToolToggle.Selected);
+                transformWidget.MouseHeld += _ =>
+                {
+                    MapEntity.DisableSelect = true;
+
+                    if (MathUtils.NearlyEqual(PlayerInput.MousePosition, transformWidget.DrawPos)) { return; }
+                    
+                    float rotationAngleRad = 0f;
+                    LocalizedString rotationString = null;
+                    if (RotateToolToggle.Selected)
+                    {
+                        rotationAngleRad = MathUtils.VectorToAngle(PlayerInput.MousePosition - Cam.WorldToScreen(oldSelectionCenter));
+                        rotationString = TextManager.GetWithVariable("SubEditor.TransformWidget.Rotation", "[value]", MathHelper.ToDegrees(rotationAngleRad).ToString("0.###", CultureInfo.CurrentCulture));
+                    }
+                    
+                    float scaleMult = 1f;
+                    LocalizedString scaleString = null;
+                    if (ScaleToolToggle.Selected)
+                    {
+                        scaleMult = Vector2.Distance(PlayerInput.MousePosition, Cam.WorldToScreen(oldSelectionCenter)) / (TransformToolWidgetOffset * GUI.Scale);
+                        scaleString = TextManager.GetWithVariable("SubEditor.TransformWidget.Scale", "[value]", scaleMult.ToString("0.###", CultureInfo.CurrentCulture));
+                    }
+                    
+                    transformWidget.Tooltip = LocalizedString.Join("\n",new[] { rotationString, scaleString }.Where(str => !str.IsNullOrEmpty()));
+                    
+                    Vector2 selectionWirePos = oldSelectionCenter - MainSub.HiddenSubPosition;
+
+                    foreach (MapEntity entity in MapEntity.SelectedList)
+                    {
+                        TransformData oldData = oldTransformData[entity];
+                        
+                        if (RotateToolToggle.Selected && entity is Item { Prefab.AllowRotatingInEditor: true } or Structure { Prefab.AllowRotatingInEditor: true })
+                        {
+                            float newRotation = MathHelper.ToDegrees(MathHelper.WrapAngle(oldData.rotation + (entity.FlippedX ^ entity.FlippedY ? -rotationAngleRad : rotationAngleRad)));
+                            switch (entity)
+                            {
+                                case Item item:
+                                    item.Rotation = newRotation;
+                                    break;
+                                case Structure structure:
+                                    structure.Rotation = newRotation;
+                                    break;
+                            }
+                        }
+                        
+                        if (ScaleToolToggle.Selected)
+                        {
+                            entity.Scale = oldData.scale * scaleMult;
+                            if (entity.ResizeVertical || entity.ResizeHorizontal)
+                            {
+                                if (entity.ResizeVertical) { entity.RectHeight = (int)(oldData.rect.Height * scaleMult); }
+                                if (entity.ResizeHorizontal) { entity.RectWidth = (int)(oldData.rect.Width * scaleMult); }
+                                if (entity is Structure structure && oldData.texOffset.HasValue) { structure.TextureOffset = oldData.texOffset.Value * scaleMult; }
+                            }
+                            oldData.textScales?.ForEach(pair => pair.Key.TextScale = pair.Value * scaleMult);
+                            oldData.lightRanges?.ForEach(pair => pair.Key.Range = pair.Value * scaleMult);
+                            oldData.wires?.ForEach(pair => pair.Key.Width = pair.Value.width * scaleMult);
+                        }
+
+                        entity.Move(MathUtils.RotatePointAroundTarget(oldSelectionCenter + (oldData.pos - oldSelectionCenter) * scaleMult, oldSelectionCenter, -rotationAngleRad) - entity.DrawPosition);
+                        oldData.wires?.ForEach(pair => pair.Key.SetNodes(pair.Value.nodes.Select(nodePos => MathUtils.RotatePointAroundTarget(selectionWirePos + (nodePos - selectionWirePos) * scaleMult, selectionWirePos, -rotationAngleRad)).ToList()));
+                    }
+                };
+                return transformWidget;
+            }
         }
 
         public enum WarningType
@@ -530,6 +658,16 @@ namespace Barotrauma
             };
 
             spacing = new GUIFrame(new RectTransform(new Vector2(0.02f, 1.0f), paddedTopPanel.RectTransform), style: null);
+            new GUIFrame(new RectTransform(new Vector2(0.1f, 0.9f), spacing.RectTransform, Anchor.Center), style: "VerticalLine");
+
+            RotateToolToggle = new GUITickBox(new RectTransform(new Vector2(0.9f, 0.9f), paddedTopPanel.RectTransform, scaleBasis: ScaleBasis.BothHeight), "", style: "SubEditorRotateToggle")
+            {
+                ToolTip = TextManager.Get("SubEditor.RotateToggleToolTip")
+            };
+            ScaleToolToggle = new GUITickBox(new RectTransform(new Vector2(0.9f, 0.9f), paddedTopPanel.RectTransform, scaleBasis: ScaleBasis.BothHeight), "", style: "SubEditorScaleToggle")
+            {
+                ToolTip = TextManager.Get("SubEditor.ScaleToggleToolTip")
+            };
 
             var selectedLayerText = new GUITextBlock(new RectTransform(new Vector2(0.15f, 1.0f), paddedTopPanel.RectTransform),
                 string.Empty, textAlignment: Alignment.Center);
@@ -1448,6 +1586,8 @@ namespace Barotrauma
 
             GUI.ForceMouseOn(null);
             SetMode(Mode.Default);
+            RotateToolToggle.Selected = false;
+            ScaleToolToggle.Selected = false;
 
             if (backedUpSubInfo != null)
             {
@@ -6192,6 +6332,8 @@ namespace Barotrauma
 
                 CharacterHUD.Update((float)deltaTime, dummyCharacter, cam);
             }
+
+            TransformWidget.Update((float)deltaTime);
         }
 
         /// <summary>
@@ -6320,6 +6462,13 @@ namespace Barotrauma
                 wiringToolPanel.DrawManually(spriteBatch);                
             }
             MapEntity.DrawEditor(spriteBatch, cam);
+
+            if (TransformWidget.Enabled)
+            {
+                TransformWidget.DrawPos = TransformWidget.IsSelected ? PlayerInput.MousePosition : Cam.WorldToScreen(SelectionCenter) + Vector2.UnitX * TransformToolWidgetOffset * GUI.Scale;
+                GUI.DrawLine(spriteBatch, Cam.WorldToScreen(SelectionCenter), TransformWidget.DrawPos, GUIStyle.Green, width: 3f);
+                TransformWidget.Draw(spriteBatch, (float)deltaTime);
+            }
 
             GUI.Draw(Cam, spriteBatch);
 

--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/SubEditorScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/SubEditorScreen.cs
@@ -46,7 +46,7 @@ namespace Barotrauma
         {
             get
             {
-                List<MapEntity> nonWireEntities = MapEntity.FilteredSelectedList.Where(entity => (entity as Item)?.GetComponent<Wire>() == null).ToList();
+                IEnumerable<MapEntity> nonWireEntities = MapEntity.FilteredSelectedList.Where(entity => (entity as Item)?.GetComponent<Wire>() == null);
                 return nonWireEntities.Any()
                     ? Vector2.Lerp((nonWireEntities.Min(entity => entity.DrawPosition.X), nonWireEntities.Min(entity => entity.DrawPosition.Y)), (nonWireEntities.Max(entity => entity.DrawPosition.X), nonWireEntities.Max(entity => entity.DrawPosition.Y)), 0.5f)
                     : Vector2.Zero;
@@ -131,7 +131,7 @@ namespace Barotrauma
                         
                         if (RotateToolToggle.Selected && entity is Item { Prefab.AllowRotatingInEditor: true } or Structure { Prefab.AllowRotatingInEditor: true })
                         {
-                            float newRotation = MathHelper.ToDegrees(MathHelper.WrapAngle(oldData.rotation + (entity.FlippedX ^ entity.FlippedY ? -rotationAngleRad : rotationAngleRad)));
+                            float newRotation = MathHelper.ToDegrees(MathHelper.WrapAngle(oldData.rotation + (entity is Structure && entity.FlippedX ^ entity.FlippedY ? -rotationAngleRad : rotationAngleRad)));
                             switch (entity)
                             {
                                 case Item item:
@@ -158,7 +158,7 @@ namespace Barotrauma
                         }
 
                         entity.Move(MathUtils.RotatePointAroundTarget(oldSelectionCenter + (oldData.pos - oldSelectionCenter) * scaleMult, oldSelectionCenter, -rotationAngleRad) - entity.DrawPosition);
-                        oldData.wires?.ForEach(pair => pair.Key.SetNodes(pair.Value.nodes.Select(nodePos => MathUtils.RotatePointAroundTarget(selectionWirePos + (nodePos - selectionWirePos) * scaleMult, selectionWirePos, -rotationAngleRad)).ToList()));
+                        oldData.wires?.ForEach(pair => pair.Key.SetNodes(pair.Value.nodes.Select(nodePos => MathUtils.RotatePointAroundTarget(selectionWirePos + (nodePos - selectionWirePos) * scaleMult, selectionWirePos, -rotationAngleRad))));
                     }
                 };
                 return transformWidget;

--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/SubEditorScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/SubEditorScreen.cs
@@ -6466,7 +6466,7 @@ namespace Barotrauma
             if (TransformWidget.Enabled)
             {
                 TransformWidget.DrawPos = TransformWidget.IsSelected ? PlayerInput.MousePosition : Cam.WorldToScreen(SelectionCenter) + Vector2.UnitX * TransformToolWidgetOffset * GUI.Scale;
-                GUI.DrawLine(spriteBatch, Cam.WorldToScreen(SelectionCenter), TransformWidget.DrawPos, GUIStyle.Green, width: 3f);
+                GUI.DrawLine(spriteBatch, Cam.WorldToScreen(TransformWidget.IsSelected ? oldSelectionCenter : SelectionCenter), TransformWidget.DrawPos, GUIStyle.Green, width: 3f);
                 TransformWidget.Draw(spriteBatch, (float)deltaTime);
             }
 

--- a/Barotrauma/BarotraumaShared/LocalMods/subeditor-tools/Locale/English.xml
+++ b/Barotrauma/BarotraumaShared/LocalMods/subeditor-tools/Locale/English.xml
@@ -1,0 +1,6 @@
+<Text language="English">
+  <SubEditor.TransformWidget.Rotation>Rotation: [value]°</SubEditor.TransformWidget.Rotation>
+  <SubEditor.TransformWidget.Scale>Scale: ×[value]</SubEditor.TransformWidget.Scale>
+  <SubEditor.RotateToggleToolTip>Edit Rotation</SubEditor.RotateToggleToolTip>
+  <SubEditor.ScaleToggleToolTip>Edit Scaling</SubEditor.ScaleToggleToolTip>
+</Text>

--- a/Barotrauma/BarotraumaShared/LocalMods/subeditor-tools/Style.xml
+++ b/Barotrauma/BarotraumaShared/LocalMods/subeditor-tools/Style.xml
@@ -1,0 +1,18 @@
+<Style>
+  <SubEditorRotateToggle color="255,255,255,255" hovercolor="255,255,255,255" selectedcolor="255,255,255,255" disabledcolor="125,125,125,125">
+    <Sprite name="GUITickBoxFreeScale.None" texture="Content/UI/UIAtlasGeneral.png" state="None" sourcerect="6,112,36,36" tile="false" maintainaspectratio="true"/>
+    <Sprite name="GUITickBoxFreeScale.Pressed" texture="Content/UI/UIAtlasGeneral.png" state="Pressed" sourcerect="109,112,36,36" tile="false" maintainaspectratio="true"/>
+    <Sprite name="GUITickBoxFreeScale.Hover" texture="Content/UI/UIAtlasGeneral.png" state="Hover" sourcerect="160,112,36,36" tile="false" maintainaspectratio="true"/>
+    <Sprite name="GUITickBoxFreeScale.Selected" texture="Content/UI/UIAtlasGeneral.png" state="Selected" sourcerect="57,112,36,36" tile="false" maintainaspectratio="true"/>
+    <Sprite name="GUITickBoxFreeScale.HoverSelected" texture="Content/UI/UIAtlasGeneral.png" state="HoverSelected" sourcerect="211,112,36,36" tile="false" maintainaspectratio="true"/>
+    <GUITextBlock textcolor="228,217,167,255" hovertextcolor="255,255,255,255" disabledtextcolor="125,125,125,125" selectedcolor="255,153,0,76" padding="10,0,10,0"/>
+  </SubEditorRotateToggle>
+  <SubEditorScaleToggle color="255,255,255,255" hovercolor="255,255,255,255" selectedcolor="255,255,255,255" disabledcolor="125,125,125,125">
+    <Sprite name="GUITickBoxFreeScale.None" texture="Content/UI/UIAtlasGeneral.png" state="None" sourcerect="6,112,36,36" tile="false" maintainaspectratio="true"/>
+    <Sprite name="GUITickBoxFreeScale.Pressed" texture="Content/UI/UIAtlasGeneral.png" state="Pressed" sourcerect="109,112,36,36" tile="false" maintainaspectratio="true"/>
+    <Sprite name="GUITickBoxFreeScale.Hover" texture="Content/UI/UIAtlasGeneral.png" state="Hover" sourcerect="160,112,36,36" tile="false" maintainaspectratio="true"/>
+    <Sprite name="GUITickBoxFreeScale.Selected" texture="Content/UI/UIAtlasGeneral.png" state="Selected" sourcerect="57,112,36,36" tile="false" maintainaspectratio="true"/>
+    <Sprite name="GUITickBoxFreeScale.HoverSelected" texture="Content/UI/UIAtlasGeneral.png" state="HoverSelected" sourcerect="211,112,36,36" tile="false" maintainaspectratio="true"/>
+    <GUITextBlock textcolor="228,217,167,255" hovertextcolor="255,255,255,255" disabledtextcolor="125,125,125,125" selectedcolor="255,153,0,76" padding="10,0,10,0"/>
+  </SubEditorScaleToggle>
+</Style>

--- a/Barotrauma/BarotraumaShared/LocalMods/subeditor-tools/filelist.xml
+++ b/Barotrauma/BarotraumaShared/LocalMods/subeditor-tools/filelist.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<contentpackage name="subeditor-tools" corepackage="False" modversion="1.0.0" gameversion="1.7.7.0">
+  <Text file="%ModDir%/Locale/English.xml" />
+  <UIStyle file="%ModDir%/Style.xml" />
+</contentpackage>

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/Wire.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/Wire.cs
@@ -546,9 +546,9 @@ namespace Barotrauma.Items.Components
             return new List<Vector2>(nodes);
         }
 
-        public void SetNodes(List<Vector2> nodes)
+        public void SetNodes(IEnumerable<Vector2> nodes)
         {
-            this.nodes = new List<Vector2>(nodes);
+            this.nodes = nodes.ToList();
             UpdateSections();
         }
 


### PR DESCRIPTION
This PR adds a rotation & scaling tool to the submarine editor.
Its functions can be toggled with the tickboxes to the right of the "Generate Waypoints" button.

With "Edit Rotation" active, users can drag the widget around to rotate the selected entities about the center of the selection.
With "Edit Scaling" active, users can drag the widget around to scale the selected entities about the center of the selection.

The current rotation and/or scaling offset is visible in a tooltip next to the widget while it is being dragged.

Added content is in the mod provided with the PR.
The tickboxes also require their own art to be done, hence the duplicate styles I have added.

![image](https://github.com/user-attachments/assets/50531d24-db35-43d8-a76a-6f57653ff5d0)