### PR TITLE
Display ballast ratio in sub editor

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/SubEditorScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/SubEditorScreen.cs
@@ -230,7 +230,22 @@ namespace Barotrauma
 
         private static LocalizedString GetTotalHullVolume()
         {
-            return $"{TextManager.Get("TotalHullVolume")}:\n{Hull.HullList.Sum(h => h.Volume)}";
+            float totalVolume = 0.0f;
+            float ballastVolume = 0.0f;
+            Hull.HullList.ForEach(h =>
+            {
+                totalVolume += h.Volume;
+
+                if (h.IsBallast())
+                {
+                    ballastVolume += h.Volume;
+                }
+            });
+
+            string retVal = $"{TextManager.Get("TotalHullVolume")}:\n{totalVolume}";
+            retVal += $" ({(ballastVolume / totalVolume * 100).ToString("0.00")} % {TextManager.Get("roomname.Ballast")})";
+
+            return retVal;
         }
 
         private static LocalizedString GetSelectedHullVolume()

--- a/Barotrauma/BarotraumaShared/SharedSource/Map/Hull.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Map/Hull.cs
@@ -1407,6 +1407,11 @@ namespace Barotrauma
             IsAirlock = false;
         }
 
+        public bool IsBallast()
+        {
+	        return roomName != null && roomName.Contains("ballast", StringComparison.OrdinalIgnoreCase);
+        }
+
         /// <summary>
         /// Does this hull have any doors leading outside?
         /// </summary>


### PR DESCRIPTION
The ballast ratio is the total hull volume divided by volume of hulls containing the word "ballast". This is the same approach as the "Wet room" detection.
The purpose is ease-of-use when building submarines and trying to figure out ballast tank sizes.

## Current workflow:
1. Change hull size.
2. Select all ballast tanks manually, this can be especially painful if a lot of linked hulls are present and the ballast tanks are scattered around the sub.
3. Divide total volume by selected volume using an external calculator. Now you know if the ballast-to-total volume has changed as you intended.
4. Tinker with hull size again, repeat these steps.

## New workflow
1. Change hull size.
2. Instantly see the current ballast ratio.
3. Happily fiddle with hull size enjoying immediate feedback.

![image](https://github.com/user-attachments/assets/67966c0b-1b84-4658-b942-53751591b53c)

## Note
I'm currently reusing the ballast translation from the roomname which is usually an i18n no-no. Since translations are not part of this repo, this will have to be addressed upstream.

## Potential future PR
I would like to propose making the _optimal neutral ballast level_ calculation automatic too in another PR. It might look like this:

```
Total hull volume:
7024156

Ballast:
1351447 (19.24 % of total volume)
optimal neutral ballast level is 0.3638

Selected volume:
512345 (optimal neutral ballast level is 0.9597)
```

Any thoughts?