### PR TITLE
Oxygen Generator Improvements

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/OxygenGenerator.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/OxygenGenerator.cs
@@ -68,7 +68,7 @@ namespace Barotrauma.Items.Components
             });
             rateSlider = new GUIScrollBar(new RectTransform(Vector2.One, rateSliderContainer.RectTransform, Anchor.Center), barSize: 0.1f, isHorizontal: true, style: "DeviceSliderSeeThrough")
             {
-                Step = GenerationRatioStepFloat,
+                Step = GenerationRatioStep,
                 OnMoved = (_, newRatio) =>
                 {
                     GenerationRatio = newRatio;

--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/OxygenGenerator.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/OxygenGenerator.cs
@@ -1,0 +1,116 @@
+using Barotrauma.Networking;
+using Microsoft.Xna.Framework;
+
+namespace Barotrauma.Items.Components
+{
+    internal partial class OxygenGenerator : IServerSerializable, IClientSerializable
+    {
+        private GUITickBox powerIndicator, autoControlIndicator;
+        private GUIScrollBar rateSlider;
+
+        [Serialize(0.5f, IsPropertySaveable.Yes)]
+        public float RateWarningIndicatorLow { get; set; }
+
+        [Serialize(0.25f, IsPropertySaveable.Yes)]
+        public float RateWarningIndicatorExtremelyLow { get; set; }
+
+        protected override void CreateGUI()
+        {
+            if (GuiFrame == null)
+            {
+                DebugConsole.AddWarning($"OxygenGenerator component of {Item.Name} ({Item.Prefab.Identifier}) has no GUIFrame defined.", Item.ContentPackage);
+                return;
+            }
+            GUILayoutGroup paddedFrame = new(new(GuiFrame.Rect.Size - GUIStyle.ItemFrameMargin, GuiFrame.RectTransform, Anchor.Center) { AbsoluteOffset = GUIStyle.ItemFrameOffset })
+            {
+                Stretch = true,
+                RelativeSpacing = 0.1f
+            };
+
+            int indicatorHeight = MathUtils.RoundToInt(GUIStyle.SubHeadingFont.LineHeight * 2);
+            GUILayoutGroup indicatorArea = new(new(Vector2.One, paddedFrame.RectTransform), isHorizontal: true, Anchor.CenterLeft) { Stretch = true };
+            powerIndicator = new(new(Vector2.UnitX, indicatorArea.RectTransform, minSize: (0, indicatorHeight)), TextManager.Get("EnginePowered"), GUIStyle.SubHeadingFont, style: "IndicatorLightGreen")
+            {
+                CanBeFocused = false,
+                OnAddedToGUIUpdateList = comp => comp.Selected = HasPower && IsActive,
+                TextBlock = { Wrap = true }
+            };
+            powerIndicator.TextBlock.OverrideTextColor(GUIStyle.TextColorNormal);
+            autoControlIndicator = new(new(Vector2.UnitX, indicatorArea.RectTransform, minSize: (0, indicatorHeight)), TextManager.Get("PumpAutoControl", "ReactorAutoControl"), GUIStyle.SubHeadingFont, style: "IndicatorLightYellow")
+            {
+                Enabled = false,
+                OnAddedToGUIUpdateList = comp => comp.Selected = controlLockTimer > 0f,
+                ToolTip = TextManager.Get("AutoControlTip"),
+                TextBlock = { Wrap = true }
+            };
+            autoControlIndicator.TextBlock.OverrideTextColor(GUIStyle.TextColorNormal);
+            GUITextBlock.AutoScaleAndNormalize(powerIndicator.TextBlock, autoControlIndicator.TextBlock);
+
+            GUITextBlock rateName = new(new(Vector2.UnitX, paddedFrame.RectTransform), TextManager.Get("OxygenGenerationRate"), GUIStyle.TextColorNormal, GUIStyle.SubHeadingFont, Alignment.CenterLeft);
+            GUITextBlock rateText = new(new(Vector2.One, rateName.RectTransform), "", GUIStyle.TextColorNormal, GUIStyle.Font, Alignment.CenterRight)
+            {
+                TextGetter = () => $"{MathUtils.RoundToInt(generatedAmount * generationRatio)}/s ({MathUtils.RoundToInt(generationRatio * 100f)}%)"
+            };
+            if (rateText.TextSize.X > rateText.Rect.Width) { rateText.Font = GUIStyle.SmallFont; }
+
+            GUIFrame rateSliderContainer = new(new(Vector2.UnitX, paddedFrame.RectTransform, minSize: (0, 50)));
+            new GUICustomComponent(new(new Vector2(0.95f, 0.9f), rateSliderContainer.RectTransform, Anchor.Center), (sb, comp) =>
+            {
+                if (RateWarningIndicatorLow > 0f)
+                {
+                    GUI.DrawRectangle(sb, comp.Rect.Location.ToVector2(), ( comp.Rect.Width * RateWarningIndicatorLow, comp.Rect.Height), GUIStyle.Orange, isFilled: true);
+                }
+                if (RateWarningIndicatorExtremelyLow > 0f)
+                {
+                    GUI.DrawRectangle(sb, comp.Rect.Location.ToVector2(), (comp.Rect.Width * RateWarningIndicatorExtremelyLow, comp.Rect.Height), GUIStyle.Red, isFilled: true);
+                }
+            });
+            rateSlider = new(new(Vector2.One, rateSliderContainer.RectTransform, Anchor.Center), barSize: 0.1f, isHorizontal: true, style: "DeviceSliderSeeThrough")
+            {
+                Step = 0.1f,
+                OnMoved = (_, newRatio) =>
+                {
+                    GenerationRatio = newRatio;
+                    if (GameMain.Client != null)
+                    {
+                        item.CreateClientEvent(this);
+                        correctionTimer = CorrectionDelay;
+                    }
+                    return true;
+                },
+                OnAddedToGUIUpdateList = comp => comp.Enabled = controlLockTimer <= 0f
+            };
+            rateSlider.Bar.RectTransform.MaxSize = new(rateSlider.Bar.Rect.Height);
+        }
+
+        public override void OnItemLoaded()
+        {
+            base.OnItemLoaded();
+            UpdateSlider();
+        }
+
+        public void ClientEventWrite(IWriteMessage msg, NetEntityEvent.IData extraData)
+        {
+            msg.WriteRangedInteger(MathUtils.RoundToInt(generationRatio * 10), 0, 10);
+        }
+
+        public void ClientEventRead(IReadMessage msg, float sendingTime)
+        {
+            if (correctionTimer > 0f)
+            {
+                StartDelayedCorrection(msg.ExtractBits(4), sendingTime);
+                return;
+            }
+
+            GenerationRatio = msg.ReadRangedInteger(0, 10) / 10f;
+        }
+
+        private void UpdateSlider()
+        {
+            if (rateSlider != null)
+            {
+                rateSlider.BarScroll = generationRatio;
+            }
+        }
+    }
+}

--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/OxygenGenerator.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Machines/OxygenGenerator.cs
@@ -41,9 +41,10 @@ namespace Barotrauma.Items.Components
                 Enabled = false,
                 OnAddedToGUIUpdateList = comp => comp.Selected = controlLockTimer > 0f,
                 ToolTip = TextManager.Get("AutoControlTip"),
-                TextBlock = { Wrap = true }
+                TextBlock = { Wrap = true, TextAlignment = Alignment.CenterRight }
             };
             autoControlIndicator.TextBlock.OverrideTextColor(GUIStyle.TextColorNormal);
+            autoControlIndicator.TextBlock.SetAsFirstChild();
             GUITextBlock.AutoScaleAndNormalize(powerIndicator.TextBlock, autoControlIndicator.TextBlock);
 
             GUITextBlock rateName = new(new(Vector2.UnitX, paddedFrame.RectTransform), TextManager.Get("OxygenGenerationRate"), GUIStyle.TextColorNormal, GUIStyle.SubHeadingFont, Alignment.CenterLeft);

--- a/Barotrauma/BarotraumaServer/ServerSource/Items/Components/Machines/OxygenGenerator.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Items/Components/Machines/OxygenGenerator.cs
@@ -4,22 +4,20 @@ namespace Barotrauma.Items.Components
 {
     internal partial class OxygenGenerator : IServerSerializable, IClientSerializable
     {
-        public void ServerEventWrite(IWriteMessage msg, Client c, NetEntityEvent.IData extraData = null)
-        {
-            msg.WriteRangedInteger(MathUtils.RoundToInt(generationRatio * 10), 0, 10);
-        }
-        
+        #region Networking
+        public void ServerEventWrite(IWriteMessage msg, Client c, NetEntityEvent.IData extraData = null) => WriteGenerationRatio(msg);
         public void ServerEventRead(IReadMessage msg, Client c)
         {
-            float newGenerationRatio = msg.ReadRangedInteger(0, 10) / 10f;
+            float newGenerationRatio = ReadGenerationRatio(msg);
 
             if (item.CanClientAccess(c))
             {
                 GenerationRatio = newGenerationRatio;
-                GameServer.Log(GameServer.CharacterLogName(c.Character) + " set the oxygen generation amount of " + item.Name + " to " + MathUtils.RoundToInt(generationRatio * 100f) + " %", ServerLog.MessageType.ItemInteraction);
+                GameServer.Log($"{GameServer.CharacterLogName(c.Character)} set the oxygen generation amount of {item.Name} to {MathUtils.RoundToInt(generationRatio * 100f)}%", ServerLog.MessageType.ItemInteraction);
             }
 
             item.CreateServerEvent(this);
         }
+        #endregion
     }
 }

--- a/Barotrauma/BarotraumaServer/ServerSource/Items/Components/Machines/OxygenGenerator.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Items/Components/Machines/OxygenGenerator.cs
@@ -1,0 +1,25 @@
+using Barotrauma.Networking;
+
+namespace Barotrauma.Items.Components
+{
+    internal partial class OxygenGenerator : IServerSerializable, IClientSerializable
+    {
+        public void ServerEventWrite(IWriteMessage msg, Client c, NetEntityEvent.IData extraData = null)
+        {
+            msg.WriteRangedInteger(MathUtils.RoundToInt(generationRatio * 10), 0, 10);
+        }
+        
+        public void ServerEventRead(IReadMessage msg, Client c)
+        {
+            float newGenerationRatio = msg.ReadRangedInteger(0, 10) / 10f;
+
+            if (item.CanClientAccess(c))
+            {
+                GenerationRatio = newGenerationRatio;
+                GameServer.Log(GameServer.CharacterLogName(c.Character) + " set the oxygen generation amount of " + item.Name + " to " + MathUtils.RoundToInt(generationRatio * 100f) + " %", ServerLog.MessageType.ItemInteraction);
+            }
+
+            item.CreateServerEvent(this);
+        }
+    }
+}

--- a/Barotrauma/BarotraumaShared/LocalMods/oxygen-changes/Locale/English.xml
+++ b/Barotrauma/BarotraumaShared/LocalMods/oxygen-changes/Locale/English.xml
@@ -1,0 +1,5 @@
+<Text language="English">
+  <OxygenGenerationRate>Oxygen Generation Rate</OxygenGenerationRate>
+  <connection.oxygen.setrate>set_oxygen_rate</connection.oxygen.setrate>
+  <connection.oxygen.rateout>oxygen_rate_out</connection.oxygen.rateout>
+</Text>

--- a/Barotrauma/BarotraumaShared/LocalMods/oxygen-changes/OxygenGenerators.xml
+++ b/Barotrauma/BarotraumaShared/LocalMods/oxygen-changes/OxygenGenerators.xml
@@ -12,38 +12,39 @@
       scale="0.5">
       <UpgradePreviewSprite scale="2.5" texture="Content/UI/WeaponUI.png" sourcerect="384,960,64,64" origin="0.5,0.45" />
       <Upgrade gameversion="0.10.0.0" scale="*0.5" />
-      <Sprite texture="oxygengenerator.png" depth="0.8" origin="0.5,0.5" sourcerect="0,0,416,384"/>
-      <BrokenSprite texture="oxygengenerator.png" sourcerect="416,0,416,384" origin="0.5,0.5" depth="0.8" maxcondition="80" fadein="true" />
-      <BrokenSprite texture="oxygengenerator.png" sourcerect="0,400,416,384" origin="0.5,0.5" depth="0.8" maxcondition="0" />
-      <DecorativeSprite texture="oxygengenerator.png" sourcerect="416,400,416,48" depth="0.824" origin="0.5,4.0"
+      <Sprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" depth="0.8" origin="0.5,0.5" sourcerect="0,0,416,384"/>
+      <BrokenSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="416,0,416,384" origin="0.5,0.5" depth="0.8" maxcondition="80" fadein="true" />
+      <BrokenSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="0,400,416,384" origin="0.5,0.5" depth="0.8" maxcondition="0" />
+      <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="416,400,416,48" depth="0.824" origin="0.5,4.0"
                         offset="0,25" offsetanim="Sine" offsetanimspeed="0.5">
         <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
       <!-- bellow parts from top to bottom -->
-      <DecorativeSprite texture="oxygengenerator.png" sourcerect="416,480,416,32" depth="0.82" origin="0.5,5.2"
+      <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="416,480,416,32" depth="0.82" origin="0.5,5.2"
                         offset="0,25" offsetanim="Sine" offsetanimspeed="0.5">
         <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
-      <DecorativeSprite texture="oxygengenerator.png" sourcerect="416,480,416,32" depth="0.821" origin="0.5,4.7"
+      <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="416,480,416,32" depth="0.821" origin="0.5,4.7"
                         offset="1,18" offsetanim="Sine" offsetanimspeed="0.5">
         <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
-      <DecorativeSprite texture="oxygengenerator.png" sourcerect="416,480,416,32" depth="0.822" origin="0.5,4.2"
+      <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="416,480,416,32" depth="0.822" origin="0.5,4.2"
                         offset="2,10" offsetanim="Sine" offsetanimspeed="0.5">
         <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
-      <DecorativeSprite texture="oxygengenerator.png" sourcerect="416,480,416,32" depth="0.823" origin="0.5,3.7"
+      <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="416,480,416,32" depth="0.823" origin="0.5,3.7"
                         offset="1,5" offsetanim="Sine" offsetanimspeed="0.5">
         <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
       <!-- tube -->
-      <DecorativeSprite texture="oxygengenerator.png" sourcerect="416,656,416,112" depth="0.824" origin="0.5,0.8"
+      <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="416,656,416,112" depth="0.824" origin="0.5,0.8"
                         offset="0,5" offsetanim="Sine" offsetanimspeed="0.5">
         <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
     <LightComponent range="140.0" lightcolor="255,184,108,193" powerconsumption="5" IsOn="false" castshadows="false" allowingameediting="false" />
 
       <OxygenGenerator powerconsumption="1000.0" minvoltage="0.5" canbeselected="true" msg="ItemMsgInteractSelect">
+        <GuiFrame relativesize="0.25,0.15" minsize="350,130" anchor="Center" relativeoffset="0,-0.075" style="ItemUI"/>
         <poweronsound file="Content/Items/PowerOnLight2.ogg" range="1500" loop="false" />
         <sound file="Content/Items/OxygenGenerator/OxygenGenerator.ogg" type="OnActive" range="1000.0" volumeproperty="CurrFlow" volume="0.001" loop="true"/>    
         <StatusEffect type="OnFire" target="This" Condition="-0.5" tags="onfire" duration="1" stackable="false" />
@@ -62,7 +63,7 @@
 
       <ItemContainer capacity="5" maxstacksize="1" canbeselected="true" hideitems="false" itempos="31,-250" iteminterval="44.5,0" msg="ItemMsgOxygenRefill">
         <Upgrade gameversion="0.15.22.1" itempos="31,-250" iteminterval="44.5,0" />
-        <GuiFrame relativesize="0.25,0.2" anchor="Center" style="ItemUI" />
+        <GuiFrame relativesize="0.25,0.2" anchor="Center" relativeoffset="0,0.075" style="ItemUI" />
         <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
         <SlotIcon slotindex="1" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
         <SlotIcon slotindex="2" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
@@ -81,11 +82,13 @@
         <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel"/>
         <RequiredItem items="screwdriver" type="Equipped"/>
         <input name="power_in" displayname="connection.powerin"/>
+        <input name="set_rate" displayname="connection.oxygen.setrate"/>
         <output name="condition_out" displayname="connection.conditionout" />
+        <output name="rate_out" displayname="connection.oxygen.rateout"/>
       </ConnectionPanel>
 
       <Repairable selectkey="Action" header="mechanicalrepairsheader" deteriorationspeed="0.125" mindeteriorationdelay="120" maxdeteriorationdelay="750" mindeteriorationcondition="0" RepairThreshold="80" fixDurationHighSkill="5" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
-        <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI"/>
+        <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" style="ItemUI"/>
         <RequiredSkill identifier="mechanical" level="55"/>
         <RequiredItem items="wrench" type="equipped"/>
         <ParticleEmitter particle="damagebubbles" particlespersecond="2" scalemin="0.5" scalemax="1.5" anglemax="360" velocitymin="-10" velocitymax="10" mincondition="0.0" maxcondition="50.0" />
@@ -109,41 +112,42 @@
       <Upgrade gameversion="0.10.0.0" scale="*0.5" />
 
       <UpgradePreviewSprite texture="Content/UI/WeaponUI.png" sourcerect="384,960,64,64" origin="0.5,0.45" />
-      <Sprite texture="oxygengenerator.png" depth="0.8" sourcerect="0,784,336,240"/>
-      <BrokenSprite texture="oxygengenerator.png" sourcerect="336,784,336,240" depth="0.8" maxcondition="40" fadein="true" />
-      <BrokenSprite texture="oxygengenerator.png" sourcerect="672,784,336,240" depth="0.8" maxcondition="0" />
+      <Sprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" depth="0.8" sourcerect="0,784,336,240"/>
+      <BrokenSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="336,784,336,240" depth="0.8" maxcondition="40" fadein="true" />
+      <BrokenSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="672,784,336,240" depth="0.8" maxcondition="0" />
 
-      <DecorativeSprite texture="oxygengenerator.png" sourcerect="610,400,336,48" depth="0.824" origin="0.6,2.4"
+      <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="610,400,336,48" depth="0.824" origin="0.6,2.4"
                         offset="0,15" offsetanim="Sine" offsetanimspeed="0.5" scale="0.7" rotation="9">
         <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
       <!-- bellows from top to bottom -->
-      <DecorativeSprite texture="oxygengenerator.png" sourcerect="610,480,336,32" depth="0.82" origin="0.45,2.0"
+      <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="610,480,336,32" depth="0.82" origin="0.45,2.0"
                         offset="0,15" offsetanim="Sine" offsetanimspeed="0.5"  rotation="9">
         <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
-      <DecorativeSprite texture="oxygengenerator.png" sourcerect="610,480,336,32" depth="0.821" origin="0.45,1.5"
+      <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="610,480,336,32" depth="0.821" origin="0.45,1.5"
                         offset="1,12" offsetanim="Sine" offsetanimspeed="0.5" rotation="6">
         <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
-      <DecorativeSprite texture="oxygengenerator.png" sourcerect="610,480,336,32" depth="0.822" origin="0.45,1.0"
+      <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="610,480,336,32" depth="0.822" origin="0.45,1.0"
                         offset="2,8" offsetanim="Sine" offsetanimspeed="0.5" rotation="3">
         <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
-      <DecorativeSprite texture="oxygengenerator.png" sourcerect="610,480,336,32" depth="0.823" origin="0.45,0.5"
+      <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="610,480,336,32" depth="0.823" origin="0.45,0.5"
                         offset="1,5" offsetanim="Sine" offsetanimspeed="0.5">
         <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
       <!-- tube -->
-      <DecorativeSprite texture="oxygengenerator.png" sourcerect="610,656,336,112" depth="0.824" origin="0.45,0.3"
+      <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="610,656,336,112" depth="0.824" origin="0.45,0.3"
                         offset="0,5" offsetanim="Sine" offsetanimspeed="0.5" rotation="345">
         <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
       <!-- background for bottles -->
-      <DecorativeSprite texture="oxygengenerator.png" sourcerect="656,564,96,74" depth="0.819" origin="0.07,0.0"
+      <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="656,564,96,74" depth="0.819" origin="0.07,0.0"
                         offset="0,0" />
 
       <OxygenGenerator powerconsumption="1000.0" minvoltage="0.5" canbeselected = "true" msg="ItemMsgInteractSelect">
+        <GuiFrame relativesize="0.25,0.15" minsize="350,130" anchor="Center" relativeoffset="0,-0.075" style="ItemUI"/>
         <poweronsound file="Content/Items/PowerOnLight1.ogg" range="1000" loop="false" />
         <sound file="Content/Items/OxygenGenerator/OxygenGenerator.ogg" type="OnActive" range="1000.0" volumeproperty="CurrFlow" volume="0.001" loop="true"/>
         <StatusEffect type="OnFire" target="This" Condition="-0.5" tags="onfire" duration="1" stackable="false" />
@@ -161,7 +165,7 @@
       <trigger/>
 
       <ItemContainer capacity="3" maxstacksize="1" canbeselected = "true" hideitems="false" itempos="185,-172" iteminterval="27,0" msg="ItemMsgOxygenRefill" containedspritedepth="0.81">
-        <GuiFrame relativesize="0.25,0.2" anchor="Center" style="ItemUI" />
+        <GuiFrame relativesize="0.25,0.2" anchor="Center" relativeoffset="0,0.075" style="ItemUI" />
         <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
         <SlotIcon slotindex="1" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
         <SlotIcon slotindex="2" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
@@ -189,11 +193,13 @@
         </StatusEffect>
         <RequiredItem items="screwdriver" type="Equipped"/>
         <input name="power_in" displayname="connection.powerin"/>
+        <input name="set_rate" displayname="connection.oxygen.setrate"/>
         <output name="condition_out" displayname="connection.conditionout" />
+        <output name="rate_out" displayname="connection.oxygen.rateout"/>
       </ConnectionPanel>
 
       <Repairable selectkey="Action" header="mechanicalrepairsheader" deteriorationspeed="0.125" mindeteriorationdelay="120" maxdeteriorationdelay="750" mindeteriorationcondition="0" RepairThreshold="80" fixDurationHighSkill="5" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
-        <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI"/>
+        <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" style="ItemUI"/>
         <RequiredSkill identifier="mechanical" level="55"/>
         <RequiredItem items="wrench" type="equipped"/>
         <ParticleEmitter particle="spark" particleamount="10" emitinterval="5" anglemax="360" velocitymin="5.0" velocitymax="250.0" scalemin="0.5" scalemax="1" mincondition="0.0" maxcondition="25.0"/>
@@ -211,6 +217,7 @@
       <BrokenSprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="243,1629,213,286" depth="0.79" origin="0.5,0.5" offset="100,0" maxcondition="10" fadein="true" />
       <UpgradePreviewSprite scale="2.5" texture="Content/UI/WeaponUI.png" sourcerect="384,960,64,64" origin="0.5,0.45" />
       <OxygenGenerator powerconsumption="1000.0" minvoltage="0.5" generatedamount="5000" canbeselected="true" msg="ItemMsgInteractSelect">
+        <GuiFrame relativesize="0.25,0.15" minsize="350,130" anchor="Center" relativeoffset="0,-0.075" style="ItemUI"/>
         <poweronsound file="Content/Items/PowerOnLight2.ogg" range="1500" loop="false" />
         <sound file="Content/Items/OxygenGenerator/OxygenGenerator.ogg" type="OnActive" range="1000.0" volumeproperty="CurrFlow" volume="0.001" loop="true" />
         <StatusEffect type="OnFire" target="This" Condition="-0.5" />
@@ -227,17 +234,19 @@
       </OxygenGenerator>
       <trigger />
       <ItemContainer capacity="5" maxstacksize="1" canbeselected="true" hideitems="false" itempos="163,-290" iteminterval="42,0" msg="ItemMsgOxygenRefill">
-        <GuiFrame relativesize="0.25,0.2" anchor="Center" style="ItemUI" />
+        <GuiFrame relativesize="0.25,0.2" anchor="Center" relativeoffset="0,0.075" style="ItemUI" />
         <Containable items="oxygentank" />
       </ItemContainer>
       <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
         <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
         <RequiredItem items="screwdriver" type="Equipped" />
         <input name="power_in" displayname="connection.powerin" />
+        <input name="set_rate" displayname="connection.oxygen.setrate"/>
         <output name="condition_out" displayname="connection.conditionout" />
+        <output name="rate_out" displayname="connection.oxygen.rateout"/>
       </ConnectionPanel>
       <Repairable selectkey="Action" header="mechanicalrepairsheader" deteriorationspeed="0.125" mindeteriorationdelay="120" maxdeteriorationdelay="750" mindeteriorationcondition="0" AIRepairThreshold="50" fixDurationHighSkill="5" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
-        <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI" />
+        <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" style="ItemUI" />
         <RequiredSkill identifier="mechanical" level="55" />
         <RequiredItem items="wrench" type="equipped" />
         <ParticleEmitter particle="damagebubbles" particlespersecond="2" scalemin="0.5" scalemax="1.5" anglemax="360" velocitymin="-10" velocitymax="10" mincondition="0.0" maxcondition="50.0" />

--- a/Barotrauma/BarotraumaShared/LocalMods/oxygen-changes/OxygenGenerators.xml
+++ b/Barotrauma/BarotraumaShared/LocalMods/oxygen-changes/OxygenGenerators.xml
@@ -17,29 +17,29 @@
       <BrokenSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="0,400,416,384" origin="0.5,0.5" depth="0.8" maxcondition="0" />
       <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="416,400,416,48" depth="0.824" origin="0.5,4.0"
                         offset="0,25" offsetanim="Sine" offsetanimspeed="0.5">
-        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+        <AnimationConditional currFlow="gt 0" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
       <!-- bellow parts from top to bottom -->
       <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="416,480,416,32" depth="0.82" origin="0.5,5.2"
                         offset="0,25" offsetanim="Sine" offsetanimspeed="0.5">
-        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+        <AnimationConditional currFlow="gt 0" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
       <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="416,480,416,32" depth="0.821" origin="0.5,4.7"
                         offset="1,18" offsetanim="Sine" offsetanimspeed="0.5">
-        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+        <AnimationConditional currFlow="gt 0" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
       <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="416,480,416,32" depth="0.822" origin="0.5,4.2"
                         offset="2,10" offsetanim="Sine" offsetanimspeed="0.5">
-        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+        <AnimationConditional currFlow="gt 0" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
       <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="416,480,416,32" depth="0.823" origin="0.5,3.7"
                         offset="1,5" offsetanim="Sine" offsetanimspeed="0.5">
-        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+        <AnimationConditional currFlow="gt 0" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
       <!-- tube -->
       <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="416,656,416,112" depth="0.824" origin="0.5,0.8"
                         offset="0,5" offsetanim="Sine" offsetanimspeed="0.5">
-        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+        <AnimationConditional currFlow="gt 0" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
     <LightComponent range="140.0" lightcolor="255,184,108,193" powerconsumption="5" IsOn="false" castshadows="false" allowingameediting="false" />
 
@@ -118,29 +118,29 @@
 
       <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="610,400,336,48" depth="0.824" origin="0.6,2.4"
                         offset="0,15" offsetanim="Sine" offsetanimspeed="0.5" scale="0.7" rotation="9">
-        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+        <AnimationConditional currFlow="gt 0" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
       <!-- bellows from top to bottom -->
       <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="610,480,336,32" depth="0.82" origin="0.45,2.0"
                         offset="0,15" offsetanim="Sine" offsetanimspeed="0.5"  rotation="9">
-        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+        <AnimationConditional currFlow="gt 0" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
       <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="610,480,336,32" depth="0.821" origin="0.45,1.5"
                         offset="1,12" offsetanim="Sine" offsetanimspeed="0.5" rotation="6">
-        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+        <AnimationConditional currFlow="gt 0" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
       <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="610,480,336,32" depth="0.822" origin="0.45,1.0"
                         offset="2,8" offsetanim="Sine" offsetanimspeed="0.5" rotation="3">
-        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+        <AnimationConditional currFlow="gt 0" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
       <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="610,480,336,32" depth="0.823" origin="0.45,0.5"
                         offset="1,5" offsetanim="Sine" offsetanimspeed="0.5">
-        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+        <AnimationConditional currFlow="gt 0" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
       <!-- tube -->
       <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="610,656,336,112" depth="0.824" origin="0.45,0.3"
                         offset="0,5" offsetanim="Sine" offsetanimspeed="0.5" rotation="345">
-        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+        <AnimationConditional currFlow="gt 0" targetitemcomponent="OxygenGenerator" />
       </DecorativeSprite>
       <!-- background for bottles -->
       <DecorativeSprite texture="Content/Items/OxygenGenerator/oxygengenerator.png" sourcerect="656,564,96,74" depth="0.819" origin="0.07,0.0"

--- a/Barotrauma/BarotraumaShared/LocalMods/oxygen-changes/OxygenGenerators.xml
+++ b/Barotrauma/BarotraumaShared/LocalMods/oxygen-changes/OxygenGenerators.xml
@@ -1,0 +1,254 @@
+<Items>
+  <Override>
+    <Item
+      name=""
+      identifier="oxygenerator"
+      tags="oxygengenerator,oxygentankrefiller"
+      category="Machine"
+      linkable="true"
+      allowedlinks="vent" 
+      damagedbyexplosions="true" 
+      explosiondamagemultiplier="0.2"
+      scale="0.5">
+      <UpgradePreviewSprite scale="2.5" texture="Content/UI/WeaponUI.png" sourcerect="384,960,64,64" origin="0.5,0.45" />
+      <Upgrade gameversion="0.10.0.0" scale="*0.5" />
+      <Sprite texture="oxygengenerator.png" depth="0.8" origin="0.5,0.5" sourcerect="0,0,416,384"/>
+      <BrokenSprite texture="oxygengenerator.png" sourcerect="416,0,416,384" origin="0.5,0.5" depth="0.8" maxcondition="80" fadein="true" />
+      <BrokenSprite texture="oxygengenerator.png" sourcerect="0,400,416,384" origin="0.5,0.5" depth="0.8" maxcondition="0" />
+      <DecorativeSprite texture="oxygengenerator.png" sourcerect="416,400,416,48" depth="0.824" origin="0.5,4.0"
+                        offset="0,25" offsetanim="Sine" offsetanimspeed="0.5">
+        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+      </DecorativeSprite>
+      <!-- bellow parts from top to bottom -->
+      <DecorativeSprite texture="oxygengenerator.png" sourcerect="416,480,416,32" depth="0.82" origin="0.5,5.2"
+                        offset="0,25" offsetanim="Sine" offsetanimspeed="0.5">
+        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+      </DecorativeSprite>
+      <DecorativeSprite texture="oxygengenerator.png" sourcerect="416,480,416,32" depth="0.821" origin="0.5,4.7"
+                        offset="1,18" offsetanim="Sine" offsetanimspeed="0.5">
+        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+      </DecorativeSprite>
+      <DecorativeSprite texture="oxygengenerator.png" sourcerect="416,480,416,32" depth="0.822" origin="0.5,4.2"
+                        offset="2,10" offsetanim="Sine" offsetanimspeed="0.5">
+        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+      </DecorativeSprite>
+      <DecorativeSprite texture="oxygengenerator.png" sourcerect="416,480,416,32" depth="0.823" origin="0.5,3.7"
+                        offset="1,5" offsetanim="Sine" offsetanimspeed="0.5">
+        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+      </DecorativeSprite>
+      <!-- tube -->
+      <DecorativeSprite texture="oxygengenerator.png" sourcerect="416,656,416,112" depth="0.824" origin="0.5,0.8"
+                        offset="0,5" offsetanim="Sine" offsetanimspeed="0.5">
+        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+      </DecorativeSprite>
+    <LightComponent range="140.0" lightcolor="255,184,108,193" powerconsumption="5" IsOn="false" castshadows="false" allowingameediting="false" />
+
+      <OxygenGenerator powerconsumption="1000.0" minvoltage="0.5" canbeselected="true" msg="ItemMsgInteractSelect">
+        <poweronsound file="Content/Items/PowerOnLight2.ogg" range="1500" loop="false" />
+        <sound file="Content/Items/OxygenGenerator/OxygenGenerator.ogg" type="OnActive" range="1000.0" volumeproperty="CurrFlow" volume="0.001" loop="true"/>    
+        <StatusEffect type="OnFire" target="This" Condition="-0.5" tags="onfire" duration="1" stackable="false" />
+        <StatusEffect type="OnBroken" targettype="This" disabledeltatime="true">
+          <sound file="Content/Items/Weapons/ExplosionMedium1.ogg" range="3000" />
+          <sound file="Content/Items/Weapons/ExplosionMedium2.ogg" range="3000" />
+          <sound file="Content/Items/Weapons/ExplosionMedium3.ogg" range="3000" />
+          <Explosion range="50" stun="0" force="3.0" flames="false" shockwave="false" sparks="true" debris="true" underwaterbubble="false"/>
+        </StatusEffect>
+        <StatusEffect type="OnBroken" target="This">
+          <sound file="Content/Items/Weapons/ExplosionDebris3.ogg" range="2000" />
+        </StatusEffect>
+      </OxygenGenerator>
+    
+      <trigger/>
+
+      <ItemContainer capacity="5" maxstacksize="1" canbeselected="true" hideitems="false" itempos="31,-250" iteminterval="44.5,0" msg="ItemMsgOxygenRefill">
+        <Upgrade gameversion="0.15.22.1" itempos="31,-250" iteminterval="44.5,0" />
+        <GuiFrame relativesize="0.25,0.2" anchor="Center" style="ItemUI" />
+        <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
+        <SlotIcon slotindex="1" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
+        <SlotIcon slotindex="2" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
+        <SlotIcon slotindex="3" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
+        <SlotIcon slotindex="4" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
+        <Containable items="oxygensource,weldingfuel" excludebroken="false" excludefullcondition="true">
+          <StatusEffect type="OnContaining" targettype="Contained" Condition="2.0" Comparison="And">
+            <Conditional Voltage="gt 0.1" targetcontainer="true" targetitemcomponent="OxygenGenerator"/>
+            <Conditional HasTag="refillableoxygensource"/>
+            <Conditional targetcontainer="true" HasStatusTag="!eq onfire" />
+          </StatusEffect>
+        </Containable>
+      </ItemContainer>
+      
+      <ConnectionPanel selectkey="Action" canbeselected = "true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+        <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel"/>
+        <RequiredItem items="screwdriver" type="Equipped"/>
+        <input name="power_in" displayname="connection.powerin"/>
+        <output name="condition_out" displayname="connection.conditionout" />
+      </ConnectionPanel>
+
+      <Repairable selectkey="Action" header="mechanicalrepairsheader" deteriorationspeed="0.125" mindeteriorationdelay="120" maxdeteriorationdelay="750" mindeteriorationcondition="0" RepairThreshold="80" fixDurationHighSkill="5" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
+        <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI"/>
+        <RequiredSkill identifier="mechanical" level="55"/>
+        <RequiredItem items="wrench" type="equipped"/>
+        <ParticleEmitter particle="damagebubbles" particlespersecond="2" scalemin="0.5" scalemax="1.5" anglemax="360" velocitymin="-10" velocitymax="10" mincondition="0.0" maxcondition="50.0" />
+        <ParticleEmitter particle="smoke" particlespersecond="2" scalemin="1" scalemax="2.5" anglemax="360" velocitymin="-50" velocitymax="50" mincondition="15.0" maxcondition="50.0" />
+        <ParticleEmitter particle="heavysmoke" particlespersecond="2" scalemin="1.0" scalemax="2.5" anglemax="360" distancemax="60" mincondition="0.0" maxcondition="15.0" />
+        <StatusEffect type="OnFailure" target="Character" targetlimbs="LeftHand,RightHand" AllowWhenBroken="true">
+          <Sound file="Content/Items/MechanicalRepairFail.ogg" range="1000" />
+          <Affliction identifier="lacerations" strength="5" />
+          <Affliction identifier="stun" strength="4" />
+        </StatusEffect>
+      </Repairable>
+    </Item>
+    <Item
+      name=""
+      identifier="shuttleoxygenerator"
+      tags="oxygengenerator,oxygentankrefiller"
+      category="Machine"
+      linkable="true"
+      allowedlinks="vent"
+      scale="0.5">
+      <Upgrade gameversion="0.10.0.0" scale="*0.5" />
+
+      <UpgradePreviewSprite texture="Content/UI/WeaponUI.png" sourcerect="384,960,64,64" origin="0.5,0.45" />
+      <Sprite texture="oxygengenerator.png" depth="0.8" sourcerect="0,784,336,240"/>
+      <BrokenSprite texture="oxygengenerator.png" sourcerect="336,784,336,240" depth="0.8" maxcondition="40" fadein="true" />
+      <BrokenSprite texture="oxygengenerator.png" sourcerect="672,784,336,240" depth="0.8" maxcondition="0" />
+
+      <DecorativeSprite texture="oxygengenerator.png" sourcerect="610,400,336,48" depth="0.824" origin="0.6,2.4"
+                        offset="0,15" offsetanim="Sine" offsetanimspeed="0.5" scale="0.7" rotation="9">
+        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+      </DecorativeSprite>
+      <!-- bellows from top to bottom -->
+      <DecorativeSprite texture="oxygengenerator.png" sourcerect="610,480,336,32" depth="0.82" origin="0.45,2.0"
+                        offset="0,15" offsetanim="Sine" offsetanimspeed="0.5"  rotation="9">
+        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+      </DecorativeSprite>
+      <DecorativeSprite texture="oxygengenerator.png" sourcerect="610,480,336,32" depth="0.821" origin="0.45,1.5"
+                        offset="1,12" offsetanim="Sine" offsetanimspeed="0.5" rotation="6">
+        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+      </DecorativeSprite>
+      <DecorativeSprite texture="oxygengenerator.png" sourcerect="610,480,336,32" depth="0.822" origin="0.45,1.0"
+                        offset="2,8" offsetanim="Sine" offsetanimspeed="0.5" rotation="3">
+        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+      </DecorativeSprite>
+      <DecorativeSprite texture="oxygengenerator.png" sourcerect="610,480,336,32" depth="0.823" origin="0.45,0.5"
+                        offset="1,5" offsetanim="Sine" offsetanimspeed="0.5">
+        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+      </DecorativeSprite>
+      <!-- tube -->
+      <DecorativeSprite texture="oxygengenerator.png" sourcerect="610,656,336,112" depth="0.824" origin="0.45,0.3"
+                        offset="0,5" offsetanim="Sine" offsetanimspeed="0.5" rotation="345">
+        <AnimationConditional Voltage="gt 0.5" targetitemcomponent="OxygenGenerator" />
+      </DecorativeSprite>
+      <!-- background for bottles -->
+      <DecorativeSprite texture="oxygengenerator.png" sourcerect="656,564,96,74" depth="0.819" origin="0.07,0.0"
+                        offset="0,0" />
+
+      <OxygenGenerator powerconsumption="1000.0" minvoltage="0.5" canbeselected = "true" msg="ItemMsgInteractSelect">
+        <poweronsound file="Content/Items/PowerOnLight1.ogg" range="1000" loop="false" />
+        <sound file="Content/Items/OxygenGenerator/OxygenGenerator.ogg" type="OnActive" range="1000.0" volumeproperty="CurrFlow" volume="0.001" loop="true"/>
+        <StatusEffect type="OnFire" target="This" Condition="-0.5" tags="onfire" duration="1" stackable="false" />
+        <StatusEffect type="OnBroken" targettype="This" disabledeltatime="true">
+          <sound file="Content/Items/Weapons/ExplosionMedium1.ogg" range="3000" />
+          <sound file="Content/Items/Weapons/ExplosionMedium2.ogg" range="3000" />
+          <sound file="Content/Items/Weapons/ExplosionMedium3.ogg" range="3000" />
+          <Explosion range="50" stun="0" force="3.0" flames="false" shockwave="false" sparks="true" debris="true" underwaterbubble="false"/>
+        </StatusEffect>
+        <StatusEffect type="OnBroken" target="This">
+          <sound file="Content/Items/Weapons/ExplosionDebris3.ogg" range="2000" />
+        </StatusEffect>
+      </OxygenGenerator>
+
+      <trigger/>
+
+      <ItemContainer capacity="3" maxstacksize="1" canbeselected = "true" hideitems="false" itempos="185,-172" iteminterval="27,0" msg="ItemMsgOxygenRefill" containedspritedepth="0.81">
+        <GuiFrame relativesize="0.25,0.2" anchor="Center" style="ItemUI" />
+        <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
+        <SlotIcon slotindex="1" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
+        <SlotIcon slotindex="2" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
+        <SlotIcon slotindex="3" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
+        <SlotIcon slotindex="4" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
+        <Containable items="oxygensource,weldingfuel" excludebroken="false" excludefullcondition="true">
+          <StatusEffect type="OnContaining" targettype="Contained" Condition="2.0" Comparison="And">
+            <Conditional Voltage="gt 0.1" targetcontainer="true" targetitemcomponent="OxygenGenerator"/>
+            <Conditional HasTag="refillableoxygensource"/>
+            <Conditional targetcontainer="true" HasStatusTag="!eq onfire" />
+          </StatusEffect>
+        </Containable>
+      </ItemContainer>
+
+      <ConnectionPanel selectkey="Action" canbeselected = "true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+        <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel"/>
+        <RequiredSkill identifier="electrical" level="55" />
+        <StatusEffect type="OnFailure" target="Character" targetlimbs="LeftHand,RightHand" AllowWhenBroken="true">
+          <Sound file="Content/Sounds/Damage/Electrocution1.ogg" range="1000" />
+          <Explosion range="100.0" force="1.0" flames="false" shockwave="false" sparks="true" underwaterbubble="false" />
+          <Affliction identifier="stun" strength="4" probability="0.5" />
+          <Affliction identifier="electricshock" strength="60"/>
+          <Affliction identifier="burn" strength="5" />
+          <ParticleEmitter particle="ElectricShock" DistanceMin="10" DistanceMax="25" ParticleAmount="5" ScaleMin="0.1" ScaleMax="0.12" />
+        </StatusEffect>
+        <RequiredItem items="screwdriver" type="Equipped"/>
+        <input name="power_in" displayname="connection.powerin"/>
+        <output name="condition_out" displayname="connection.conditionout" />
+      </ConnectionPanel>
+
+      <Repairable selectkey="Action" header="mechanicalrepairsheader" deteriorationspeed="0.125" mindeteriorationdelay="120" maxdeteriorationdelay="750" mindeteriorationcondition="0" RepairThreshold="80" fixDurationHighSkill="5" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
+        <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI"/>
+        <RequiredSkill identifier="mechanical" level="55"/>
+        <RequiredItem items="wrench" type="equipped"/>
+        <ParticleEmitter particle="spark" particleamount="10" emitinterval="5" anglemax="360" velocitymin="5.0" velocitymax="250.0" scalemin="0.5" scalemax="1" mincondition="0.0" maxcondition="25.0"/>
+        <ParticleEmitter particle="fleshsmoke" particlespersecond="2" scalemin="1" scalemax="3" mincondition="0.0" maxcondition="1.0"/>
+        <StatusEffect type="OnFailure" target="Character" targetlimbs="LeftHand,RightHand" AllowWhenBroken="true">
+          <Sound file="Content/Items/MechanicalRepairFail.ogg" range="1000" />
+          <Affliction identifier="lacerations" strength="5" />
+          <Affliction identifier="stun" strength="4" />
+        </StatusEffect>
+      </Repairable>
+    </Item>
+    <Item name="" nameidentifier="oxygenerator" identifier="outpostoxygenerator" tags="oxygengenerator" category="Machine" linkable="true" allowedlinks="vent" damagedbyexplosions="true" scale="0.5" explosiondamagemultiplier="0.2">
+      <Sprite texture="Content/Map/Outposts/Art/GenericAssets2.png" depth="0.8" sourcerect="52,1197,360,410" origin="0.5,0.5" />
+      <BrokenSprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="2,1607,240,302" depth="0.79" origin="0.5,0.5" offset="100,0" maxcondition="80" fadein="true" />
+      <BrokenSprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="243,1629,213,286" depth="0.79" origin="0.5,0.5" offset="100,0" maxcondition="10" fadein="true" />
+      <UpgradePreviewSprite scale="2.5" texture="Content/UI/WeaponUI.png" sourcerect="384,960,64,64" origin="0.5,0.45" />
+      <OxygenGenerator powerconsumption="1000.0" minvoltage="0.5" generatedamount="5000" canbeselected="true" msg="ItemMsgInteractSelect">
+        <poweronsound file="Content/Items/PowerOnLight2.ogg" range="1500" loop="false" />
+        <sound file="Content/Items/OxygenGenerator/OxygenGenerator.ogg" type="OnActive" range="1000.0" volumeproperty="CurrFlow" volume="0.001" loop="true" />
+        <StatusEffect type="OnFire" target="This" Condition="-0.5" />
+        <StatusEffect type="OnActive" targettype="Contained" targets="oxygentank" Condition="2.0" />
+        <StatusEffect type="OnBroken" targettype="This" disabledeltatime="true">
+          <sound file="Content/Items/Weapons/ExplosionMedium1.ogg" range="3000" />
+          <sound file="Content/Items/Weapons/ExplosionMedium2.ogg" range="3000" />
+          <sound file="Content/Items/Weapons/ExplosionMedium3.ogg" range="3000" />
+          <Explosion range="50" stun="0" force="3.0" flames="false" shockwave="false" sparks="true" debris="true" underwaterbubble="false" />
+        </StatusEffect>
+        <StatusEffect type="OnBroken" target="This">
+          <sound file="Content/Items/Weapons/ExplosionDebris3.ogg" range="2000" />
+        </StatusEffect>
+      </OxygenGenerator>
+      <trigger />
+      <ItemContainer capacity="5" maxstacksize="1" canbeselected="true" hideitems="false" itempos="163,-290" iteminterval="42,0" msg="ItemMsgOxygenRefill">
+        <GuiFrame relativesize="0.25,0.2" anchor="Center" style="ItemUI" />
+        <Containable items="oxygentank" />
+      </ItemContainer>
+      <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+        <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+        <RequiredItem items="screwdriver" type="Equipped" />
+        <input name="power_in" displayname="connection.powerin" />
+        <output name="condition_out" displayname="connection.conditionout" />
+      </ConnectionPanel>
+      <Repairable selectkey="Action" header="mechanicalrepairsheader" deteriorationspeed="0.125" mindeteriorationdelay="120" maxdeteriorationdelay="750" mindeteriorationcondition="0" AIRepairThreshold="50" fixDurationHighSkill="5" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
+        <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI" />
+        <RequiredSkill identifier="mechanical" level="55" />
+        <RequiredItem items="wrench" type="equipped" />
+        <ParticleEmitter particle="damagebubbles" particlespersecond="2" scalemin="0.5" scalemax="1.5" anglemax="360" velocitymin="-10" velocitymax="10" mincondition="0.0" maxcondition="50.0" />
+        <ParticleEmitter particle="smoke" particlespersecond="2" scalemin="1" scalemax="2.5" anglemax="360" velocitymin="-50" velocitymax="50" mincondition="15.0" maxcondition="50.0" />
+        <ParticleEmitter particle="heavysmoke" particlespersecond="2" scalemin="1.0" scalemax="2.5" anglemax="360" distancemax="60" maxcondition="15.0" />
+        <StatusEffect type="OnFailure" target="Character" targetlimbs="LeftHand,RightHand" AllowWhenBroken="true">
+          <Sound file="Content/Items/MechanicalRepairFail.ogg" range="1000" />
+          <Affliction identifier="lacerations" strength="5" />
+          <Affliction identifier="stun" strength="4" />
+        </StatusEffect>
+      </Repairable>
+    </Item>
+  </Override>
+</Items>

--- a/Barotrauma/BarotraumaShared/LocalMods/oxygen-changes/Upgrades.xml
+++ b/Barotrauma/BarotraumaShared/LocalMods/oxygen-changes/Upgrades.xml
@@ -5,7 +5,7 @@
     <ResourceCost item="oxygeniteshard" amount="5" levels="1-2"/>
     <MaxLevel tier="1" level="0"/>
     <MaxLevel tier="2" level="1"/>
-    <OxygenGenerator generatedamount="+20%"/>
+    <OxygenGenerator generatedamount="+20%" ratewarningindicatorlow="-20%" ratewarningindicatorextremelylow="-20%"/>
     <Sprite texture="Content/UI/CampaignUIAtlas2.png" sourcerect="768,768,128,128"/>
   </UpgradeModule>
 </UpgradeModules>

--- a/Barotrauma/BarotraumaShared/LocalMods/oxygen-changes/Upgrades.xml
+++ b/Barotrauma/BarotraumaShared/LocalMods/oxygen-changes/Upgrades.xml
@@ -1,11 +1,11 @@
 <UpgradeModules>
   <UpgradeCategory identifier="oxygengenerators" items="oxygengenerator"/>
-  <UpgradeModule identifier="increaseoxygengeneration" maxlevel="2" categories="oxygengenerators" increaseontooltip="25">
+  <UpgradeModule identifier="increaseoxygengeneration" maxlevel="2" categories="oxygengenerators" increaseontooltip="20">
     <Price baseprice="2000" increaselow="+0%" increasehigh="+200%"/>
     <ResourceCost item="oxygeniteshard" amount="5" levels="1-2"/>
     <MaxLevel tier="1" level="0"/>
     <MaxLevel tier="2" level="1"/>
-    <OxygenGenerator generatedamount="+25%" powerconsumption="-5%"/>
+    <OxygenGenerator generatedamount="+20%"/>
     <Sprite texture="Content/UI/CampaignUIAtlas2.png" sourcerect="768,768,128,128"/>
   </UpgradeModule>
 </UpgradeModules>

--- a/Barotrauma/BarotraumaShared/LocalMods/oxygen-changes/Upgrades.xml
+++ b/Barotrauma/BarotraumaShared/LocalMods/oxygen-changes/Upgrades.xml
@@ -5,7 +5,7 @@
     <ResourceCost item="oxygeniteshard" amount="5" levels="1-2"/>
     <MaxLevel tier="1" level="0"/>
     <MaxLevel tier="2" level="1"/>
-    <OxygenGenerator generatedamount="+20%" ratewarningindicatorlow="-20%" ratewarningindicatorextremelylow="-20%"/>
+    <OxygenGenerator generatedamount="+20%"/>
     <Sprite texture="Content/UI/CampaignUIAtlas2.png" sourcerect="768,768,128,128"/>
   </UpgradeModule>
 </UpgradeModules>

--- a/Barotrauma/BarotraumaShared/LocalMods/oxygen-changes/Upgrades.xml
+++ b/Barotrauma/BarotraumaShared/LocalMods/oxygen-changes/Upgrades.xml
@@ -1,0 +1,11 @@
+<UpgradeModules>
+  <UpgradeCategory identifier="oxygengenerators" items="oxygengenerator"/>
+  <UpgradeModule identifier="increaseoxygengeneration" maxlevel="2" categories="oxygengenerators" increaseontooltip="25">
+    <Price baseprice="2000" increaselow="+0%" increasehigh="+200%"/>
+    <ResourceCost item="oxygeniteshard" amount="5" levels="1-2"/>
+    <MaxLevel tier="1" level="0"/>
+    <MaxLevel tier="2" level="1"/>
+    <OxygenGenerator generatedamount="+25%" powerconsumption="-5%"/>
+    <Sprite texture="Content/UI/CampaignUIAtlas2.png" sourcerect="768,768,128,128"/>
+  </UpgradeModule>
+</UpgradeModules>

--- a/Barotrauma/BarotraumaShared/LocalMods/oxygen-changes/filelist.xml
+++ b/Barotrauma/BarotraumaShared/LocalMods/oxygen-changes/filelist.xml
@@ -1,0 +1,5 @@
+<ContentPackage name="oxygen-changes" modversion="1.0.0" gameversion="1.0.8.0">
+  <Text file="%ModDir%/Locale/English.xml"/>
+  <Item file="%ModDir%/OxygenGenerators.xml"/>
+  <UpgradeModules file="%ModDir%/Upgrades.xml"/>
+</ContentPackage>

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/OxygenGenerator.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/OxygenGenerator.cs
@@ -9,8 +9,8 @@ namespace Barotrauma.Items.Components
 {
     internal partial class OxygenGenerator : Powered
     {
-        private const int GenerationRatioStepInt = 10;
-        private const float GenerationRatioStepFloat = GenerationRatioStepInt / 100f;
+        private const int GenerationRatioSteps = 10;
+        private const float GenerationRatioStep = 1f / GenerationRatioSteps;
         
         private float generatedAmount;
         private float generationRatio;
@@ -46,7 +46,7 @@ namespace Barotrauma.Items.Components
             set
             {
                 if (!MathUtils.IsValid(value)) { return; }
-                generationRatio = MathUtils.RoundTowardsClosest(MathHelper.Clamp(value, 0f, 1f), GenerationRatioStepFloat);
+                generationRatio = MathUtils.RoundTowardsClosest(MathHelper.Clamp(value, 0f, 1f), GenerationRatioStep);
 #if CLIENT
                 UpdateSlider();
 #endif
@@ -195,8 +195,8 @@ namespace Barotrauma.Items.Components
         }
         
         #region Networking
-        private static float ReadGenerationRatio(IReadMessage msg) => msg.ReadRangedInteger(0, GenerationRatioStepInt) / (float)GenerationRatioStepInt;
-        private void WriteGenerationRatio(IWriteMessage msg) => msg.WriteRangedInteger(MathUtils.RoundToInt(generationRatio * GenerationRatioStepInt), 0, GenerationRatioStepInt);
+        private static float ReadGenerationRatio(IReadMessage msg) => msg.ReadRangedInteger(0, GenerationRatioSteps) * GenerationRatioStep;
+        private void WriteGenerationRatio(IWriteMessage msg) => msg.WriteRangedInteger(MathUtils.RoundToInt(generationRatio / GenerationRatioStep), 0, GenerationRatioSteps);
         #endregion
     }
 }

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/OxygenGenerator.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Machines/OxygenGenerator.cs
@@ -25,6 +25,7 @@ namespace Barotrauma.Items.Components
 
         private float controlLockTimer;
         
+        [Serialize(0f, IsPropertySaveable.No, "The current adjusted oxygen output of the generator. Setting this value in XML has no effect.")]
         public float CurrFlow
         {
             get;


### PR DESCRIPTION
This PR makes changes to oxygen generators that I believe will enhance the interactions available with them.

The first change adds the ability for players to find and change the oxygen generation rate either manually, or through wiring.

The second change adds a UI to oxygen generators that allows players to:
1. See if it is powered.
2. Manually change the oxygen generation rate.
3. See if the generation rate is being controlled through wiring.

The third change adds a new upgrade for oxygen generators that increases the oxygen generation rate.
This upgrade has a base cost of 2000 mk and 5 oxygenite shards, with tier restrictions of:
- Tier 1: Unavailable
- Tier 2: Level 1
- Tier 3: Level 2

Each level of this upgrade increases oxygen generation by 20%.

The intended effect of these changes is to add more depth to the mechanics of oxygen generators, with the end goal of getting players to engage with them beyond it just being a repairable device that fills oxygen tanks.

For example, traitors can set the generation amount to a lower value to silently starve the crew of oxygen.
Another example is players can create more complex "duty cycle" circuts to save fuel by dynamically changing the generation amount through wiring, therefore reducing the power consumption.