### PR TITLE
Show circuit box labels in connection panel

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/CircuitBox/CircuitBoxInputOutputNode.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/CircuitBox/CircuitBoxInputOutputNode.cs
@@ -73,10 +73,12 @@ namespace Barotrauma
                             : TextManager.Get(value).Fallback(value);
 
                     conn.SetLabel(newLabel, this);
+                    conn.Connection.DisplayNameOverride = string.IsNullOrWhiteSpace(value) ? null : newLabel;
                 }
                 else
                 {
                     conn.SetLabel(conn.Connection.DisplayName, this);
+                    conn.Connection.DisplayNameOverride = null;
                 }
             }
 #endif

--- a/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/Connection.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Items/Components/Signal/Connection.cs
@@ -18,7 +18,15 @@ namespace Barotrauma.Items.Components
         public readonly int MaxWires = 5;
 
         public readonly string Name;
-        public readonly LocalizedString DisplayName;
+
+        private readonly LocalizedString _displayName;
+        public LocalizedString DisplayName
+        {
+	        get => DisplayNameOverride ?? _displayName;
+	        private init => _displayName = value;
+        }
+
+        public LocalizedString DisplayNameOverride;
 
         private readonly HashSet<Wire> wires;
         public IReadOnlyCollection<Wire> Wires => wires;


### PR DESCRIPTION
Previously, a circuit box's connection panel would show `SIGNAL_IN/OUT_1-8` instead of the labels that the user applied.

This fixes #15697.

### Example circuit box
![Circuitbox example](https://github.com/user-attachments/assets/9554331b-3634-4327-8860-4b3c6471f679)

### Previous
![Previous connection panel](https://github.com/user-attachments/assets/9cc8dfe7-5518-4723-9bd3-90f713134d8c)

### Now
This PR makes it so the displayed connection's name is based on the circuitbox's label:
![Current connection panel](https://github.com/user-attachments/assets/957cca23-7656-4318-86a9-ab83125c3e20)

Tested on both client and server.

I thought about doing this without an extra property but found no good way to restore the `DisplayName`.