### PR TITLE
Subeditor background picker

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/bug-reports.yml
+++ b/.github/DISCUSSION_TEMPLATE/bug-reports.yml
@@ -73,8 +73,7 @@ body:
       label: Version
       description: Which version of the game did the bug happen in? You can see the current version number in the bottom left corner of your screen in the main menu.
       options:
-        - v1.6.19.1 (Unto the Breach Update Hotfix 2)
-        - v1.7.0.1 (Unstable)
+        - v1.7.7.0 (Winter Update)
         - Other
     validations:
       required: true

--- a/Barotrauma/BarotraumaClient/ClientSource/GameSession/GameModes/TestGameMode.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GameSession/GameModes/TestGameMode.cs
@@ -69,8 +69,6 @@ namespace Barotrauma
                 };
             }
 
-            // Set the background color to the selected color
-            GameMain.LightManager.BackgroundColor = GameSettings.CurrentConfig.SubEditorBackground;
         }
 
         public override void AddToGUIUpdateList()

--- a/Barotrauma/BarotraumaClient/ClientSource/GameSession/GameModes/TestGameMode.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GameSession/GameModes/TestGameMode.cs
@@ -68,6 +68,9 @@ namespace Barotrauma
                     }
                 };
             }
+
+            // Set the background color to the selected color
+            GameMain.LightManager.BackgroundColor = GameSettings.CurrentConfig.SubEditorBackground;
         }
 
         public override void AddToGUIUpdateList()

--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/EditorScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/EditorScreen.cs
@@ -11,12 +11,12 @@ namespace Barotrauma
         {
             DeselectEditorSpecific();
 #if !DEBUG
-            //reset cheats the player might have used in the editor
-            GameMain.LightManager.LightingEnabled = true;
-            GameMain.LightManager.LosEnabled = true;
-            Hull.EditFire = false;
-            Hull.EditWater = false;
-            HumanAIController.DisableCrewAI = false;
+                //reset cheats the player might have used in the editor
+                GameMain.LightManager.LightingEnabled = true;
+                GameMain.LightManager.LosEnabled = true;
+                Hull.EditFire = false;
+                Hull.EditWater = false;
+                HumanAIController.DisableCrewAI = false;
 #endif
         }
 
@@ -54,20 +54,25 @@ namespace Barotrauma
             };
 
             // Add RGB picker
-            var colorPickerButton = new GUIButton(new RectTransform(new Vector2(0.1f, 1f), layoutParents[0].RectTransform), style: "ColorPicker")
+            var colorPickerButton = new GUIButton(new RectTransform(new Vector2(0.1f, 1f), layoutParents[0].RectTransform), style: "GUIButtonSmall")
             {
                 OnClicked = (button, obj) =>
                 {
-                    var colorPicker = new GUIColorPicker(BackgroundColor, (color) =>
+                    var colorPicker = new GUIColorPicker(new RectTransform(new Vector2(0.5f, 0.5f), msgBox.Content.RectTransform))
                     {
-                        rInput.IntValue = color.R;
-                        gInput.IntValue = color.G;
-                        bInput.IntValue = color.B;
-                        BackgroundColor = color;
-                        var config = GameSettings.CurrentConfig;
-                        config.SubEditorBackground = color;
-                        GameSettings.SetCurrentConfig(config);
-                    });
+                        CurrentColor = BackgroundColor,
+                        OnColorSelected = (component, color) =>
+                        {
+                            rInput.IntValue = color.R;
+                            gInput.IntValue = color.G;
+                            bInput.IntValue = color.B;
+                            BackgroundColor = color;
+                            var config = GameSettings.CurrentConfig;
+                            config.SubEditorBackground = color;
+                            GameSettings.SetCurrentConfig(config);
+                            return true;
+                        }
+                    };
                     return true;
                 }
             };

--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/EditorScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/EditorScreen.cs
@@ -53,6 +53,25 @@ namespace Barotrauma
                 GameSettings.SetCurrentConfig(config);
             };
 
+            // Add RGB picker
+            var colorPickerButton = new GUIButton(new RectTransform(new Vector2(0.1f, 1f), layoutParents[0].RectTransform), style: "ColorPicker")
+            {
+                OnClicked = (button, obj) =>
+                {
+                    var colorPicker = new GUIColorPicker(BackgroundColor, (color) =>
+                    {
+                        rInput.IntValue = color.R;
+                        gInput.IntValue = color.G;
+                        bInput.IntValue = color.B;
+                        BackgroundColor = color;
+                        var config = GameSettings.CurrentConfig;
+                        config.SubEditorBackground = color;
+                        GameSettings.SetCurrentConfig(config);
+                    });
+                    return true;
+                }
+            };
+
             // Dropdown for color presets
             var presetDropdown = new GUIDropDown(new RectTransform(new Vector2(1f, 0.1f), msgBox.Content.RectTransform));
             foreach (var preset in GameSettings.CurrentConfig.ColorPresets)
@@ -87,6 +106,7 @@ namespace Barotrauma
                 GameSettings.CurrentConfig.ColorPresets[colorNameBox.Text] = BackgroundColor;
                 GameSettings.SaveCurrentConfig();
                 presetDropdown.AddItem(colorNameBox.Text, colorNameBox.Text);
+                colorNameBox.Text = string.Empty; // Clear the naming field
                 return true;
             };
 
@@ -109,6 +129,7 @@ namespace Barotrauma
             };
 
             // Ok button
+            msgBox.Buttons[0].RectTransform.RelativeOffset = new Vector2(0, 0.05f); // Move the OK button down
             msgBox.Buttons[0].OnClicked = (button, o) => 
             { 
                 msgBox.Close();

--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/EditorScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/EditorScreen.cs
@@ -78,6 +78,25 @@ namespace Barotrauma
             {
                 presetDropdown.AddItem(preset.Key, preset.Key);
             }
+
+            // Delete button
+            var deleteButton = new GUIButton(new RectTransform(new Vector2(0.5f, 0.1f), msgBox.Content.RectTransform), TextManager.Get("Delete"));
+            deleteButton.OnClicked += (button, obj) =>
+            {
+                var selectedPreset = presetDropdown.SelectedData as string;
+                if (selectedPreset != null && selectedPreset != "default")
+                {
+                    GameSettings.CurrentConfig.ColorPresets.Remove(selectedPreset);
+                    GameSettings.SaveCurrentConfig();
+                    presetDropdown.ClearChildren();
+                    foreach (var preset in GameSettings.CurrentConfig.ColorPresets)
+                    {
+                        presetDropdown.AddItem(preset.Key, preset.Key);
+                    }
+                }
+                return true;
+            };
+
             presetDropdown.OnSelected += (selected, obj) =>
             {
                 var selectedPreset = obj as string;
@@ -107,24 +126,6 @@ namespace Barotrauma
                 GameSettings.SaveCurrentConfig();
                 presetDropdown.AddItem(colorNameBox.Text, colorNameBox.Text);
                 colorNameBox.Text = string.Empty; // Clear the naming field
-                return true;
-            };
-
-            // Delete button
-            var deleteButton = new GUIButton(new RectTransform(new Vector2(0.5f, 0.1f), msgBox.Content.RectTransform), TextManager.Get("Delete"));
-            deleteButton.OnClicked += (button, obj) =>
-            {
-                var selectedPreset = presetDropdown.SelectedData as string;
-                if (selectedPreset != null && selectedPreset != "default")
-                {
-                    GameSettings.CurrentConfig.ColorPresets.Remove(selectedPreset);
-                    GameSettings.SaveCurrentConfig();
-                    presetDropdown.ClearChildren();
-                    foreach (var preset in GameSettings.CurrentConfig.ColorPresets)
-                    {
-                        presetDropdown.AddItem(preset.Key, preset.Key);
-                    }
-                }
                 return true;
             };
 

--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/EditorScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/EditorScreen.cs
@@ -37,7 +37,7 @@ namespace Barotrauma
             }
 
             // Attach number inputs to our generated parent elements
-            var rInput = new GUINumberInput(new RectTransform(new Vector2(0.7f, 1f), layoutParents[0].RectTransform), NumberType.Int) { IntValue = BackgroundColor.R };
+            var rInput = new GUINumberInput(new RectTransform(new Vector2(0.6f, 1f), layoutParents[0].RectTransform, Anchor.CenterRight), NumberType.Int) { IntValue = BackgroundColor.R };
             var gInput = new GUINumberInput(new RectTransform(new Vector2(0.7f, 1f), layoutParents[1].RectTransform), NumberType.Int) { IntValue = BackgroundColor.G };
             var bInput = new GUINumberInput(new RectTransform(new Vector2(0.7f, 1f), layoutParents[2].RectTransform), NumberType.Int) { IntValue = BackgroundColor.B };
 
@@ -54,7 +54,7 @@ namespace Barotrauma
             };
 
             // Add RGB picker
-            var colorPickerButton = new GUIButton(new RectTransform(new Vector2(0.1f, 1f), layoutParents[0].RectTransform), style: "GUIButtonSmall")
+            var colorPickerButton = new GUIButton(new RectTransform(new Vector2(.3f, 1f), layoutParents[0].RectTransform, Anchor.CenterLeft), style: "GUIButtonSmall")
             {
                 OnClicked = (button, obj) =>
                 {
@@ -135,7 +135,7 @@ namespace Barotrauma
             };
 
             // Ok button
-            msgBox.Buttons[0].RectTransform.RelativeOffset = new Vector2(0, 0.05f); // Move the OK button down
+            msgBox.Buttons[0].RectTransform.RelativeOffset = new Vector2(0, 0.1f); // Move the OK button down
             msgBox.Buttons[0].OnClicked = (button, o) => 
             { 
                 msgBox.Close();

--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/EditorScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/EditorScreen.cs
@@ -24,7 +24,7 @@ namespace Barotrauma
 
         public void CreateBackgroundColorPicker()
         {
-            var msgBox = new GUIMessageBox(TextManager.Get("CharacterEditor.EditBackgroundColor"), "", new[] { TextManager.Get("OK") }, new Vector2(0.2f, 0.175f), minSize: new Point(300, 175));
+            var msgBox = new GUIMessageBox(TextManager.Get("CharacterEditor.EditBackgroundColor"), "", new[] { TextManager.Get("OK") }, new Vector2(0.2f, 0.3f), minSize: new Point(300, 300));
             var rgbLayout = new GUILayoutGroup(new RectTransform(new Vector2(1f, 0.25f), msgBox.Content.RectTransform), isHorizontal: true);
 
             // Generate R,G,B labels and parent elements
@@ -36,7 +36,7 @@ namespace Barotrauma
                 layoutParents[i] = colorContainer;
             }
 
-            // attach number inputs to our generated parent elements
+            // Attach number inputs to our generated parent elements
             var rInput = new GUINumberInput(new RectTransform(new Vector2(0.7f, 1f), layoutParents[0].RectTransform), NumberType.Int) { IntValue = BackgroundColor.R };
             var gInput = new GUINumberInput(new RectTransform(new Vector2(0.7f, 1f), layoutParents[1].RectTransform), NumberType.Int) { IntValue = BackgroundColor.G };
             var bInput = new GUINumberInput(new RectTransform(new Vector2(0.7f, 1f), layoutParents[2].RectTransform), NumberType.Int) { IntValue = BackgroundColor.B };
@@ -53,34 +53,6 @@ namespace Barotrauma
                 GameSettings.SetCurrentConfig(config);
             };
 
-            // Create button
-            var createButton = new GUIButton(new RectTransform(new Vector2(0.5f, 0.1f), msgBox.Content.RectTransform), TextManager.Get("Create"));
-            createButton.OnClicked += (button, obj) =>
-            {
-                var colorName = new GUITextBox(new RectTransform(new Vector2(1f, 0.1f), msgBox.Content.RectTransform));
-                if (string.IsNullOrWhiteSpace(colorName.Text))
-                {
-                    colorName.Flash(GUIStyle.Red);
-                    return false;
-                }
-                GameSettings.CurrentConfig.ColorPresets[colorName.Text] = BackgroundColor;
-                GameSettings.SaveCurrentConfig();
-                return true;
-            };
-
-            // Delete button
-            var deleteButton = new GUIButton(new RectTransform(new Vector2(0.5f, 0.1f), msgBox.Content.RectTransform), TextManager.Get("Delete"));
-            deleteButton.OnClicked += (button, obj) =>
-            {
-                var selectedPreset = presetDropdown.SelectedData as string;
-                if (selectedPreset != null)
-                {
-                    GameSettings.CurrentConfig.ColorPresets.Remove(selectedPreset);
-                    GameSettings.SaveCurrentConfig();
-                }
-                return true;
-            };
-
             // Dropdown for color presets
             var presetDropdown = new GUIDropDown(new RectTransform(new Vector2(1f, 0.1f), msgBox.Content.RectTransform));
             foreach (var preset in GameSettings.CurrentConfig.ColorPresets)
@@ -95,6 +67,43 @@ namespace Barotrauma
                     rInput.IntValue = color.R;
                     gInput.IntValue = color.G;
                     bInput.IntValue = color.B;
+                }
+
+                // Disable delete button if "default" is selected
+                deleteButton.Enabled = selectedPreset != "default";
+                return true;
+            };
+
+            // Create button
+            var colorNameBox = new GUITextBox(new RectTransform(new Vector2(1f, 0.1f), msgBox.Content.RectTransform));
+            var createButton = new GUIButton(new RectTransform(new Vector2(0.5f, 0.1f), msgBox.Content.RectTransform), TextManager.Get("Create"));
+            createButton.OnClicked += (button, obj) =>
+            {
+                if (string.IsNullOrWhiteSpace(colorNameBox.Text))
+                {
+                    colorNameBox.Flash(GUIStyle.Red);
+                    return false;
+                }
+                GameSettings.CurrentConfig.ColorPresets[colorNameBox.Text] = BackgroundColor;
+                GameSettings.SaveCurrentConfig();
+                presetDropdown.AddItem(colorNameBox.Text, colorNameBox.Text);
+                return true;
+            };
+
+            // Delete button
+            var deleteButton = new GUIButton(new RectTransform(new Vector2(0.5f, 0.1f), msgBox.Content.RectTransform), TextManager.Get("Delete"));
+            deleteButton.OnClicked += (button, obj) =>
+            {
+                var selectedPreset = presetDropdown.SelectedData as string;
+                if (selectedPreset != null && selectedPreset != "default")
+                {
+                    GameSettings.CurrentConfig.ColorPresets.Remove(selectedPreset);
+                    GameSettings.SaveCurrentConfig();
+                    presetDropdown.ClearChildren();
+                    foreach (var preset in GameSettings.CurrentConfig.ColorPresets)
+                    {
+                        presetDropdown.AddItem(preset.Key, preset.Key);
+                    }
                 }
                 return true;
             };

--- a/Barotrauma/BarotraumaShared/SharedSource/Settings/GameSettings.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Settings/GameSettings.cs
@@ -147,7 +147,7 @@ namespace Barotrauma
                         var color = preset.Attribute("color")?.Value;
                         if (name != null && color != null)
                         {
-                            retVal.ColorPresets[name] = Color.Parse(color);
+                            retVal.ColorPresets[name] = ParseColor(color);
                         }
                     }
                 }
@@ -529,7 +529,7 @@ namespace Barotrauma
             [StructSerialization.Skip]
             public InventoryKeyMapping InventoryKeyMap;
 #endif
-            public Dictionary<string, Color> ColorPresets { get; set; } = new Dictionary<string, Color>();
+public Dictionary<string, Color> ColorPresets { get; set; } = new Dictionary<string, Color>();
 
             public void SerializeElement(XElement element)
             {
@@ -541,9 +541,34 @@ namespace Barotrauma
                 {
                     presetsElement.Add(new XElement("preset",
                         new XAttribute("name", kvp.Key),
-                        new XAttribute("color", kvp.Value.ToString())));
+                        new XAttribute("color", ColorToString(kvp.Value))));
                 }
                 element.Add(presetsElement);
+            }
+
+            private static Color ParseColor(string colorString)
+            {
+                // Parse the color string in the format "#RRGGBB"
+                if (colorString.StartsWith("#"))
+                {
+                    colorString = colorString.Substring(1);
+                }
+
+                if (colorString.Length != 6)
+                {
+                    throw new ArgumentException("Invalid color string format");
+                }
+
+                byte r = byte.Parse(colorString.Substring(0, 2), System.Globalization.NumberStyles.HexNumber);
+                byte g = byte.Parse(colorString.Substring(2, 2), System.Globalization.NumberStyles.HexNumber);
+                byte b = byte.Parse(colorString.Substring(4, 2), System.Globalization.NumberStyles.HexNumber);
+
+                return new Color(r, g, b);
+            }
+
+            private static string ColorToString(Color color)
+            {
+                return $"#{color.R:X2}{color.G:X2}{color.B:X2}";
             }
         }
 

--- a/Barotrauma/BarotraumaShared/SharedSource/Settings/GameSettings.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Settings/GameSettings.cs
@@ -55,60 +55,62 @@ namespace Barotrauma
         {
             public const float DefaultAimAssist = 0.05f;
 
+            // Explicit constructor to initialize fields
+            public Config()
+            {
+                Language = LanguageIdentifier.None;
+                VerboseLogging = false;
+                SaveDebugConsoleLogs = false;
+                SavePath = string.Empty;
+                SubEditorUndoBuffer = 32;
+                MaxAutoSaves = 8;
+                AutoSaveIntervalSeconds = 300;
+                SubEditorBackground = new Color(13, 37, 69, 255);
+                EnableSplashScreen = true;
+                PauseOnFocusLost = true;
+                AimAssistAmount = DefaultAimAssist;
+                EnableMouseLook = true;
+                ShowEnemyHealthBars = EnemyHealthBarMode.ShowAll;
+                ChatSpeechBubbles = true;
+                InteractionLabelDisplayMode = InteractionLabelDisplayMode.Everything;
+                ChatOpen = true;
+                CrewMenuOpen = true;
+                ShowOffensiveServerPrompt = true;
+                TutorialSkipWarning = true;
+                CorpseDespawnDelay = 600;
+                CorpseDespawnDelayPvP = 60;
+                CorpsesPerSubDespawnThreshold = 5;
+                UseDualModeSockets = true;
+                DisableInGameHints = false;
+                EnableSubmarineAutoSave = true;
+                QuickStartSub = Identifier.Empty;
+                RemoteMainMenuContentUrl = "https://www.barotraumagame.com/gamedata/";
+                Graphics = GraphicsSettings.GetDefault();
+                Audio = AudioSettings.GetDefault();
+                ColorPresets = new Dictionary<string, Color>
+                {
+                    { "default", new Color(13, 37, 69, 255) }
+                };
+#if CLIENT
+                CrossplayChoice = Eos.EosSteamPrimaryLogin.CrossplayChoice.Unknown;
+                DisableGlobalSpamList = false;
+                KeyMap = KeyMapping.GetDefault();
+                InventoryKeyMap = InventoryKeyMapping.GetDefault();
+                SavedCampaignSettings = new XElement("campaignsettings");
+#endif
+#if DEBUG
+                QuickStartSub = "Humpback".ToIdentifier();
+                AutomaticQuickStartEnabled = false;
+                AutomaticCampaignLoadEnabled = false;
+                TextManagerDebugModeEnabled = false;
+                ModBreakerMode = false;
+                TestScreenEnabled = false;
+#endif
+            }
+
             public static Config GetDefault()
             {
-                Config config = new Config
-                {
-#if SERVER
-                    //server defaults to English, clients get a prompt to select a language
-                    Language = TextManager.DefaultLanguage,
-#else
-                    Language = LanguageIdentifier.None,
-#endif
-                    SubEditorUndoBuffer = 32,
-                    MaxAutoSaves = 8,
-                    AutoSaveIntervalSeconds = 300,
-                    SubEditorBackground = new Color(13, 37, 69, 255),
-                    EnableSplashScreen = true,
-                    PauseOnFocusLost = true,
-                    RemoteMainMenuContentUrl = "https://www.barotraumagame.com/gamedata/",
-                    AimAssistAmount = DefaultAimAssist,
-                    ShowEnemyHealthBars = EnemyHealthBarMode.ShowAll,
-                    ChatSpeechBubbles = true,
-                    InteractionLabelDisplayMode = InteractionLabelDisplayMode.Everything,
-                    EnableMouseLook = true,
-                    ChatOpen = true,
-                    CrewMenuOpen = true,
-                    ShowOffensiveServerPrompt = true,
-                    TutorialSkipWarning = true,
-                    CorpseDespawnDelay = 600,
-                    CorpseDespawnDelayPvP = 60,
-                    CorpsesPerSubDespawnThreshold = 5,
-#if OSX
-                    UseDualModeSockets = false,
-#else
-                    UseDualModeSockets = true,
-#endif
-                    DisableInGameHints = false,
-                    EnableSubmarineAutoSave = true,
-                    Graphics = GraphicsSettings.GetDefault(),
-                    Audio = AudioSettings.GetDefault(),
-#if CLIENT
-                    CrossplayChoice = Eos.EosSteamPrimaryLogin.CrossplayChoice.Unknown,
-                    DisableGlobalSpamList = false,
-                    KeyMap = KeyMapping.GetDefault(),
-                    InventoryKeyMap = InventoryKeyMapping.GetDefault()
-#endif
-
-                };
-#if DEBUG
-                config.QuickStartSub = "Humpback".ToIdentifier();
-                config.AutomaticQuickStartEnabled = false;
-                config.AutomaticCampaignLoadEnabled = false;
-                config.TextManagerDebugModeEnabled = false;
-                config.ModBreakerMode = false;
-#endif
-                return config;
+                return new Config();
             }
 
             public static Config FromElement(XElement element, in Config? fallback = null)
@@ -150,6 +152,12 @@ namespace Barotrauma
                             retVal.ColorPresets[name] = ParseColor(color);
                         }
                     }
+                }
+
+                // Ensure the default color preset is present
+                if (!retVal.ColorPresets.ContainsKey("default"))
+                {
+                    retVal.ColorPresets["default"] = new Color(13, 37, 69, 255);
                 }
 
                 return retVal;
@@ -529,11 +537,43 @@ namespace Barotrauma
             [StructSerialization.Skip]
             public InventoryKeyMapping InventoryKeyMap;
 #endif
-public Dictionary<string, Color> ColorPresets { get; set; } = new Dictionary<string, Color>();
+            public Dictionary<string, Color> ColorPresets { get; set; }
 
             public void SerializeElement(XElement element)
             {
-                // ... existing code ...
+                // Serialize existing fields
+                element.SetAttributeValue("language", Language.ToString());
+                element.SetAttributeValue("verboselogging", VerboseLogging);
+                element.SetAttributeValue("savedebugconsolelogs", SaveDebugConsoleLogs);
+                element.SetAttributeValue("savepath", SavePath);
+                element.SetAttributeValue("subeditorundobuffer", SubEditorUndoBuffer);
+                element.SetAttributeValue("maxautosaves", MaxAutoSaves);
+                element.SetAttributeValue("autosaveintervalseconds", AutoSaveIntervalSeconds);
+                element.SetAttributeValue("subeditorbackground", ColorToString(SubEditorBackground));
+                element.SetAttributeValue("enablesplashscreen", EnableSplashScreen);
+                element.SetAttributeValue("pauseonfocuslost", PauseOnFocusLost);
+                element.SetAttributeValue("aimassistamount", AimAssistAmount);
+                element.SetAttributeValue("enablemouselook", EnableMouseLook);
+                element.SetAttributeValue("showenemyhealthbars", ShowEnemyHealthBars.ToString());
+                element.SetAttributeValue("chatspeechbubbles", ChatSpeechBubbles);
+                element.SetAttributeValue("interactionlabeldisplaymode", InteractionLabelDisplayMode.ToString());
+                element.SetAttributeValue("chatopen", ChatOpen);
+                element.SetAttributeValue("crewmenuopen", CrewMenuOpen);
+                element.SetAttributeValue("showoffensiveserverprompt", ShowOffensiveServerPrompt);
+                element.SetAttributeValue("tutorialskipwarning", TutorialSkipWarning);
+                element.SetAttributeValue("corpsedespawndelay", CorpseDespawnDelay);
+                element.SetAttributeValue("corpsedespawndelaypvp", CorpseDespawnDelayPvP);
+                element.SetAttributeValue("corpsespersubdespawnthreshold", CorpsesPerSubDespawnThreshold);
+                element.SetAttributeValue("usedualmodesockets", UseDualModeSockets);
+                element.SetAttributeValue("disableingamehints", DisableInGameHints);
+                element.SetAttributeValue("enablesubmarineautosave", EnableSubmarineAutoSave);
+                element.SetAttributeValue("quickstartsub", QuickStartSub.ToString());
+                element.SetAttributeValue("remotemainmenucontenturl", RemoteMainMenuContentUrl);
+#if CLIENT
+                element.SetAttributeValue("crossplaychoice", CrossplayChoice.ToString());
+                element.SetAttributeValue("disableglobalspamlist", DisableGlobalSpamList);
+                element.SetAttributeValue("savedcampaignsettings", SavedCampaignSettings.ToString());
+#endif
 
                 // Save color presets
                 var presetsElement = new XElement("colorpresets");
@@ -618,7 +658,7 @@ public Dictionary<string, Color> ColorPresets { get; set; } = new Dictionary<str
             bool languageChanged = currentConfig.Language != newConfig.Language;
             bool audioOutputChanged = currentConfig.Audio.AudioOutputDevice != newConfig.Audio.AudioOutputDevice;
             bool voiceCaptureChanged = currentConfig.Audio.VoiceCaptureDevice != newConfig.Audio.VoiceCaptureDevice;
-            bool textScaleChanged = Math.Abs(currentConfig.Graphics.TextScale - newConfig.Graphics.TextScale) > MathF.Pow(2.0f, -7);
+            bool textScaleChanged = Math.abs(currentConfig.Graphics.TextScale - newConfig.Graphics.TextScale) > MathF.Pow(2.0f, -7);
 
             bool hudScaleChanged = !MathUtils.NearlyEqual(currentConfig.Graphics.HUDScale, newConfig.Graphics.HUDScale);
 

--- a/Barotrauma/BarotraumaShared/SharedSource/Settings/GameSettings.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Settings/GameSettings.cs
@@ -137,6 +137,21 @@ namespace Barotrauma
                 LoadSubEditorImages(element);
 #endif
 
+                // Load color presets
+                var presets = element.Element("colorpresets");
+                if (presets != null)
+                {
+                    foreach (var preset in presets.Elements("preset"))
+                    {
+                        var name = preset.Attribute("name")?.Value;
+                        var color = preset.Attribute("color")?.Value;
+                        if (name != null && color != null)
+                        {
+                            retVal.ColorPresets[name] = Color.Parse(color);
+                        }
+                    }
+                }
+
                 return retVal;
             }
 
@@ -514,6 +529,22 @@ namespace Barotrauma
             [StructSerialization.Skip]
             public InventoryKeyMapping InventoryKeyMap;
 #endif
+            public Dictionary<string, Color> ColorPresets { get; set; } = new Dictionary<string, Color>();
+
+            public void SerializeElement(XElement element)
+            {
+                // ... existing code ...
+
+                // Save color presets
+                var presetsElement = new XElement("colorpresets");
+                foreach (var kvp in ColorPresets)
+                {
+                    presetsElement.Add(new XElement("preset",
+                        new XAttribute("name", kvp.Key),
+                        new XAttribute("color", kvp.Value.ToString())));
+                }
+                element.Add(presetsElement);
+            }
         }
 
         public const string PlayerConfigPath = "config_player.xml";

--- a/Barotrauma/BarotraumaShared/SharedSource/Settings/GameSettings.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Settings/GameSettings.cs
@@ -658,7 +658,7 @@ namespace Barotrauma
             bool languageChanged = currentConfig.Language != newConfig.Language;
             bool audioOutputChanged = currentConfig.Audio.AudioOutputDevice != newConfig.Audio.AudioOutputDevice;
             bool voiceCaptureChanged = currentConfig.Audio.VoiceCaptureDevice != newConfig.Audio.VoiceCaptureDevice;
-            bool textScaleChanged = Math.abs(currentConfig.Graphics.TextScale - newConfig.Graphics.TextScale) > MathF.Pow(2.0f, -7);
+            bool textScaleChanged = Math.Abs(currentConfig.Graphics.TextScale - newConfig.Graphics.TextScale) > MathF.Pow(2.0f, -7);
 
             bool hudScaleChanged = !MathUtils.NearlyEqual(currentConfig.Graphics.HUDScale, newConfig.Graphics.HUDScale);
 


### PR DESCRIPTION
this adds functionality to the subeditor background color picker:

-add an RGB color picker (it's rendered in the wrong spot and clicking more than once opens extra pickers, but should be an easy fix for people who actually know what they're doing)
-add saving and loading color presets to the config_player.xml
-add deleting presets
-add default preset that is the standard dark blue color (can't be deleted)

![image](https://github.com/user-attachments/assets/1d45989b-430f-48ff-9b2b-9cbdf49c997f)
![image](https://github.com/user-attachments/assets/83847b97-cae9-4b88-8bf4-8c03ee5073ad)
![image](https://github.com/user-attachments/assets/641c3612-ada9-4c96-af3a-529eb6b77c15)
![image](https://github.com/user-attachments/assets/de875eb5-9227-4d76-a6b9-7e65677a430d)

# I recommend going through everything, for example the serialization, this contains copilot stuff and sometimes it changes things that should not have been changed without asking me first, and I am not yet skilled enough to know how to do it correctly

but basically it does work, and hopefully makes things at least 5% easier when implementing. I am marking it as a draft until I figure out how to fix the issues (possibly never)