### PR TITLE
Increase the timeout threshold for waiting players

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Networking/Primitives/NetworkConnection/NetworkConnection.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Networking/Primitives/NetworkConnection/NetworkConnection.cs
@@ -17,8 +17,9 @@ namespace Barotrauma.Networking
     
     abstract class NetworkConnection
     {
-        public const double TimeoutThreshold = 60.0; //full minute for timeout because loading screens can take quite a while
-        public const double TimeoutThresholdInGame = 10.0;
+        // If player takes too long to load mod, server need to wait longer
+        public const double TimeoutThreshold = 600.0; //full minute for timeout because loading screens can take quite a while
+        public const double TimeoutThresholdInGame = 60.0;
 
         public AccountInfo AccountInfo { get; private set; } = AccountInfo.None;
 


### PR DESCRIPTION
### Disclaimers

 * [x]  I have searched the issue tracker to check if the issue has already been reported.
 * [x]  My issue happened while using mods.

### What happened?

If players install large mods, the loading time when connecting to the server will increase significantly, especially for players with lower-spec computers, as mods are loaded during the connection process

If the timeout duration is too short, players may be disconnected from the server

a better approach might be to set up a heartbeat mechanism or loading status notification during the connection, but raising the threshold can effectively solve my problem

### Reproduction steps

Install a large number of biological, environmental, architectural and other mod

### Bug prevalence

It is related to the performance of the computer and the size of the mod.

### Single player or multiplayer?

Multiplayer

### Which operating system did you encounter this bug on?

Windows, Linux

### Relevant error messages and crash reports

timeout
