### PR TITLE
Pass all args to GetValidArgs in DebugConsole.AutoComplete

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/DebugConsole.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/DebugConsole.cs
@@ -2314,7 +2314,7 @@ namespace Barotrauma
                 int autoCompletedArgIndex = args.Length > 0 && command.Last() != ' ' ? args.Length - 1 : args.Length;
 
                 //get all valid arguments for the given command
-                string[][] allArgs = matchingCommand.GetValidArgs();
+                string[] allArgs = matchingCommand.GetValidArgs(args);
                 if (allArgs == null || allArgs.GetLength(0) < autoCompletedArgIndex + 1) { return command; }
 
                 if (string.IsNullOrEmpty(currentAutoCompletedCommand))


### PR DESCRIPTION
> [!NOTE]
> Just a draft

It's impossible to organize args like a tree, all the args from different branches on the same depth will mix in one array
On the other hand you're getting string[][] from GetValidArgs and using only one layer

Example: i have a test command that should run some test method from some test class like that "test testClass testMethod"
testClass will autocomplete fine, but all testMethods from all classes will mix in one array because they all considered 2nd arg

It would probably require changing all the commands, but since you are already considering this i can't help but ask what do you think of this?
![Screenshot_3](https://github.com/user-attachments/assets/f1a2e4f0-5bda-450f-b113-814feff7cb14)
