### PR TITLE
Item Server Log Message Inconsistency

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Item.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Item.cs
@@ -3937,7 +3937,7 @@ namespace Barotrauma
                 }
                 logPropertyChangeCoroutine = CoroutineManager.Invoke(() =>
                 {
-                    GameServer.Log($"{sender.Character?.Name ?? sender.Name} set the value \"{property.Name}\" of the item \"{Name}\" to \"{logValue}\".", ServerLog.MessageType.ItemInteraction);
+                    GameServer.Log($"{GameServer.CharacterLogName(sender.Character)} set the value \"{property.Name}\" of the item \"{Name}\" to \"{logValue}\".", ServerLog.MessageType.ItemInteraction);
                 }, delay: 1.0f);
             }
 #endif


### PR DESCRIPTION
Related to https://github.com/FakeFishGames/Barotrauma/discussions/15473

This item log message is inconsistent with the other server log messages since it does not wrap the sender.Character with GameServer.CharacterLogName.
This does not cause any issues for the vanilla game, but it can cause an issue for mods using Harmony monitor the log since it is inconsistent with the other server log messages. 

The output of the log message is not changed in any way by this code change. It is a procedural change only.

Here is a C# mod that is affected by this inconsistency.
https://steamcommunity.com/sharedfiles/filedetails/?id=3396389364