### PR TITLE
Custom Submarine Classes

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/GUI/SubmarineSelection.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GUI/SubmarineSelection.cs
@@ -383,8 +383,8 @@ namespace Barotrauma
 
                     submarineDisplays[i].submarineName.Text = subToDisplay.DisplayName;                    
                     
-                    submarineDisplays[i].submarineClass.Text = TextManager.GetWithVariable("submarineclass.classsuffixformat", "[type]", TextManager.Get($"submarineclass.{subToDisplay.SubmarineClass}"));
-                    submarineDisplays[i].submarineClass.ToolTip = TextManager.Get("submarineclass.description") + "\n\n" + TextManager.Get($"submarineclass.{subToDisplay.SubmarineClass}.description"); 
+                    submarineDisplays[i].submarineClass.Text = TextManager.GetWithVariable("submarineclass.classsuffixformat", "[type]", subToDisplay.Class.Name);
+                    submarineDisplays[i].submarineClass.ToolTip = TextManager.Get("submarineclass.description") + "\n\n" + subToDisplay.Class.Description; 
 
                     submarineDisplays[i].submarineTier.Text = TextManager.Get($"submarinetier.{subToDisplay.Tier}");
                     submarineDisplays[i].submarineTier.ToolTip = TextManager.Get("submarinetier.description");

--- a/Barotrauma/BarotraumaClient/ClientSource/GUI/TabMenu.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GUI/TabMenu.cs
@@ -1769,7 +1769,7 @@ namespace Barotrauma
 
             LocalizedString className = !sub.Info.HasTag(SubmarineTag.Shuttle) ?
                 TextManager.GetWithVariables("submarine.classandtier", 
-                    ("[class]", TextManager.Get($"submarineclass.{sub.Info.SubmarineClass}")),
+                    ("[class]", sub.Info.Class.Name),
                     ("[tier]", TextManager.Get($"submarinetier.{sub.Info.Tier}"))) :
                 TextManager.Get("shuttle");
 

--- a/Barotrauma/BarotraumaClient/ClientSource/GUI/UpgradeStore.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GUI/UpgradeStore.cs
@@ -1518,11 +1518,11 @@ namespace Barotrauma
             // submarine name
             new GUITextBlock(rectT(1, 0, submarineInfoFrame), submarine.Info.DisplayName, textAlignment: Alignment.Right, font: GUIStyle.LargeFont);
 
-            LocalizedString classText = $"{TextManager.GetWithVariable("submarineclass.classsuffixformat", "[type]", TextManager.Get($"submarineclass.{submarine.Info.SubmarineClass}"))}";
+            LocalizedString classText = $"{TextManager.GetWithVariable("submarineclass.classsuffixformat", "[type]", submarine.Info.Class.Name)}";
             // submarine class + tier
             new GUITextBlock(rectT(1.0f, 0.15f, submarineInfoFrame), classText, textAlignment: Alignment.Right, font: GUIStyle.Font)
             {
-                ToolTip = TextManager.Get("submarineclass.description") + "\n\n" + TextManager.Get($"submarineclass.{submarine.Info.SubmarineClass}.description")
+                ToolTip = TextManager.Get("submarineclass.description") + "\n\n" + submarine.Info.Class.Description
             };
             new GUITextBlock(rectT(1.0f, 0.15f, submarineInfoFrame), TextManager.Get($"submarinetier.{submarine.Info.Tier}"), textAlignment: Alignment.Right, font: GUIStyle.Font)
             {

--- a/Barotrauma/BarotraumaClient/ClientSource/Map/Map/Map.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Map/Map/Map.cs
@@ -396,9 +396,8 @@ namespace Barotrauma
             if (location.CanHaveSubsForSale())
             {
                 overrideTiers = new List<(SubmarineClass subClass, int tier)>();
-                foreach (SubmarineClass subClass in Enum.GetValues(typeof(SubmarineClass)))
+                foreach (SubmarineClass subClass in SubmarineClass.Classes)
                 {
-                    if (subClass == SubmarineClass.Undefined) { continue; }
                     int highestClassTier = location.HighestSubmarineTierAvailable(subClass);
                     if (highestClassTier > 0 && highestClassTier > highestSubTier)
                     {
@@ -414,7 +413,8 @@ namespace Barotrauma
             {
                 foreach (var (subClass, tier) in overrideTiers)
                 {
-                    CreateTextWithIcon(TextManager.GetWithVariable($"advancedsub.{subClass}", "[tiernumber]", tier.ToString()), icon: null, style: "LocationOverlaySubmarineIcon");
+                    string textTag = $"advancedsub.{subClass.TextIdentifier.IfEmpty(in subClass.Identifier)}";
+                    CreateTextWithIcon(TextManager.GetWithVariable(textTag, "[tiernumber]", tier.ToString()), icon: subClass.AvailabilityIcon, style: "LocationOverlaySubmarineIcon");
                 }
             }
 
@@ -428,8 +428,8 @@ namespace Barotrauma
                     CanBeFocused = true
                 };
                 var guiIcon =
-                    style == null ? 
-                    new GUIImage(new RectTransform(Vector2.One * 1.25f, textHolder.RectTransform, scaleBasis: ScaleBasis.BothHeight), icon) :
+                    icon != null ? 
+                    new GUIImage(new RectTransform(Vector2.One * 1.25f, textHolder.RectTransform, scaleBasis: ScaleBasis.BothHeight), icon, scaleToFit: true) { Color = icon.Color } :
                     new GUIImage(new RectTransform(Vector2.One * 1.25f, textHolder.RectTransform, scaleBasis: ScaleBasis.BothHeight), style);
                 var textBlock = new GUITextBlock(new RectTransform(new Vector2(0.9f, 1.0f), textHolder.RectTransform), text);
                 textBlock.RectTransform.MinSize = new Point((int)textBlock.TextSize.X, 0);

--- a/Barotrauma/BarotraumaClient/ClientSource/Map/SubmarineInfo.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Map/SubmarineInfo.cs
@@ -99,7 +99,7 @@ namespace Barotrauma
             float rightPanelWidth = 0.4f / leftPanelWidth;
             LocalizedString className = !HasTag(SubmarineTag.Shuttle) ?
                 TextManager.GetWithVariables("submarine.classandtier",
-                    ("[class]", TextManager.Get($"submarineclass.{SubmarineClass}")),
+                    ("[class]", Class.Name),
                     ("[tier]", TextManager.Get($"submarinetier.{Tier}"))) :
                 TextManager.Get("shuttle");
 
@@ -121,7 +121,7 @@ namespace Barotrauma
             {
                 submarineClassText = new GUITextBlock(new RectTransform(new Point(leftPanelWidthInt, classHeight), parent.Content.RectTransform), className, textAlignment: Alignment.CenterLeft, font: GUIStyle.SubHeadingFont)
                 {
-                    ToolTip = TextManager.Get("submarinetierandclass.description")+"\n\n"+ TextManager.Get($"submarineclass.{SubmarineClass}.description")
+                    ToolTip = TextManager.Get("submarinetierandclass.description")+"\n\n"+ Class.Description
                 };
                 submarineClassText.HoverColor = Color.Transparent;
                 submarineClassText.RectTransform.MinSize = new Point(0, (int)submarineClassText.TextSize.Y);

--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/GameClient.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/GameClient.cs
@@ -1886,7 +1886,7 @@ namespace Barotrauma.Networking
             {
                 string subName = inc.ReadString();
                 string subHash = inc.ReadString();
-                SubmarineClass subClass = (SubmarineClass)inc.ReadByte();
+                Identifier subClass = inc.ReadIdentifier();
                 bool isShuttle = inc.ReadBoolean();
                 bool requiredContentPackagesInstalled = inc.ReadBoolean();
 
@@ -1895,7 +1895,7 @@ namespace Barotrauma.Networking
                 {
                     matchingSub = new SubmarineInfo(Path.Combine(SaveUtil.SubmarineDownloadFolder, subName) + ".sub", subHash, tryLoad: false)
                     {
-                        SubmarineClass = subClass
+                        Class = SubmarineClass.Find(subClass)
                     };
                     if (isShuttle) { matchingSub.AddTag(SubmarineTag.Shuttle); }
                 }
@@ -2617,7 +2617,7 @@ namespace Barotrauma.Networking
                         }
                         if (subElement.FindChild("classtext", recursive: true) is GUITextBlock classTextBlock)
                         {
-                            classTextBlock.Text = TextManager.Get($"submarineclass.{newSub.SubmarineClass}");
+                            classTextBlock.Text = newSub.Class.Name;
                             classTextBlock.TextColor = new Color(classTextBlock.TextColor, 0.8f);
                         }
                         if (subElement.FindChild("pricetext", recursive: true) is GUITextBlock priceTextBlock)

--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/CampaignSetupUI/MultiPlayerCampaignSetupUI.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/CampaignSetupUI/MultiPlayerCampaignSetupUI.cs
@@ -107,7 +107,7 @@ namespace Barotrauma
             if (GameMain.NetLobbyScreen.SelectedSub == null) { return false; }
             selectedSub = GameMain.NetLobbyScreen.SelectedSub;
 
-            if (selectedSub.SubmarineClass == SubmarineClass.Undefined)
+            if (selectedSub.Class == SubmarineClass.Undefined)
             {
                 new GUIMessageBox(TextManager.Get("error"), TextManager.Get("undefinedsubmarineselected"));
                 return false;

--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/CampaignSetupUI/SinglePlayerCampaignSetupUI.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/CampaignSetupUI/SinglePlayerCampaignSetupUI.cs
@@ -396,7 +396,7 @@ namespace Barotrauma
             if (subList.SelectedData is not SubmarineInfo) { return false; }
             selectedSub = subList.SelectedData as SubmarineInfo;
             
-            if (selectedSub.SubmarineClass == SubmarineClass.Undefined)
+            if (selectedSub.Class == SubmarineClass.Undefined)
             {
                 new GUIMessageBox(TextManager.Get("error"), TextManager.Get("undefinedsubmarineselected"));
                 return false;
@@ -549,7 +549,7 @@ namespace Barotrauma
                     ToolTip = textBlock.ToolTip
                 };
                 new GUITextBlock(new RectTransform(new Vector2(1.0f, 0.5f), infoContainer.RectTransform),
-                    TextManager.Get($"submarineclass.{sub.SubmarineClass}"), textAlignment: Alignment.TopRight, font: GUIStyle.SmallFont)
+                    sub.Class.Name, textAlignment: Alignment.TopRight, font: GUIStyle.SmallFont)
                 {
                     TextColor = textBlock.TextColor * 0.8f,
                     ToolTip = textBlock.ToolTip

--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/GameScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/GameScreen.cs
@@ -177,7 +177,7 @@ namespace Barotrauma
                 Vector2 position = Submarine.MainSubs[i].SubBody != null ? Submarine.MainSubs[i].WorldPosition : Submarine.MainSubs[i].HiddenSubPosition;
                 
                 Color indicatorColor = i == 0 ? Color.LightBlue * 0.5f : GUIStyle.Red * 0.5f;
-                Sprite displaySprite = Submarine.MainSubs[i].Info.HasTag(SubmarineTag.Shuttle) ? shuttleSprite : subLocationSprite;
+                Sprite displaySprite = Submarine.MainSubs[i].Info.HasTag(SubmarineTag.Shuttle) ? shuttleSprite : Submarine.MainSubs[i].Info.Class.LocationIndicator ?? subLocationSprite;
                 if (displaySprite != null)
                 {
                     GUI.DrawIndicator(
@@ -234,11 +234,10 @@ namespace Barotrauma
                     SubmarineType.Wreck => wreckSprite,
                     SubmarineType.BeaconStation => beaconSprite,
                     SubmarineType.Ruin => ruinSprite,
-                    _ => subLocationSprite
+                    _ => submarine.Info.Class?.LocationIndicator ?? subLocationSprite
                 };
-                
-                // use a little dimmer color for transports
-                if (submarine.Info.SubmarineClass == SubmarineClass.Transport) { indicatorColor *= 0.75f; }
+
+                indicatorColor *= displaySprite.Color.A / 255f;
                 
                 if (displaySprite != null)
                 {

--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/NetLobbyScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/NetLobbyScreen.cs
@@ -3147,7 +3147,7 @@ namespace Barotrauma
                     CanBeFocused = false
                 };
                 new GUITextBlock(new RectTransform(new Vector2(1.0f, 0.5f), infoContainer.RectTransform),
-                    TextManager.Get($"submarineclass.{sub.SubmarineClass}"), textAlignment: Alignment.TopRight, font: GUIStyle.SmallFont)
+                    sub.Class.Name, textAlignment: Alignment.TopRight, font: GUIStyle.SmallFont)
                 {
                     Padding = Vector4.Zero,
                     UserData = "classtext",

--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/SubEditorScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/SubEditorScreen.cs
@@ -1824,7 +1824,7 @@ namespace Barotrauma
                     MainSub.Info.PreviewImage = null;
                 }
             }
-            else if (MainSub.Info.SubmarineClass == SubmarineClass.Undefined && !MainSub.Info.HasTag(SubmarineTag.Shuttle))
+            else if (MainSub.Info.Class == SubmarineClass.Undefined && !MainSub.Info.HasTag(SubmarineTag.Shuttle))
             {
                 var msgBox = new GUIMessageBox(TextManager.Get("warning"), TextManager.Get("undefinedsubmarineclasswarning"), new LocalizedString[] { TextManager.Get("yes"), TextManager.Get("no") });
 
@@ -2726,9 +2726,9 @@ namespace Barotrauma
             };
             GUIDropDown classDropDown = new GUIDropDown(new RectTransform(new Vector2(0.4f, 1.0f), classGroup.RectTransform));
             classDropDown.RectTransform.MinSize = new Point(0, subTypeContainer.RectTransform.Children.Max(c => c.MinSize.Y));
-            foreach (SubmarineClass subClass in Enum.GetValues(typeof(SubmarineClass)))
+            foreach (SubmarineClass subClass in SubmarineClass.Classes)
             {
-                classDropDown.AddItem(TextManager.Get($"{nameof(SubmarineClass)}.{subClass}"), subClass, toolTip: TextManager.Get($"submarineclass.{subClass}.description"));
+                classDropDown.AddItem(subClass.Name, subClass, toolTip: subClass.Description);
             }
             classDropDown.AddItem(TextManager.Get(nameof(SubmarineTag.Shuttle)), SubmarineTag.Shuttle);
             classDropDown.OnSelected += (selected, userdata) =>
@@ -2737,16 +2737,17 @@ namespace Barotrauma
                 {
                     case SubmarineClass submarineClass:
                         MainSub.Info.RemoveTag(SubmarineTag.Shuttle);
-                        MainSub.Info.SubmarineClass = submarineClass;
+                        MainSub.Info.Class = submarineClass;
                         break;
                     case SubmarineTag.Shuttle:
                         MainSub.Info.AddTag(SubmarineTag.Shuttle);
-                        MainSub.Info.SubmarineClass = SubmarineClass.Undefined;
+                        MainSub.Info.Class = SubmarineClass.Undefined;
                         break;
                 }
                 return true;
             };
-            classDropDown.SelectItem(!MainSub.Info.HasTag(SubmarineTag.Shuttle) ? MainSub.Info.SubmarineClass : (object)SubmarineTag.Shuttle);
+            classDropDown.ListBox.Content.FindChild(SubmarineClass.Undefined).SetAsFirstChild();
+            classDropDown.SelectItem(!MainSub.Info.HasTag(SubmarineTag.Shuttle) ? MainSub.Info.Class : (object)SubmarineTag.Shuttle);
 
             var tierGroup = new GUILayoutGroup(new RectTransform(new Vector2(1.0f, 0.05f), subSettingsContainer.RectTransform), isHorizontal: true)
             {
@@ -3590,7 +3591,7 @@ namespace Barotrauma
                 else if (sub.IsPlayer)
                 {
                     var classText = new GUITextBlock(new RectTransform(new Vector2(0.2f, 1.0f), textBlock.RectTransform, Anchor.CenterRight),
-                    TextManager.Get($"submarineclass.{sub.SubmarineClass}"), textAlignment: Alignment.CenterRight, font: GUIStyle.SmallFont)
+                    sub.Class.Name, textAlignment: Alignment.CenterRight, font: GUIStyle.SmallFont)
                     {
                         TextColor = textBlock.TextColor * 0.8f,
                         ToolTip = textBlock.ToolTip.SanitizedString

--- a/Barotrauma/BarotraumaClient/ClientSource/Upgrades/UpgradePrefab.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Upgrades/UpgradePrefab.cs
@@ -2,6 +2,11 @@
 
 namespace Barotrauma
 {
+    internal partial class SubmarineClass
+    {
+        public readonly Sprite LocationIndicator, AvailabilityIcon;
+    }
+    
     sealed partial class UpgradePrefab
     {
         public readonly ImmutableArray<DecorativeSprite> DecorativeSprites = new ImmutableArray<DecorativeSprite>();

--- a/Barotrauma/BarotraumaClient/WindowsClient.csproj
+++ b/Barotrauma/BarotraumaClient/WindowsClient.csproj
@@ -64,6 +64,15 @@
 
   <ItemGroup Condition="'$(Configuration)'!='Debug'">
     <Content Include="..\BarotraumaShared\**\*" CopyToOutputDirectory="PreserveNewest" Exclude="..\BarotraumaShared\Data\Saves\*.save;..\BarotraumaShared\ModLists\*.xml;..\BarotraumaShared\LocalMods\[DebugOnlyTest]*\**" />
+    <Content Update="..\BarotraumaShared\LocalMods\more-sub-classes\filelist.xml">
+      <Link>LocalMods\more-sub-classes\filelist.xml</Link>
+    </Content>
+    <Content Update="..\BarotraumaShared\LocalMods\more-sub-classes\UpgradeModules.xml">
+      <Link>LocalMods\more-sub-classes\UpgradeModules.xml</Link>
+    </Content>
+    <Content Update="..\BarotraumaShared\LocalMods\more-sub-classes\UpgradeModules.xml">
+      <Link>LocalMods\more-sub-classes\UpgradeModules.xml</Link>
+    </Content>
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'=='Debug'">
     <Content Include="..\BarotraumaShared\**\*" CopyToOutputDirectory="PreserveNewest" />

--- a/Barotrauma/BarotraumaServer/ServerSource/Networking/GameServer.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Networking/GameServer.cs
@@ -1937,7 +1937,7 @@ namespace Barotrauma.Networking
                 var sub = subList[i];
                 outmsg.WriteString(sub.Name);
                 outmsg.WriteString(sub.MD5Hash.ToString());
-                outmsg.WriteByte((byte)sub.SubmarineClass);
+                outmsg.WriteIdentifier(sub.Class.Identifier);
                 outmsg.WriteBoolean(sub.HasTag(SubmarineTag.Shuttle));
                 outmsg.WriteBoolean(sub.RequiredContentPackagesInstalled);
             }

--- a/Barotrauma/BarotraumaShared/LocalMods/custom-sub-classes/UpgradeModules.xml
+++ b/Barotrauma/BarotraumaShared/LocalMods/custom-sub-classes/UpgradeModules.xml
@@ -1,0 +1,17 @@
+<UpgradeModules>
+  <SubmarineClass identifier="undefined" purchasable="false">
+    <LocationIndicator texture="Content/UI/UIPositionIndicators.png" sourcerect="0,0,128,128"/>
+  </SubmarineClass>
+  <SubmarineClass identifier="scout" altidentifier="deepdiver">
+    <LocationIndicator texture="Content/UI/UIPositionIndicators.png" sourcerect="0,0,128,128"/>
+    <AvailabilityIcon texture="Content/Map/MapAtlas.png" sourcerect="124,798,48,28" color="gui.blue"/>
+  </SubmarineClass>
+  <SubmarineClass identifier="attack">
+    <LocationIndicator texture="Content/UI/UIPositionIndicators.png" sourcerect="0,0,128,128"/>
+    <AvailabilityIcon texture="Content/Map/MapAtlas.png" sourcerect="124,798,48,28" color="gui.red"/>
+  </SubmarineClass>
+  <SubmarineClass identifier="transport">
+    <LocationIndicator texture="Content/UI/UIPositionIndicators.png" sourcerect="0,0,128,128" color="255,255,255,191"/>
+    <AvailabilityIcon texture="Content/Map/MapAtlas.png" sourcerect="124,798,48,28" color="gui.orange"/>
+  </SubmarineClass>
+</UpgradeModules>

--- a/Barotrauma/BarotraumaShared/LocalMods/custom-sub-classes/filelist.xml
+++ b/Barotrauma/BarotraumaShared/LocalMods/custom-sub-classes/filelist.xml
@@ -1,0 +1,3 @@
+<contentpackage name="custom-sub-classes" corepackage="False" modversion="1.0.0" gameversion="1.7.7.0">
+  <UpgradeModules file="%ModDir%/UpgradeModules.xml"/>
+</contentpackage>

--- a/Barotrauma/BarotraumaShared/SharedSource/ContentManagement/ContentFile/UpgradeModulesFile.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/ContentManagement/ContentFile/UpgradeModulesFile.cs
@@ -9,18 +9,23 @@ namespace Barotrauma
 
         protected override bool MatchesSingular(Identifier identifier) =>
             identifier == "upgrademodule" ||
+            identifier == "submarineclass" ||
             identifier == "upgradecategory";
 
         protected override bool MatchesPlural(Identifier identifier) =>
             identifier == "upgrademodules";
 
-        protected override PrefabCollection<UpgradeContentPrefab> Prefabs => UpgradeContentPrefab.PrefabsAndCategories;
+        protected override PrefabCollection<UpgradeContentPrefab> Prefabs => UpgradeContentPrefab.AllPrefabs;
         protected override UpgradeContentPrefab CreatePrefab(ContentXElement element)
         {
             Identifier elemName = element.NameAsIdentifier();
             if (elemName == "upgradecategory")
             {
                 return new UpgradeCategory(element, this);
+            }
+            else if (elemName == "submarineclass")
+            {
+                return new SubmarineClass(element, this);
             }
             else
             {

--- a/Barotrauma/BarotraumaShared/SharedSource/Map/LinkedSubmarine.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Map/LinkedSubmarine.cs
@@ -280,7 +280,7 @@ namespace Barotrauma
 
             IdRemap parentRemap = new IdRemap(Submarine.Info.SubmarineElement, Submarine.IdOffset);
             sub = Submarine.Load(info, false, parentRemap);
-            sub.Info.SubmarineClass = Submarine.Info.SubmarineClass;
+            sub.Info.Class = Submarine.Info.Class;
             if (Submarine.Info.IsOutpost && Submarine.TeamID == CharacterTeamType.FriendlyNPC)
             {
                 sub.TeamID = CharacterTeamType.FriendlyNPC;

--- a/Barotrauma/BarotraumaShared/SharedSource/Map/Map/Location.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Map/Map/Location.cs
@@ -1520,7 +1520,7 @@ namespace Barotrauma
             return HasOutpost() && CanHaveCampaignInteraction(CampaignMode.InteractionType.PurchaseSub);
         }
 
-        public int HighestSubmarineTierAvailable(SubmarineClass submarineClass = SubmarineClass.Undefined)
+        public int HighestSubmarineTierAvailable(SubmarineClass submarineClass = null)
         {
             if (CanHaveSubsForSale())
             {

--- a/Barotrauma/BarotraumaShared/SharedSource/Map/Submarine.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Map/Submarine.cs
@@ -1913,7 +1913,7 @@ namespace Barotrauma
             element.Add(new XAttribute("ismanuallyoutfitted", Info.IsManuallyOutfitted));
             if (Info.IsPlayer && !Info.HasTag(SubmarineTag.Shuttle))
             {
-                element.Add(new XAttribute("class", Info.SubmarineClass.ToString()));
+                element.Add(new XAttribute("class", Info.Class.Identifier));
             }
             element.Add(new XAttribute("tags", Info.Tags.ToString()));
             element.Add(new XAttribute("outposttags", Info.OutpostTags.ConvertToString()));

--- a/Barotrauma/BarotraumaShared/SharedSource/Map/SubmarineInfo.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Map/SubmarineInfo.cs
@@ -25,7 +25,6 @@ namespace Barotrauma
     }
 
     public enum SubmarineType { Player, Outpost, OutpostModule, Wreck, BeaconStation, EnemySubmarine, Ruin }
-    public enum SubmarineClass { Undefined, Scout, Attack, Transport }
 
     partial class SubmarineInfo : IDisposable
     {
@@ -118,7 +117,12 @@ namespace Barotrauma
 
         public bool IsManuallyOutfitted { get; set; }
 
-        public SubmarineClass SubmarineClass;
+        private Identifier classIdentifier;
+        public SubmarineClass Class
+        {
+            get => SubmarineClass.Find(classIdentifier) ?? SubmarineClass.Undefined;
+            set => classIdentifier = value.Identifier;
+        }
 
         public OutpostModuleInfo OutpostModuleInfo { get; set; }
         public BeaconStationInfo BeaconStationInfo { get; set; }
@@ -148,7 +152,7 @@ namespace Barotrauma
                                              OutpostModuleInfo.ModuleFlags.Contains("ruinworkshop".ToIdentifier()) ||
                                              OutpostModuleInfo.ModuleFlags.Contains("ruinshrine".ToIdentifier()));
 
-        public bool IsCampaignCompatible => IsPlayer && !HasTag(SubmarineTag.Shuttle) && !HasTag(SubmarineTag.HideInMenus) && SubmarineClass != SubmarineClass.Undefined;
+        public bool IsCampaignCompatible => IsPlayer && !HasTag(SubmarineTag.Shuttle) && !HasTag(SubmarineTag.HideInMenus) && Class != null;
         public bool IsCampaignCompatibleIgnoreClass => IsPlayer && !HasTag(SubmarineTag.Shuttle) && !HasTag(SubmarineTag.HideInMenus);
 
         public bool AllowPreviewImage => Type == SubmarineType.Player;
@@ -323,7 +327,7 @@ namespace Barotrauma
             LowFuel = original.LowFuel;
             GameVersion = original.GameVersion;
             Type = original.Type;
-            SubmarineClass = original.SubmarineClass;
+            Class = original.Class;
             hash = !string.IsNullOrEmpty(original.FilePath) && File.Exists(original.FilePath) ? original.MD5Hash : null;
             Dimensions = original.Dimensions;
             CargoCapacity = original.CargoCapacity;
@@ -464,23 +468,11 @@ namespace Barotrauma
 
             if (Type == SubmarineType.Player)
             {
-                if (SubmarineElement?.Attribute("class") != null)
-                {
-                    string classStr = SubmarineElement.GetAttributeString("class", "Undefined");
-                    if (classStr == "DeepDiver")
-                    {
-                        //backwards compatibility
-                        SubmarineClass = SubmarineClass.Scout;
-                    }
-                    else if (Enum.TryParse(classStr, out SubmarineClass submarineClass))
-                    {
-                        SubmarineClass = submarineClass;
-                    }
-                }
+                classIdentifier = SubmarineElement.GetAttributeIdentifier("class", SubmarineClass.UndefinedIdentifier);
             }
             else
             {
-                SubmarineClass = SubmarineClass.Undefined;
+                classIdentifier = SubmarineClass.UndefinedIdentifier;
             }
 
             RequiredContentPackages.Clear();

--- a/Barotrauma/BarotraumaShared/SharedSource/Sprite/Sprite.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Sprite/Sprite.cs
@@ -101,6 +101,8 @@ namespace Barotrauma
         public Identifier EntityIdentifier { get; set; }
         public string Name { get; set; }
 
+        public Color Color { get; set; }
+        
         partial void LoadTexture(ref Vector4 sourceVector, ref bool shouldReturn);
 
         partial void CalculateSourceRect();
@@ -144,6 +146,7 @@ namespace Barotrauma
             size.Y *= sourceRect.Height;
             RelativeOrigin = SourceElement.GetAttributeVector2("origin", new Vector2(0.5f, 0.5f));
             Depth = SourceElement.GetAttributeFloat("depth", 0.001f);
+            Color = SourceElement.GetAttributeColor("color", Color.White);
 #if CLIENT
             AddToList(this);
 #endif

--- a/Barotrauma/BarotraumaShared/SharedSource/Upgrades/UpgradePrefab.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Upgrades/UpgradePrefab.cs
@@ -77,7 +77,7 @@ namespace Barotrauma
 
     abstract class UpgradeContentPrefab : Prefab
     {
-        public static readonly PrefabCollection<UpgradeContentPrefab> PrefabsAndCategories = new PrefabCollection<UpgradeContentPrefab>(
+        public static readonly PrefabCollection<UpgradeContentPrefab> AllPrefabs = new PrefabCollection<UpgradeContentPrefab>(
             onAdd: (prefab, isOverride) =>
             {
                 if (prefab is UpgradePrefab upgradePrefab)
@@ -87,6 +87,10 @@ namespace Barotrauma
                 else if (prefab is UpgradeCategory upgradeCategory)
                 {
                     UpgradeCategory.Categories.Add(upgradeCategory, isOverride);
+                }
+                else if (prefab is SubmarineClass submarineClass)
+                {
+                    SubmarineClass.Classes.Add(submarineClass, isOverride);
                 }
             },
             onRemove: (prefab) =>
@@ -99,24 +103,83 @@ namespace Barotrauma
                 {
                     UpgradeCategory.Categories.Remove(upgradeCategory);
                 }
+                else if (prefab is SubmarineClass submarineClass)
+                {
+                    SubmarineClass.Classes.Remove(submarineClass);
+                }
             },
             onSort: () =>
             {
                 UpgradePrefab.Prefabs.SortAll();
                 UpgradeCategory.Categories.SortAll();
+                SubmarineClass.Classes.SortAll();
             },
             onAddOverrideFile: (file) =>
             {
                 UpgradePrefab.Prefabs.AddOverrideFile(file);
                 UpgradeCategory.Categories.AddOverrideFile(file);
+                SubmarineClass.Classes.AddOverrideFile(file);
             },
             onRemoveOverrideFile: (file) =>
             {
                 UpgradePrefab.Prefabs.RemoveOverrideFile(file);
                 UpgradeCategory.Categories.RemoveOverrideFile(file);
+                SubmarineClass.Classes.RemoveOverrideFile(file);
             });
 
         public UpgradeContentPrefab(ContentXElement element, UpgradeModulesFile file) : base(file, element) { }
+    }
+
+    internal partial class SubmarineClass : UpgradeContentPrefab
+    {
+        public static readonly PrefabCollection<SubmarineClass> Classes = new();
+        
+        public static Identifier UndefinedIdentifier = new("undefined");
+        public static SubmarineClass Undefined => Classes[UndefinedIdentifier];
+
+        public readonly ImmutableHashSet<Identifier> AltIdentifiers;
+        public readonly Identifier TextIdentifier;
+        public readonly LocalizedString Name, Description;
+        public readonly bool Purchasable;
+        
+        public SubmarineClass(ContentXElement element, UpgradeModulesFile file) : base(element, file)
+        {
+            AltIdentifiers = element.GetAttributeIdentifierArray(Array.Empty<Identifier>(), "altidentifiers", "altidentifier", "oldidentifiers", "oldidentifier").ToImmutableHashSet();
+            
+            TextIdentifier = element.GetAttributeIdentifier("textidentifier", Identifier);
+            Name = TextManager.Get($"SubmarineClass.{TextIdentifier}").Fallback(element.GetAttributeString("name", Identifier.Value));
+            Description = TextManager.Get($"SubmarineClass.{TextIdentifier}.Description").Fallback(element.GetAttributeString("description", ""));
+            
+            Purchasable = element.GetAttributeBool("purchasable", true);
+
+#if CLIENT
+            foreach (ContentXElement subElement in element.Elements())
+            {
+                switch (subElement.Name.ToString().ToLowerInvariant())
+                {
+                    case "locationindicator":
+                    {
+                        LocationIndicator = new Sprite(subElement);
+                        break;
+                    }
+                    case "availabilityicon":
+                    {
+                        AvailabilityIcon = new Sprite(subElement);
+                        break;
+                    }
+                }
+            }
+#endif
+        }
+
+        public static SubmarineClass? Find(Identifier identifier)
+        {
+            if (identifier.IsEmpty) { return null; }
+            if (Classes.TryGet(identifier, out SubmarineClass? submarineClass)) { return submarineClass; }
+            return Classes.Find(subClass => subClass.AltIdentifiers.Contains(identifier));
+        }
+        
+        public override void Dispose() { }
     }
 
     internal class UpgradeCategory : UpgradeContentPrefab
@@ -201,7 +264,7 @@ namespace Barotrauma
             Set
         }
 
-        private readonly Either<SubmarineClass, int> tierOrClass;
+        private readonly Either<Identifier, int> tierOrClass;
         private readonly int value;
         private readonly MaxLevelModType type;
 
@@ -230,9 +293,9 @@ namespace Barotrauma
                 return subTier == tier;
             }
 
-            if (tierOrClass.TryGet(out SubmarineClass targetClass))
+            if (tierOrClass.TryGet(out Identifier targetClass))
             {
-                return subClass == targetClass;
+                return subClass.Identifier == targetClass;
             }
 
             return false;
@@ -242,9 +305,9 @@ namespace Barotrauma
         {
             bool isValid = true;
 
-            SubmarineClass subClass = element.GetAttributeEnum("class", SubmarineClass.Undefined);
+            Identifier subClass = element.GetAttributeIdentifier("class", Identifier.Empty);
             int tier = element.GetAttributeInt("tier", 0);
-            if (subClass != SubmarineClass.Undefined)
+            if (subClass != Identifier.Empty)
             {
                 tierOrClass = subClass;
             }
@@ -566,7 +629,7 @@ namespace Barotrauma
 
             foreach (UpgradeMaxLevelMod mod in MaxLevelsMods)
             {
-                if (mod.AppliesTo(info.SubmarineClass, tier)) { level = mod.GetLevelAfter(level); }
+                if (mod.AppliesTo(info.Class, tier)) { level = mod.GetLevelAfter(level); }
             }
 
             return level;


### PR DESCRIPTION
This PR unhardcodes the existing submarine classes, and allows modders to define their own.

In addition, modders can also add custom outpost availability icons  as well as custom level location indicators for each class.