### PR TITLE
Add minValue for CharacterAbilityPsychoClown.cs

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Talents/Abilities/CustomAbilities/CharacterAbilityPsychoClown.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Talents/Abilities/CustomAbilities/CharacterAbilityPsychoClown.cs
@@ -3,6 +3,7 @@
     class CharacterAbilityPsychoClown : CharacterAbility
     {
         private readonly StatTypes statType;
+        private readonly float minValue;
         private readonly float maxValue;
         private readonly string afflictionIdentifier;
         private float lastValue = 0f;
@@ -12,6 +13,7 @@
         {
             statType = CharacterAbilityGroup.ParseStatType(abilityElement.GetAttributeString("stattype", ""), CharacterTalent.DebugIdentifier);
             maxValue = abilityElement.GetAttributeFloat("maxvalue", 0f);
+            minValue = abilityElement.GetAttributeFloat("minvalue", 0f);
             afflictionIdentifier = abilityElement.GetAttributeString("afflictionidentifier", "");
         }
 
@@ -31,7 +33,7 @@
                     afflictionStrength = affliction.Strength / affliction.Prefab.MaxStrength;
                 }
 
-                lastValue = afflictionStrength * maxValue;
+                lastValue = minValue + afflictionStrength * (maxValue - minValue);
                 Character.ChangeStat(statType, lastValue);
             }
             else


### PR DESCRIPTION
Added a minValue, and the strength is lerped between the two in order to avoid needing another statValue change elsewhere. Shouldn't conflict with existing implementations, given that the base was by default 0. This doesn't fix/change anything in vanilla, but it gives a little bit more flexibility in modding.