### PR TITLE
Improved Reactor modding compatibility

### DIFF
--- a/Reactorfix/OutpostItems.xml
+++ b/Reactorfix/OutpostItems.xml
@@ -1,0 +1,1246 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Items>
+  <Item name="" identifier="op_clowncurtain2" width="199" height="381" scale="0.5" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="2,2,199,381" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownmannequin1" width="76" height="259" scale="0.5" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="2,763,76,259" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownjukebox" width="149" height="258" scale="0.5" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="82,763,149,258" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <Powered IsActive="true" PowerConsumption="50">
+      <LightComponent range="20" lightcolor="209,46,158,255" blinkfrequency="1" powerconsumption="0" IsOn="true" castshadows="false" allowingameediting="false">
+        <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="205,95,169,278" depth="0.98" origin="0.5,0.5" />
+      </LightComponent>      
+      <sound file="Content/Sounds/ClubMusic_accordion.ogg" type="OnActive" range="1000.0" loop="true" volume="0.01" volumeproperty="PowerConsumption" selectionmode="Manual" mutebackgroundmusic="true" />
+      <sound file="Content/Sounds/ClubMusic_ztrr.ogg" type="OnActive" range="1000.0" loop="true" volume="0.01" volumeproperty="PowerConsumption" selectionmode="Manual" mutebackgroundmusic="true" />
+      <sound file="Content/Sounds/ClubMusic_seafloor.ogg" type="OnActive" range="1000.0" loop="true" volume="0.01" volumeproperty="PowerConsumption" selectionmode="Manual"  mutebackgroundmusic="true"/>
+      <sound file="Content/Sounds/ClubMusic_alien.ogg" type="OnActive" range="1000.0" loop="true" volume="0.01" volumeproperty="PowerConsumption" selectionmode="Manual" mutebackgroundmusic="true" />
+      <TriggerComponent triggeredby="Human" force="0" radius="50">
+        <StatusEffect type="OnActive" target="This,Character" interval="0.5" CheckConditionalAlways="true" disabledeltatime="true">
+          <Conditional PowerConsumption="gt 0" targetitemcomponent="Powered" />
+          <Conditional IsBot="true" />
+          <Affliction identifier="stun" amount="0.22" />
+        </StatusEffect>
+      </TriggerComponent>
+    </Powered>
+    <CustomInterface canbeselected="true" ElementStates="true,1,50">
+      <GuiFrame relativesize="0.2,0.15" anchor="CenterLeft" pivot="BottomLeft" relativeoffset="0.006,-0.05" style="ItemUI" />
+      <TickBox text="speaker.on" targetitemcomponent="Powered" propertyname="IsActive" ContinuousSignal="false" GetValueInterval="1" />
+      <IntegerInput text="speaker.trackselection" propertyname="ManuallySelectedSound" targetitemcomponent="Powered" min="0" max="3">
+        <StatusEffect type="OnUse" targettype="This">
+          <sound file="Content/Sounds/ClubMusic_transitionScratch.ogg" range="1000.0" />
+        </StatusEffect>
+      </IntegerInput>
+      <IntegerInput text="speaker.volume" propertyname="PowerConsumption" targetitemcomponent="Powered" min="0" max="100" step="10"/>
+    </CustomInterface>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" identifier="op_clowninstrument1" width="151" height="236" scale="0.5" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="235,763,151,236" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownball1" width="83" height="223" scale="0.5" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="390,763,83,223" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownmic" width="68" height="215" scale="0.5" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="477,763,68,215" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownmannequin3" nameidentifier="op_clownmannequin1"  width="135" height="315" scale="0.5" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="184,387,135,315" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownsign1" width="212" height="43" scale="0.5" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="184,706,212,43" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownmannequin2" nameidentifier="op_clownmannequin1" width="145" height="310" scale="0.5" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="400,387,145,310" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownmask2" width="60" height="85" scale="0.5" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="323,2,60,85" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownmask3" nameidentifier="op_clownmask2" width="60" height="79" scale="0.5" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="323,377,60,79" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownmask4" nameidentifier="op_clownmask2" width="59" height="71" scale="0.5" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="323,460,59,71" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownmask1" nameidentifier="op_clownmask2" width="52" height="80" scale="0.5" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="323,535,52,80" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownshow1" width="146" height="201" scale="0.5" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="378,91,146,201" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownsign3" nameidentifier="op_clownsign1" width="136" height="66" scale="0.5" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="378,296,136,66" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownsign2" nameidentifier="op_clownsign1" width="197" height="60" scale="0.5" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="387,2,197,60" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownshow2" nameidentifier="op_clownshow1" width="145" height="200" scale="0.5" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="528,66,145,200" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownmarquee" width="272" height="149" scale="0.5" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="677,2,272,149" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="120" lightcolor="209,127,46,255" flicker="0.1" powerconsumption="0" IsOn="true" castshadows="false" allowingameediting="false">
+      <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="677,155,272,149" depth="0.98" premultiplyalpha="true" origin="0.5,0.5" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_clowninstrument2" width="264" height="191" scale="0.6" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="549,308,264,191" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownball2" width="164" height="163" scale="0.5" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="817,462,164,163" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownshow3" nameidentifier="op_clownshow1" width="145" height="200" scale="0.5" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="549,503,145,200" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownshow4" nameidentifier="op_clownshow1" width="145" height="200" scale="0.5" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="549,707,145,200" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownposter1"  width="143" height="200" scale="0.5" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="698,629,143,200" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clownposter2" nameidentifier="op_clownposter1" width="142" height="199" scale="0.5" noninteractable="true" category="Decorative" subcategory="clownassets">
+    <sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" sourcerect="845,629,142,199" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <!--Separatist Outpost-->
+  <Item name="" identifier="op_sepsandbag" nameidentifier="op_sepsandbag" width="490" height="180" scale="0.5" noninteractable="true" category="Decorative, Wrecked" subcategory="banditseparatist">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="2,2,490,180" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_rippedposter" nameidentifier="op_sepposter1" width="462" height="126" scale="0.5" noninteractable="true" category="Decorative" subcategory="separatistassets">
+    <sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="496,2,462,126" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sepnoose" width="39" height="116" scale="0.5" noninteractable="true" category="Decorative, Wrecked" subcategory="banditseparatist">
+    <sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="962,2,39,116" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sepbarbedwire" width="454" height="83" scale="0.5" noninteractable="true" category="Decorative, Wrecked" subcategory="banditseparatist">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="496,132,454,83" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sepdebris1" nameidentifier="banditprop22" width="408" height="157" scale="0.5" noninteractable="true" category="Decorative, Wrecked" subcategory="banditseparatist">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="2,186,408,157" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_septent" nameidentifier="banditprop22" width="370" height="278" scale="0.5" noninteractable="true" category="Decorative, Wrecked" subcategory="banditseparatist">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="414,219,370,278" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sepdebris3" nameidentifier="banditprop22" width="358" height="203" scale="0.5" noninteractable="true" category="Decorative, Wrecked" subcategory="banditseparatist">
+    <sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="2,347,358,203" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sephologram1" width="145" height="87" scale="0.5" noninteractable="true" category="Decorative" subcategory="separatistassets">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="788,219,145,87" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sepposter1" width="136" height="199" scale="0.5" noninteractable="true" category="Decorative" subcategory="separatistassets">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="788,310,136,199" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_septacticalmap" width="339" height="136" scale="0.5" noninteractable="true" category="Decorative" subcategory="separatistassets">
+    <sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="364,501,339,136" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sepdebris2" nameidentifier="banditprop22" width="306" height="74" scale="0.5" noninteractable="true" category="Decorative, Wrecked" subcategory="banditseparatist">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="707,513,306,74" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sepposter3" nameidentifier="op_sepposter1" width="333" height="145" scale="0.5" noninteractable="true" category="Decorative" subcategory="separatistassets">
+ 	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="2,554,333,145" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sepbody" nameidentifier="banditprop3" width="280" height="67" scale="0.5" noninteractable="true" category="Decorative, Wrecked" subcategory="banditseparatist">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="707,591,280,67" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sepgraffiti" nameidentifier="graffiti1" width="323" height="202" scale="0.5" noninteractable="true" category="Decorative" subcategory="generic">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="339,641,323,202" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_brokenstatue" width="121" height="111" scale="0.5" noninteractable="true" category="Decorative" subcategory="separatistassets">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="339,847,121,111" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sephologram2" nameidentifier="op_sephologram1" width="129" height="80" scale="0.5" noninteractable="true" category="Decorative" subcategory="separatistassets">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="464,847,129,80" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sepdebris4" nameidentifier="banditprop22" width="237" height="211" scale="0.5" noninteractable="true" category="Decorative, Wrecked" subcategory="banditseparatist">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="2,703,237,211" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sepposter2" nameidentifier="op_sepposter1" width="135" height="196" scale="0.5" noninteractable="true" category="Decorative" subcategory="separatistassets">
+	<sprite texture="Content/Map/Outposts/Art/SeparatistOutpost.png" sourcerect="666,662,135,196" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <!--Husk District-->
+  <Item name="" identifier="op_husksign" width="139" height="74" scale="0.5" noninteractable="true" category="Decorative" subcategory="cultistassets">
+    <sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="845,928,139,74" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskposter1" width="99" height="139" scale="0.5" noninteractable="true" category="Decorative" subcategory="cultistassets">
+    <sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="724,722,99,139" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskposter2" nameidentifier="op_huskposter1" width="120" height="165" scale="0.5" noninteractable="true" category="Decorative" subcategory="cultistassets">
+    <sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="828,722,120,165" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskposter3" nameidentifier="op_huskposter1" width="99" height="139" scale="0.5" noninteractable="true" category="Decorative" subcategory="cultistassets">
+    <sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="727,869,100,139" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_husktable" width="549" height="240" scale="0.5" noninteractable="true" category="Decorative" subcategory="cultistassets">
+  	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="2,2,549,240" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskscribble" width="422" height="246" scale="0.5" noninteractable="true" category="Decorative" subcategory="cultistassets">
+	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="555,2,422,246" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskstatue1" width="271" height="474" scale="0.5" noninteractable="true" category="Decorative" subcategory="cultistassets">
+	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="2,246,271,474" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskstatue4" nameidentifier="op_huskstatue1" width="259" height="187" scale="0.5" noninteractable="true" category="Decorative" subcategory="cultistassets">
+ 	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="277,246,259,187" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskincubator" width="187" height="264" scale="0.5" noninteractable="true" category="Decorative" subcategory="cultistassets">
+ 	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="2,724,187,264" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_husklabel" width="140" height="39" scale="0.5" noninteractable="true" category="Decorative" subcategory="cultistassets">
+	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="193,982,140,39" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_husklabel1" width="53" height="35" scale="0.5" noninteractable="true" category="Decorative" subcategory="cultistassets">
+	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="337,982,53,35" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskcloak" width="115" height="232" scale="0.5" noninteractable="true" category="Decorative" subcategory="cultistassets">
+ 	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="277,437,115,232" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_humantank" width="159" height="331" scale="0.5" noninteractable="true" category="Decorative" subcategory="cultistassets">
+	<LightComponent range="130" lightcolor="255,0,100,120" pulsefrequency="0.5" pulseamount="0.2" powerconsumption="0" IsOn="true" castshadows="false" allowingameediting="false"/>
+    <sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="394,673,159,331" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="193,724,171,254" depth="0.96" origin="0.5,0.5" offset="0,5" offsetanim="Sine" offsetanimspeed="2" />
+	<DecorativeSprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="557,638,131,316" depth="0.97" />
+  </Item>
+  <Item name="" identifier="op_huskstroller1" width="184" height="197" scale="0.5" noninteractable="true" category="Decorative" subcategory="cultistassets">
+	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="396,437,184,197" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskgraffiti" width="159" height="181" scale="0.5" noninteractable="true" category="Decorative" subcategory="cultistassets">
+	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="540,252,159,181" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskstroller2" nameidentifier="op_huskstroller1" width="254" height="137" scale="0.5" noninteractable="true" category="Decorative" subcategory="cultistassets">
+	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="703,252,254,137" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskphoto2" nameidentifier="op_huskphoto1" width="56" height="70" scale="0.5" noninteractable="true" category="Decorative" subcategory="cultistassets">
+	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="961,252,56,70" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskbody" width="134" height="54" scale="0.5" noninteractable="true" category="Decorative" subcategory="cultistassets">
+	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="584,958,134,54" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskstatue2" nameidentifier="op_huskstatue1" width="224" height="184" scale="0.5" noninteractable="true" category="Decorative" subcategory="cultistassets">
+  	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="584,437,224,184" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskstatue3" nameidentifier="op_huskstatue1" width="207" height="157" scale="0.5" noninteractable="true" category="Decorative" subcategory="cultistassets">
+	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="812,393,207,157" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_huskphoto1" width="205" height="143" scale="0.5" noninteractable="true" category="Decorative" subcategory="cultistassets">
+  	<sprite texture="Content/Map/Outposts/Art/HuskDistrict.png" sourcerect="812,554,205,143" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <!--Misc Signs and Decorations-->
+  <Item name="" identifier="windowframecorner" nameidentifier="shop_decoration" width="229" height="232" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/MiningMachine.png" sourcerect="709,728,229,232" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_weaponstoresign" nameidentifier="sign" width="137" height="159" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="297,502,137,159" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_medicalstoresign" nameidentifier="sign" width="242" height="63" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="172,735,242,63" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_electricalstoresign" nameidentifier="sign" width="242" height="63" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="172,815,166,188" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0" lightcolor="213,213,185,255" flicker="0.3" powerconsumption="0" IsOn="true" castshadows="false" allowingameediting="false">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="842,809,166,188" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_storesign1.png" nameidentifier="opdeco_adposter" width="326" height="165" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="2,2,326,165" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="70" lightcolor="213,213,185,120" flicker="0.3" powerconsumption="0" IsOn="true" castshadows="false" allowingameediting="false"/>
+  </Item>
+  <Item name="" identifier="op_shipyardsign2.png" nameidentifier="opdeco_adposter" width="310" height="139" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="2,171,310,139" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="70" lightcolor="213,213,185,120" flicker="0.3" powerconsumption="0" IsOn="true" castshadows="false" allowingameediting="false"/>
+  </Item>
+  <Item name="" identifier="op_shipyardsign1.png" nameidentifier="opdeco_adposter" width="185" height="191" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="316,173,185,191" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0" lightcolor="213,213,185,255" flicker="0.3" powerconsumption="0" IsOn="true" castshadows="false" allowingameediting="false">      
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="332,2,163,167" depth="0.97" premultiplyalpha="false" origin="0.5,0.52" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_jobgraffiti.png" nameidentifier="graffiti1" width="196" height="126" scale="0.5" noninteractable="true" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="2,314,196,126" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_storesign2.png" nameidentifier="sign" width="156" height="87" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="202,368,156,87" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_directionsign.png" nameidentifier="sign" width="142" height="122" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="362,368,142,122" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_hiringsign.png" nameidentifier="sign" width="155" height="193" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="2,444,155,193" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="70" lightcolor="213,213,185,120" flicker="0.3" powerconsumption="0" IsOn="true" castshadows="false" allowingameediting="false"/>
+  </Item>
+  <!-->Item name="" identifier="op_lamppost.png" width="149" height="347" scale="0.5" noninteractable="true" category="Decorative">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="2,641,149,347" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="70" lightcolor="213,213,185,120" flicker="0.3" powerconsumption="0" IsOn="true" offset="-100,0" castshadows="false" allowingameediting="false"/>
+  </Item>
+  </!-->
+  <Item name="" identifier="op_circusposter.png" width="127" height="174" scale="0.5" noninteractable="true" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="161,459,127,174" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_plaque.png" width="120" height="85" scale="0.5" noninteractable="true" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/SignAssets.png" sourcerect="161,637,120,85" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="streetlight" nameidentifier="streetlight" width="56" height="55" scale="0.5" category="Decorative" subcategory="lighting">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="757,1,56,55" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="250.0" lightcolor="255,255,255,111" IsOn="true" castshadows="true" allowingameediting="false" powerconsumption="5">
+      <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="815,1,56,55" depth="0.97" premultiplyalpha="false" origin="0.5,0.52" />
+    </LightComponent>
+    <DecorativeSprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" depth="0.961" sourcerect="775,56,22,344" offset="0,-172"/>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="power" displayname="connection.power" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+      <input name="set_color" displayname="connection.setcolor" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" identifier="shop_decoration01" nameidentifier="shop_decoration" width="60" height="82" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/ArmoryColonyModule.png" sourcerect="743,262,60,82" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration02" nameidentifier="shop_decoration" width="71" height="108" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/ArmoryColonyModule.png" sourcerect="651,302,71,108" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration03" nameidentifier="shop_decoration" width="84" height="52" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/ArmoryColonyModule.png" sourcerect="729,360,84,52" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration04" nameidentifier="shop_decoration" width="50" height="90" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/ArmoryColonyModule.png" sourcerect="659,417,50,90" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration05" nameidentifier="shop_decoration" width="88" height="86" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/ArmoryColonyModule.png" sourcerect="729,417,88,86" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration06" nameidentifier="shop_decoration" width="37" height="133" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/ArmoryColonyModule.png" sourcerect="833,374,37,133" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration07" nameidentifier="shop_decoration" width="42" height="84" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/ArmoryColonyModule.png" sourcerect="877,369,42,84" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration08" nameidentifier="shop_decoration" width="42" height="84" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/ArmoryColonyModule.png" sourcerect="928,369,42,84" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration09" nameidentifier="shop_decoration" width="42" height="84" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/ArmoryColonyModule.png" sourcerect="978,369,42,84" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration10" nameidentifier="shop_decoration" width="43" height="44" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/ArmoryColonyModule.png" sourcerect="977,463,43,44" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration11" nameidentifier="shop_decoration" width="96" height="48" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="926,1,96,48" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration12" nameidentifier="shop_decoration" width="126" height="88" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="827,83,126,88" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration13" nameidentifier="shop_decoration" width="61" height="94" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="963,59,61,94" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration14" nameidentifier="shop_decoration" width="63" height="112" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="872,182,63,112" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration15" nameidentifier="shop_decoration" width="70" height="76" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="952,182,70,76" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration16" nameidentifier="shop_decoration" width="31" height="43" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="984,272,31,43" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration17" nameidentifier="shop_decoration" width="133" height="79" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="823,304,133,79" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration18" nameidentifier="shop_decoration" width="52" height="45" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="970,315,52,45" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration19" nameidentifier="shop_decoration" width="78" height="113" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="760,843,78,113" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration20" nameidentifier="shop_decoration" width="54" height="111" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="858,843,54,111" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration21" nameidentifier="shop_decoration" width="75" height="60" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="941,839,75,60" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration22" nameidentifier="shop_decoration" width="82" height="53" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="844,965,82,53" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_decoration23" nameidentifier="shop_decoration" width="91" height="101" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="931,920,91,101" depth="0.96" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="shop_shelf4" nameidentifier="shelf" width="301" height="377" texturescale="1.0,1.0" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/GenericWalls2.png" sourcerect="1719,450,301,377" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/GenericWalls2.png" sourcerect="1719,836,301,377" depth="0.95" origin="0.5,0.5"/>
+  </Item>
+  <!--Cafeteria and Garden Assets-->
+  <Item name="" identifier="op_cafeteriawindow" width="600" height="217" scale="0.5" noninteractable="true" category="Decorative" subcategory="cafeteria">
+    <sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" sourcerect="2,2,600,217" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_gardendistiller" width="370" height="355" scale="0.5" noninteractable="true" category="Decorative" subcategory="garden">
+    <sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" sourcerect="606,2,370,355" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_cafeteriabench" width="332" height="209" scale="0.5" noninteractable="true" category="Decorative" subcategory="cafeteria">
+    <sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" sourcerect="2,223,332,209" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_cafeteriatable" width="252" height="172" scale="0.5" noninteractable="true" category="Decorative" subcategory="cafeteria">
+    <sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" sourcerect="338,223,252,172" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_gardenbags1" nameidentifier="op_gardenbags" width="323" height="195" scale="0.5" noninteractable="true" category="Decorative" subcategory="garden">
+    <sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" sourcerect="594,361,323,195" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_cafeteriacart" width="191" height="329" scale="0.5" noninteractable="true" category="Decorative" subcategory="cafeteria">
+    <sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" sourcerect="2,647,191,329" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_gardenbags2" nameidentifier="op_gardenbags" width="282" height="77" scale="0.5" noninteractable="true" category="Decorative" subcategory="garden">
+    <sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" sourcerect="2,560,282,77" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_gardenplanter" nameidentifier="smallplanter" width="107" height="106" scale="0.5" noninteractable="true" category="Decorative" subcategory="garden">
+    <sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" sourcerect="2,436,107,106" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_gardenproducebox" width="266" height="250" scale="0.5" noninteractable="true" category="Decorative" subcategory="garden">
+    <sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" sourcerect="288,524,266,250" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_cafeteriachair" tags="chair" width="152" height="240" scale="0.5" noninteractable="false" category="Decorative" subcategory="cafeteria" canflipy="false">
+    <sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" sourcerect="197,778,152,240" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <Controller UserPos="10,30" direction="Right" hidehud="false" canbeselected="true" issecondaryitem="true" drawuserbehind="true">
+      <limbposition limb="Head" position="45,40" />
+      <limbposition limb="Torso" position="50,-30" />
+      <limbposition limb="Waist" position="50,-80" />
+      <limbposition limb="RightLeg" position="165,-140" />
+      <limbposition limb="LeftLeg" position="165,-140" />
+      <limbposition limb="RightHand" position="120,-80" allowusinglimb="true" />
+      <limbposition limb="LeftHand" position="120,-80" allowusinglimb="true" />
+    </Controller>
+  </Item>
+
+  <Item name="" identifier="op_gardenplanter2" nameidentifier="smallplanter" width="107" height="106" scale="0.5" noninteractable="true" category="Decorative" subcategory="garden">
+    <Sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.45" sourcerect="593,696,202,64" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.49" sourcerect="480,789,138,104" offset="0,60" randomrotation="-60,60" randomscale="0.8,1" randomoffset="80,10" origin="0.5,0.5" randomgroupid="1" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.52" sourcerect="619,789,138,104" offset="0,60" randomrotation="-60,60" randomscale="0.8,1" randomoffset="80,10" origin="0.5,0.5" randomgroupid="2" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.48" sourcerect="766,775,121,104" offset="0,60" randomrotation="-60,60" randomscale="0.8,1" randomoffset="80,10" origin="0.5,0.5" randomgroupid="3" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.51" sourcerect="480,789,138,104" offset="0,60" randomrotation="-60,60" randomscale="0.8,1" randomoffset="80,10" origin="0.5,0.5" randomgroupid="2" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.47" sourcerect="619,789,138,104" offset="0,60" randomrotation="-60,60" randomscale="0.8,1" randomoffset="80,10" origin="0.5,0.5" randomgroupid="3" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.50" sourcerect="766,775,121,104" offset="0,60" randomrotation="-60,60" randomscale="0.8,1" randomoffset="80,10" origin="0.5,0.5" randomgroupid="1" />
+  </Item>
+  <Item name="" identifier="op_gardenplanter3" nameidentifier="smallplanter" width="107" height="106" scale="0.5" noninteractable="true" category="Decorative" subcategory="garden">
+    <Sprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.45" sourcerect="919,946,83,59" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.49" sourcerect="497,910,96,100" offset="0,50" randomrotation="-20,20" randomscale="0.5,1" randomoffset="20,20" origin="0.5,0.5" randomgroupid="1" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.48" sourcerect="612,912,96,100" offset="0,50" randomrotation="-20,20" randomscale="0.5,1" randomoffset="20,20" origin="0.5,0.5" randomgroupid="2" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.51" sourcerect="724,912,96,100" offset="0,50" randomrotation="-20,20" randomscale="0.5,1" randomoffset="20,20" origin="0.5,0.5" randomgroupid="3" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.47" sourcerect="497,910,96,100" offset="0,50" randomrotation="-20,20" randomscale="0.5,1" randomoffset="20,20" origin="0.5,0.5" randomgroupid="2" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.50" sourcerect="612,912,96,100" offset="0,50" randomrotation="-20,20" randomscale="0.5,1" randomoffset="20,20" origin="0.5,0.5" randomgroupid="3" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.46" sourcerect="724,912,96,100" offset="0,50" randomrotation="-20,20" randomscale="0.5,1" randomoffset="20,20" origin="0.5,0.5" randomgroupid="1" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/CafeteriaGardenAssets.png" depth="0.52" sourcerect="919,864,83,82" origin="0.5,0.5" offset="0,70"/>
+  </Item>
+
+  <!--Adminstration and Residential Assets-->
+  <Item name="" identifier="op_freezer" width="273" height="394" scale="0.5" noninteractable="true" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="0,0,273,394" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_clothesrack" width="286" height="356" scale="0.5" noninteractable="true" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="274,0,284,356" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <Upgrade gameversion="1.5.0.0" refreshrect="true" />
+  </Item>
+  <Item name="" identifier="op_washingmachine" width="199" height="262" scale="0.5" noninteractable="true" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="273,357,199,262" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="848,627,99,99" depth="0.98" premultiplyalpha="false" origin="0.5,0.5" rotationspeed="-715" />
+  </Item>
+  <Item name="" identifier="op_smallcouch" width="254" height="173" scale="0.5" noninteractable="true" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="0,394,254,173" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_metalchair" width="269" height="162" scale="0.5" noninteractable="true" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="472,357,269,162" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_boxcart" width="177" height="199" scale="0.5" noninteractable="true" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="0,567,177,199" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_janitorcart" width="140" height="242" scale="0.5" noninteractable="true" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="472,519,140,242" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_inkpainting" width="234" height="125" scale="0.5" noninteractable="true" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="559,222,234,125" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_towellocker" width="107" height="236" scale="0.5" noninteractable="true" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="177,619,107,236" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_banner" width="119" height="211" scale="0.5" noninteractable="true" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="284,619,119,211" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_painting2" nameidentifier="op_painting1" width="137" height="176" scale="0.5" noninteractable="true" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="612,519,137,176" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_raptorhead" width="160" height="131" scale="0.5" noninteractable="true" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="612,695,160,131" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_statue" width="124" height="163" scale="0.5" noninteractable="true" category="Decorative" subcategory="office">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="741,347,124,163" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_painting1" width="150" height="117" scale="0.5" noninteractable="true" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="749,510,150,117" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_shower" width="76" height="159" scale="0.5" noninteractable="true" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="772,627,76,159" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_trophy2" nameidentifier="opdeco_officedisplay1" width="62" height="99" scale="0.5" noninteractable="true" category="Decorative" subcategory="office">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="767,0,62,99" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_sworddisplay" width="183" height="60" scale="0.5" noninteractable="true" category="Decorative" subcategory="office">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="403,761,183,60" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_trophy3" nameidentifier="opdeco_officedisplay1" width="60" height="106" scale="0.5" noninteractable="true" category="Decorative" subcategory="office">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="403,619,60,106" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_trophy1" nameidentifier="opdeco_officedisplay1" width="59" height="100" scale="0.5" noninteractable="true" category="Decorative" subcategory="office">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="848,726,59,100" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="op_wetsign" width="50" height="116" scale="0.5" noninteractable="true" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="739,103,50,116" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+
+  <!--Flickering hologram displays-->
+  <Item name="" identifier="op_hologramdisplay1" width="157" height="95" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="office" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="2,657,157,95" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="10.0" lightcolor="111,199,255,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="1.0">
+      <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="2,657,157,95" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_hologramdisplay2" nameidentifier="op_hologramdisplay1" width="128" height="78" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="office" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="160,656,128,78" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="10.0" lightcolor="111,199,255,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="1.0">
+      <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="160,656,128,78" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_hologramdisplay3" nameidentifier="op_hologramdisplay1" width="128" height="80" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="office" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="0,752,128,80" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="10.0" lightcolor="111,199,255,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="1.0">
+      <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="0,752,128,80" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_hologramdisplay4" nameidentifier="op_hologramdisplay1" width="129" height="81" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="office" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="159,735,129,81" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="10.0" lightcolor="111,199,255,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="1.0">
+      <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="159,735,129,81" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="opdeco_screen01" nameidentifier="opdeco_screen" width="96" height="64" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="office" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="752,352,96,64" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="111,199,255,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="0.0">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="752,352,96,64" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="opdeco_screen02" nameidentifier="opdeco_screen" width="96" height="64" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="office" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="752,416,96,64" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="60,110,66,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="0.0">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="752,416,96,64" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="opdeco_screen03" nameidentifier="opdeco_screen" width="96" height="64" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="office" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="752,480,96,64" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="200,180,60,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="0.0">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="752,480,96,64" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="opdeco_screen04" nameidentifier="opdeco_screen" width="96" height="64" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="office" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="304,672,96,64" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="220,95,60,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="0.0">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="304,672,96,64" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <!--Shop containers-->
+  <Item name="" identifier="opdeco_container" width="160" height="336" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="shop" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/Shop.png" sourcerect="0,0,160,336" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="111,199,175,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="0.0">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/Shop.png" sourcerect="400,672,160,336" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="opdeco_shopsuit1" width="160" height="336" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="shop" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/Shop.png" sourcerect="160,0,160,336" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="111,199,175,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="0.0">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/Shop.png" sourcerect="560,672,160,336" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="opdeco_shopsuit2" nameidentifier="opdeco_shopsuit1" width="160" height="336" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="shop" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/Shop.png" sourcerect="320,0,160,336" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="111,199,175,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="0.0">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/Shop.png" sourcerect="720,672,160,336" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <!--Research tanks and monitoring tables-->
+  <Item name="" identifier="op_researchcontainmenttank1" width="414" height="297" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="researchmedical">
+    <sprite texture="Content/Map/Outposts/Art/MedicalItemResearch.png" sourcerect="0,6,414,297" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="255,255,255,111" IsOn="true" castshadows="false" allowingameediting="false">
+      <sprite texture="Content/Map/Outposts/Art/MedicalItemResearchLights.png" sourcerect="0,6,414,297" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_researchtable" width="732" height="248" texturescale="1.0,1.0" scale="0.5" category="Decorative" requirecampaigninteract="true" subcategory="researchmedical">
+    <sprite texture="Content/Map/Outposts/Art/MedicalItemResearch.png" sourcerect="3,311,732,248" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="255,255,255,111" IsOn="true" castshadows="false" allowingameediting="false">
+      <sprite texture="Content/Map/Outposts/Art/MedicalItemResearchLights.png" sourcerect="3,311,732,248" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_researchcontainmenttank2" nameidentifier="op_researchcontainmenttank1" width="201" height="281" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="researchmedical">
+    <sprite texture="Content/Map/Outposts/Art/MedicalItemResearch.png" sourcerect="3,567,201,281" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="255,255,255,111" IsOn="true" castshadows="false" allowingameediting="false">
+      <sprite texture="Content/Map/Outposts/Art/MedicalItemResearchLights.png" sourcerect="3,567,201,281" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_researchcontainmenttank3" nameidentifier="op_researchcontainmenttank1" width="221" height="364" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="researchmedical">
+    <sprite texture="Content/Map/Outposts/Art/MedicalItemResearch.png" sourcerect="209,562,221,364" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/MedicalItemResearch.png" sourcerect="745,311,222,268" depth="0.98" origin="0.5,0.5"/>
+    <DecorativeSprite texture="Content/Map/Outposts/Art/MedicalItemResearch.png" sourcerect="921,210,63,91" depth="0.975" origin="0.5,0.5" offset="80,80" offsetanim="Noise" rotationanim="Noise" rotation="80" rotationspeed="0.5" offsetanimspeed="0.05" />
+    <LightComponent range="0.0" lightcolor="255,255,255,111" IsOn="true" castshadows="false" allowingameediting="false">
+      <sprite texture="Content/Map/Outposts/Art/MedicalItemResearchLights.png" sourcerect="209,562,221,364" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_vendingmachine1" tags="vendingmachine" width="238" height="396" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="1,497,238,396" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <Fabricator canbeselected="true" powerconsumption="0.0" msg="ItemMsgInteractSelect" createbuttontext="campaignstoretab.buy" ShowSortByDropdown="false" ShowAvailableOnlyTickBox="false" ShowCategoryButtons="false">
+      <GuiFrame relativesize="0.4,0.5" style="ItemUI" anchor="Center" />
+      <sound file="Content/Items/Fabricators/Fabricator.ogg" type="OnActive" range="200.0" loop="true"/>
+    </Fabricator>
+    <ItemContainer capacity="0" canbeselected="false" hideitems="true" slotsperrow="1" uilabel="" allowuioverlap="true"/>
+    <ItemContainer capacity="1" canbeselected="true" hideitems="true" slotsperrow="1" uilabel="" allowuioverlap="true"/>
+    <LightComponent range="0.0" lightcolor="255,255,255,111" IsOn="true" castshadows="false" alphablend="false" allowingameediting="false">
+      <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="241,497,238,396" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_vendingmachine2" nameidentifier="op_vendingmachine1" variantof="op_vendingmachine1">
+    <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="481,497,238,396"/>
+    <LightComponent >
+      <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="721,497,238,396" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="op_workbenchlamp" width="127" height="119" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="engineering">
+    <sprite texture="Content/Map/Outposts/Art/Shop.png" sourcerect="96,481,127,119" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="255,117,0,111" IsOn="true" castshadows="false" allowingameediting="false">
+      <sprite texture="Content/Map/Outposts/Art/Shop.png" sourcerect="96,597,127,134" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <!--Dorm-->
+  <Item name="" identifier="opdeco_bunkbeds" width="356" height="264" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="generic" spritecolor="255,255,255,255">
+    <Upgrade gameversion="0.12.0.0" noninteractable="false" />
+    <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1600,1760,384,264" depth="0.85" premultiplyalpha="false" origin="0.5,0.5" />
+    <Controller UserPos="0,-300" direction="Right" hidehud="false" canbeselected="true" drawuserbehind="true" noninteractablewhenflippedy="true">
+      <!-- don't allow laying in bed when wearing an exosuit -->
+      <RequiredItem items="deepdivinglarge" type="Picked" requireempty="true" />
+      <limbposition limb="Head" position="-26,-170" />
+      <limbposition limb="Torso" position="84,-140" />
+      <limbposition limb="Waist" position="224,-160" />
+      <limbposition limb="RightFoot" position="444,-160" />
+      <limbposition limb="LeftFoot" position="444,-160" />
+      <limbposition limb="RightHand" position="224,-160" allowusinglimb="false" />
+      <limbposition limb="LeftHand" position="224,-160" allowusinglimb="false" />
+      <StatusEffect type="OnActive" target="Character">
+        <reduceaffliction type="damage" strength="0.05" />
+        <reduceaffliction identifier="concussion" strength="0.04" />
+        <reduceaffliction identifier="infection" strength="0.02" />
+        <reduceaffliction identifier="bloodloss" strength="0.05" />
+        <reduceaffliction identifier="bleeding" strength="0.05" />
+        <reduceaffliction identifier="nausea" strength="0.5" />
+        <reduceaffliction identifier="drunk" strength="0.5" />
+        <reduceaffliction identifier="opiatewithdrawal" strength="0.06" />
+        <reduceaffliction identifier="opiateaddiction" strength="0.06" />
+        <reduceaffliction identifier="chemwithdrawal" strength="0.06" />
+        <reduceaffliction identifier="chemaddiction" strength="0.06" />
+      </StatusEffect>
+    </Controller>
+    <Upgrade gameversion="0.20.8.0">
+      <Controller>
+        <RequiredItem items="deepdivinglarge" type="Picked" requireempty="true" />
+      </Controller>
+    </Upgrade>
+  </Item>
+  <Item name="" identifier="opdeco_bunks1" nameidentifier="opdeco_bunks1" allowattachitems="false" width="463" height="398" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1296,1289,463,387" depth="0.85" premultiplyalpha="false" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1390,1126,320,160" depth="0.86" origin="0.5,0.5" offset="40,-95" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1390,1126,320,160" depth="0.86" origin="0.5,0.5" offset="40,105" />
+    <Controller UserPos="0,-300" direction="Right" hidehud="false" canbeselected="true" drawuserbehind="true" noninteractablewhenflippedy="true">
+      <!-- don't allow laying in bed when wearing an exosuit -->
+      <RequiredItem items="deepdivinglarge" type="Picked" requireempty="true" />
+      <limbposition limb="Head" position="14,-300" />
+      <limbposition limb="Torso" position="124,-270" />
+      <limbposition limb="Waist" position="264,-290" />
+      <limbposition limb="RightFoot" position="484,-290" />
+      <limbposition limb="LeftFoot" position="484,-290" />
+      <limbposition limb="RightHand" position="264,-290" allowusinglimb="false" />
+      <limbposition limb="LeftHand" position="264,-290" allowusinglimb="false" />
+      <StatusEffect type="OnActive" target="Character">
+        <reduceaffliction type="damage" strength="0.05" />
+        <reduceaffliction identifier="concussion" strength="0.04" />
+        <reduceaffliction identifier="infection" strength="0.02" />
+        <reduceaffliction identifier="bloodloss" strength="0.05" />
+        <reduceaffliction identifier="bleeding" strength="0.05" />
+        <reduceaffliction identifier="nausea" strength="0.5" />
+        <reduceaffliction identifier="drunk" strength="0.5" />
+        <reduceaffliction identifier="opiatewithdrawal" strength="0.06" />
+        <reduceaffliction identifier="opiateaddiction" strength="0.06" />
+        <reduceaffliction identifier="chemwithdrawal" strength="0.06" />
+        <reduceaffliction identifier="chemaddiction" strength="0.06" />
+      </StatusEffect>
+    </Controller>
+    <Upgrade gameversion="0.20.8.0">
+      <Controller>
+        <RequiredItem items="deepdivinglarge" type="Picked" requireempty="true" />
+      </Controller>
+    </Upgrade>
+  </Item>
+  <Item name="" identifier="opdeco_hospitalbed" width="416" height="192" texturescale="1.0,1.0" scale="0.5" noninteractable="false" category="Decorative" subcategory="researchmedical">
+    <Upgrade gameversion="0.12.0.0" noninteractable="false" />
+    <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="96,304,416,192" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <Controller UserPos="0,-300" direction="Right" hidehud="false" issecondaryitem="true" canbeselected="true" noninteractablewhenflippedy="true" drawuserbehind="true">
+      <!-- don't allow laying in bed when wearing an exosuit -->
+      <RequiredItem items="deepdivinglarge" type="Picked" requireempty="true" />
+      <limbposition limb="Head" position="-6,-10" />
+      <limbposition limb="Torso" position="104,0" />
+      <limbposition limb="Waist" position="244,-80" />
+      <limbposition limb="RightFoot" position="380,-20" />
+      <limbposition limb="LeftFoot" position="380,-20" />
+      <limbposition limb="RightHand" position="234,-10" allowusinglimb="false" />
+      <limbposition limb="LeftHand" position="234,-10" allowusinglimb="false" />
+      <StatusEffect type="OnActive" target="Character">
+        <reduceaffliction type="damage" strength="0.075" />
+        <reduceaffliction identifier="concussion" strength="0.06" />
+        <reduceaffliction identifier="infection" strength="0.025" />
+        <reduceaffliction identifier="bloodloss" strength="0.075" />
+        <reduceaffliction identifier="bleeding" strength="0.075" />
+        <reduceaffliction identifier="nausea" strength="0.75" />
+        <reduceaffliction identifier="drunk" strength="0.75" />
+        <reduceaffliction identifier="opiatewithdrawal" strength="0.08" />
+        <reduceaffliction identifier="opiateaddiction" strength="0.08" />
+        <reduceaffliction identifier="chemwithdrawal" strength="0.08" />
+        <reduceaffliction identifier="chemaddiction" strength="0.08" />
+      </StatusEffect>
+    </Controller>
+    <Upgrade gameversion="0.20.8.0">
+      <Controller>
+        <RequiredItem items="deepdivinglarge" type="Picked" requireempty="true" />
+      </Controller>
+    </Upgrade>
+  </Item>
+  <Item name="" identifier="opdeco_prisonbed" allowattachitems="true" width="384" height="96" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="864,1888,384,96" depth="0.98" premultiplyalpha="false" origin="0.5,0.5" />
+    <Controller UserPos="0,-300" direction="Right" hidehud="false" issecondaryitem="true" canbeselected="true" noninteractablewhenflippedy="true" drawuserbehind="true">
+      <!-- don't allow laying in bed when wearing an exosuit -->
+      <RequiredItem items="deepdivinglarge" type="Picked" requireempty="true" />
+      <limbposition limb="Head" position="-6,-10" />
+      <limbposition limb="Torso" position="104,20" />
+      <limbposition limb="Waist" position="244,-60" />
+      <limbposition limb="RightFoot" position="380,0" />
+      <limbposition limb="LeftFoot" position="380,0" />
+      <limbposition limb="RightHand" position="234,10" allowusinglimb="false" />
+      <limbposition limb="LeftHand" position="234,10" allowusinglimb="false" />
+      <StatusEffect type="OnActive" target="Character">
+        <reduceaffliction type="damage" strength="0.05" />
+        <reduceaffliction identifier="concussion" strength="0.04" />
+        <reduceaffliction identifier="infection" strength="0.02" />
+        <reduceaffliction identifier="bloodloss" strength="0.05" />
+        <reduceaffliction identifier="bleeding" strength="0.05" />
+        <reduceaffliction identifier="nausea" strength="0.5" />
+        <reduceaffliction identifier="drunk" strength="0.5" />
+        <reduceaffliction identifier="opiatewithdrawal" strength="0.06" />
+        <reduceaffliction identifier="opiateaddiction" strength="0.06" />
+        <reduceaffliction identifier="chemwithdrawal" strength="0.06" />
+        <reduceaffliction identifier="chemaddiction" strength="0.06" />
+      </StatusEffect>
+    </Controller>
+    <Upgrade gameversion="0.20.8.0">
+      <Controller>
+        <RequiredItem items="deepdivinglarge" type="Picked" requireempty="true" />
+      </Controller>
+    </Upgrade>
+  </Item>
+
+  <Item name="" identifier="opdeco_heater" width="144" height="336" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="generic" spritecolor="255,255,255,255" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1291,1689,144,333" depth="0.95" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="246,92,59,0" IsOn="true" castshadows="false" alphablend="false" allowingameediting="false" flicker="0.0" pulseamont="0.2" pulsefrequency="0.2">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <Upgrade gameversion="0.18.13.0" lightcolor="246,92,59,0" />
+      <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1441,1689,144,333" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+      <StatusEffect type="OnActive" target="This">
+        <Conditional hastag="eq sauna" />
+        <ParticleEmitter particle="bubbles" particlespersecond="10" anglemin="60" anglemax="120" scalemin="0.5" scalemax="1" velocitymin="20" velocitymax="30" copyentityangle="false" drawontop="true"/>
+        <ParticleEmitter particle="steamspray" particlespersecond="30" anglemin="60" anglemax="120" scalemin="2" scalemax="3" velocitymin="100" velocitymax="200" copyentityangle="false" highqualitycollisiondetection="true" drawontop="true" />
+        <ParticleEmitter particle="steamspray" particlespersecond="20" anglemin="0" anglemax="360" scalemin="0.75" scalemax="1.5" velocitymin="20" velocitymax="50" copyentityangle="false" highqualitycollisiondetection="true" drawontop="true" colormultiplier="255,255,255,180" />
+      </StatusEffect>
+    </LightComponent>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+    </ConnectionPanel>
+  </Item>
+  <!--Tunnel wall with flickering lights-->
+  <Item name="" identifier="opbg_tunnel3" allowattachitems="true" width="831" height="416" scale="0.5" category="Decorative" subcategory="backgroundwall" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/TunnelWalls.png" sourcerect="0,416,831,416" depth="0.98" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="255,56,56,111" IsOn="true" castshadows="false" allowingameediting="false" flicker="0.1" flickerspeed="0.1" blinkfrequency="1" >      
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/TunnelWalls.png" sourcerect="0,1248,832,372" depth="0.1" origin="0.5,0.55" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <!--Tunnel Light Tower-->
+  <Item name="" identifier="op_lighttower" width="176" height="352" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="mining" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/TunnelWalls.png" sourcerect="849,1697,176,352" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="160.0" lightcolor="255,234,181,200" IsOn="true" castshadows="false" LightOffset="0,147" allowingameediting="false">
+      <sprite texture="Content/Map/Outposts/Art/TunnelWalls.png" sourcerect="671,1697,176,62" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <!--Wall Decorations-->
+  <Item name="" identifier="op_lightbox1" width="163" height="209" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="generic" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="1357,590,163,209" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="60.0" lightcolor="255,234,181,200" IsOn="true" castshadows="false" allowingameediting="false"/>
+  </Item>
+  <Item name="" identifier="op_lightbox2" nameidentifier="op_lightbox1" width="159" height="206" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="generic" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="1526,586,159,206" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="60.0" lightcolor="255,234,181,200" IsOn="true" castshadows="false" allowingameediting="false"/>
+  </Item>
+  <Item name="" identifier="op_lightbox3" nameidentifier="op_lightbox1" width="289" height="194" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="generic" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="1760,394,289,194" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="60.0" lightcolor="255,234,181,200" IsOn="true" castshadows="false" allowingameediting="false"/>
+  </Item>
+  <Item name="" identifier="op_lightbox4" nameidentifier="op_lightbox1" width="145" height="194" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="generic" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="1759,1607,145,194" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="60.0" lightcolor="255,234,181,200" IsOn="true" castshadows="false" allowingameediting="false"/>
+  </Item>
+  <Item name="" identifier="op_lightbox5" nameidentifier="op_lightbox1" width="145" height="194" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="generic" noninteractable="true">
+    <sprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="1903,1607,144,194" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="60.0" lightcolor="255,234,181,200" IsOn="true" castshadows="false" allowingameediting="false"/>
+  </Item>
+  <!-- Medical -->
+  <Item name="" identifier="opdeco_mountedmonitor1" nameidentifier="medicalmonitor" width="96" height="128" texturescale="1.0,1.0" scale="0.5" noninteractable="true" category="Decorative" subcategory="researchmedical">
+    <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="0,0,96,128" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="255,255,255,255" IsOn="true" castshadows="false" allowingameediting="false">
+      <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="96,0,96,128" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="opdeco_medcompartment1" nameidentifier="medicalcompartment" tags="container,suppliescontainer" linkable="true" width="80" height="80" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="researchmedical">
+    <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="192,0,80,80" depth="0.84" premultiplyalpha="false" origin="0.5,0.5" />
+    <ItemContainer capacity="3" slotsperrow="3" canbeselected="true" hideitems="true" msg="ItemMsgInteractSelect">
+      <GuiFrame relativesize="0.15,0.2" anchor="Center" style="ItemUI" />
+      <Containable items="smallitem,mediumitem" excludedidentifiers="mobilecontainer" />
+    </ItemContainer>
+  </Item>
+  <Item name="" identifier="opdeco_medcompartment2" nameidentifier="medicalcompartment" tags="container,suppliescontainer" linkable="true" width="48" height="80" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="researchmedical">
+    <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="272,0,48,80" depth="0.84" premultiplyalpha="false" origin="0.5,0.5" />
+    <ItemContainer capacity="2" slotsperrow="3" canbeselected="true" hideitems="true" msg="ItemMsgInteractSelect">
+      <GuiFrame relativesize="0.15,0.16" anchor="Center" style="ItemUI" />
+      <Containable items="smallitem,mediumitem" excludedidentifiers="mobilecontainer" />
+    </ItemContainer>
+  </Item>
+  <Item name="" identifier="opdeco_medcompartment3" nameidentifier="medicalcompartment" tags="container,suppliescontainer" linkable="true" width="80" height="128" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="researchmedical">
+    <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="400,0,80,128" depth="0.84" premultiplyalpha="false" origin="0.5,0.5" />
+    <ItemContainer capacity="6" slotsperrow="3" canbeselected="true" hideitems="true" msg="ItemMsgInteractSelect">
+      <GuiFrame relativesize="0.18,0.25" anchor="Center" style="ItemUI" />
+      <Containable items="smallitem,mediumitem" excludedidentifiers="mobilecontainer" />
+    </ItemContainer>
+  </Item>
+  <Item name="" identifier="opdeco_surgicallights" width="272" height="128" texturescale="1.0,1.0" scale="0.5" noninteractable="true" category="Decorative" subcategory="researchmedical">
+    <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="752,0,272,128" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="255,255,255,0" IsOn="true" castshadows="false" alphablend="false" allowingameediting="false">
+      <Upgrade gameversion="0.18.12.0" lightcolor="255,255,255,0" />
+      <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="480,0,272,128" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="opdeco_xrayscreen" width="208" height="144" texturescale="1.0,1.0" scale="0.5" noninteractable="true" category="Decorative" subcategory="researchmedical">
+    <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="304,160,208,144" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="255,255,255,0" IsOn="true" castshadows="false" alphablend="false" allowingameediting="false" flicker="0.1" pulsefrequency="0.5" pulseamount="0.2">      
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <Upgrade gameversion="0.18.12.0" lightcolor="255,255,255,0" />
+      <sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="96,160,208,144" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="opdeco_xrayscreen2" nameidentifier="opdeco_xrayscreen" width="369" height="133" texturescale="1.0,1.0" scale="0.5" noninteractable="true" category="Decorative" subcategory="researchmedical">
+    <sprite texture="Content/Map/Outposts/Art/MedicalColonyAssets.png" sourcerect="0,0,369,133" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="255,255,255,0" IsOn="true" castshadows="false" alphablend="false" allowingameediting="false" flicker="0.1" pulsefrequency="0.5" pulseamount="0.2">      
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <Upgrade gameversion="0.18.12.0" lightcolor="255,255,255,0" />
+      <sprite texture="Content/Map/Outposts/Art/MedicalColonyAssets.png" sourcerect="0,133,369,133" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="opdeco_xrayscreen3" nameidentifier="opdeco_xrayscreen" width="192" height="208" texturescale="1.0,1.0" scale="0.5" noninteractable="true" category="Decorative" subcategory="researchmedical">
+    <sprite texture="Content/Map/Outposts/Art/MedicalColonyAssets.png" sourcerect="199,266,192,208" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="255,255,255,0" IsOn="true" castshadows="false" alphablend="false" allowingameediting="false" flicker="0.1" pulsefrequency="0.5" pulseamount="0.2">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <Upgrade gameversion="0.18.12.0" lightcolor="255,255,255,0" />
+      <sprite texture="Content/Map/Outposts/Art/MedicalColonyAssets.png" sourcerect="0,267,192,208" depth="0.1" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+  </Item>
+  <Item name="" identifier="opdeco_wheelchair2" nameidentifier="opdeco_wheelchair1" tags="chair" allowattachitems="false" texturescale="1.0,1.0" scale="0.5" category="Decorative" canflipy="false" subcategory="researchmedical">
+    <sprite texture="Content/Map/Outposts/Art/MedicalColonyAssets.png" sourcerect="452,781,249,225" depth="0.55" premultiplyalpha="false" origin="0.5,0.5" />
+    <Controller UserPos="10,30" direction="Right" hidehud="false" canbeselected="true" issecondaryitem="true" drawuserbehind="true">
+      <limbposition limb="Head" position="70,45" />
+      <limbposition limb="Torso" position="90,-30" />
+      <limbposition limb="Waist" position="95,-85" />
+      <limbposition limb="RightFoot" position="180,-220" />
+      <limbposition limb="LeftFoot" position="180,-220" />
+      <limbposition limb="RightHand" position="130,-100" allowusinglimb="true" />
+      <limbposition limb="LeftHand" position="130,-100" allowusinglimb="true" />
+    </Controller>
+  </Item>
+
+  <!--Outpost Machines-->
+  <Item name="" nameidentifier="reactor1" identifier="outpostreactor" tags="reactor" type="Reactor" linkable="true" category="Machine" damagedbyexplosions="true" scale="0.5" explosiondamagemultiplier="0.2">
+    <trigger />
+    <sprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="38,336,575,849" depth="0.8" origin="0.5,0.5" />
+    <UpgradePreviewSprite scale="3.0" texture="Content/UI/WeaponUI.png" sourcerect="0,960,64,64" origin="0.5,0.45" />
+    <BrokenSprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="473,1197,502,655" depth="0.79" maxcondition="50" offset="0,0" fadein="true" />
+    <BrokenSprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="975,1197,502,690" depth="0.79" maxcondition="10" offset="0,0" fadein="true" />
+    <aitarget sightrange="500" soundrange="7500" />
+    <Reactor canbeselected="true" firedelay="20" meltdowndelay="120" maxpoweroutput="20000" fuelconsumptionrate="0.2" vulnerabletoemp="false" msg="ItemMsgInteractSelect">
+      <StatusEffect type="InWater" target="This" condition="-0.5">
+        <Conditional condition="gt 10" />
+      </StatusEffect>
+      <GuiFrame relativesize="0.5,0.45" minsize="700,350" maxsize="2688,1166" anchor="Center" relativeoffset="0.1,0" style="ItemUI" />
+      <GraphLine texture="Content/Items/Reactor/graphLine.png">
+        <Sprite name="ReactorGraphLine" texture="Content/Items/Reactor/graphLine.png" sourcerect="0,0,32,32" />
+      </GraphLine>
+      <FissionRateMeter>
+        <Sprite name="FissionRateMeter" texture="Content/Items/Reactor/reactor.png" sourcerect="544,770,441,240" origin="0.5,1" />
+      </FissionRateMeter>
+      <TurbineOutputMeter>
+        <Sprite name="TurbineOutputMeter" texture="Content/Items/Reactor/reactor.png" sourcerect="544,770,441,240" origin="0.5,1" />
+      </TurbineOutputMeter>
+      <MeterPointer>
+        <Sprite name="MeterPointer" texture="Content/UI/UIAtlasDevices.png" sourcerect="938,846,31,167 " origin="0.5,0.9" />
+      </MeterPointer>
+      <SectorSprite>
+        <Sprite name="SectorSprite" texture="Content/UI/UIAtlasDevices.png" sourcerect="769,326,238,455" origin="0.95,0.5" />
+      </SectorSprite>
+      <TempMeterFrame>
+        <Sprite name="TempMeterFrame" texture="Content/UI/UIAtlasDevices.png" sourcerect="92,517,59,265" origin="0,0" size="0.5,1" />
+      </TempMeterFrame>
+      <TempMeterBar>
+        <Sprite name="TempMeterBar" texture="Content/UI/UIAtlasDevices.png" sourcerect="270,414,106,47" origin="0.5,0" />
+      </TempMeterBar>
+      <TempRangeIndicator>
+        <Sprite name="TempRangeIndicator" texture="Content/UI/UIAtlasDevices.png" sourcerect="31,614,52,25" origin="0.5,0.5" size="0.6,0.6" />
+      </TempRangeIndicator>
+      <RequiredSkill identifier="electrical" level="50" />
+      <RequiredItem items="idcard" type="Picked" msg="ItemMsgUnauthorizedAccess" ignoreineditor="true" />
+      <sound file="Content/Items/Reactor/Reactor.ogg" type="OnActive" range="2000.0" volumeproperty="FissionRate" volume="0.02" loop="true" />
+      <StatusEffect type="OnBroken" target="This" FissionRate="0.0" disabledeltatime="true">
+        <sound file="Content/Items/Weapons/ExplosionLarge2.ogg" type="OnUse" volume="10" selectionmode="Random" range="50000" dontmuffle="true" />
+        <sound file="Content/Items/Weapons/ExplosionDebris5.ogg" range="8000" />
+        <Explosion range="750" ballastfloradamage="1000" structuredamage="300" itemdamage="500" force="25.0" camerashake="0" debris="true" flashrange="10000" flashduration="5.0" screencolor="255,255,255,255" screencolorrange="5000" screencolorduration="3.0" decal="explosion" decalsize="1">
+          <Affliction identifier="explosiondamage" strength="500" />
+          <Affliction identifier="burn" strength="500" />
+          <Affliction identifier="stun" strength="15" />
+        </Explosion>
+        <Explosion range="2000" force="0.0" camerashake="200" camerashakerange="50000" showEffects="false" empstrength="1.25" applyfireeffects="false" ignorecover="true">
+          <Affliction identifier="radiationsickness" strength="75" />
+          <Affliction identifier="emp" strength="50" multiplybymaxvitality="true" />
+        </Explosion>
+        <ParticleEmitter particle="underwaterexplosion" anglemin="0" anglemax="360" particleamount="3" velocitymin="0" velocitymax="0" scalemin="15" scalemax="15" />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="Contained" Condition="0.0" setvalue="true" />
+    </Reactor>
+    <LightComponent range="300.0" lightcolor="255,186,152,119" powerconsumption="0" IsOn="false" castshadows="false" allowingameediting="false">
+      <IsActive targetitemcomponent="Reactor" temperature="gt 2" />
+      <sprite texture="Content/Map/Outposts/Art/GenericAssets2.png" depth="0.025" sourcerect="649,761,575,425" alphablend="false" origin="0.5,0.0" alpha="1.0" />
+    </LightComponent>
+    <LightComponent range="400" lightcolor="255,0,0,250" powerconsumption="0" IsOn="false" castshadows="false" allowingameediting="false" blinkfrequency="1">
+      <IsActive targetitemcomponent="Reactor" temperaturecritical="eq true" />
+    </LightComponent>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.3,0.35" minsize="400,350" maxsize="480,460" anchor="Center" style="ConnectionPanel" />
+      <RequiredSkill identifier="electrical" level="70" />
+      <StatusEffect type="OnFailure" target="Character" targetlimbs="LeftHand,RightHand" AllowWhenBroken="true">
+        <Sound file="Content/Sounds/Damage/Electrocution1.ogg" range="1000" />
+        <Explosion range="100.0" force="1.0" flames="false" shockwave="false" sparks="true" underwaterbubble="false" />
+        <Affliction identifier="stun" strength="4" probability="0.5" />
+        <Affliction identifier="electricshock" strength="60"/>
+        <Affliction identifier="burn" strength="5" />
+        <ParticleEmitter particle="ElectricShock" DistanceMin="10" DistanceMax="25" ParticleAmount="5" ScaleMin="0.1" ScaleMax="0.12" />
+      </StatusEffect>
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <output name="power_out" displayname="connection.powerout" maxwires="1" />
+      <output name="temperature_out" displayname="connection.temperatureout" />
+      <input name="shutdown" displayname="connection.shutdown" />
+      <input name="set_fissionrate" displayname="connection.setfissionrate" />
+      <input name="set_turbineoutput" displayname="connection.setturbineoutput" />
+      <output name="meltdown_warning" displayname="connection.meltdownwarning">
+        <StatusEffect type="OnUse" target="This">
+          <ParticleEmitter particle="smoke" particlespersecond="2" scalemin="1" scalemax="2.5" anglemax="360" velocitymin="-50" velocitymax="50" mincondition="15.0" maxcondition="50.0" />
+          <ParticleEmitter particle="swirlysmoke" particlespersecond="3" scalemin="1" scalemax="2" anglemin="0" anglemax="360" velocitymin="0" velocitymax="10" />
+          <sound file="Content/Items/Reactor/ReactorOverheatAlarm.ogg" type="OnUse" range="10000.0" loop="true" volume="1.0" />
+        </StatusEffect>
+      </output>
+      <output name="power_value_out" displayname="connection.powervalueout" />
+      <output name="load_value_out" displayname="connection.loadvalueout" />
+      <output name="fuel_out" displayname="connection.availablefuelout" />
+      <output name="condition_out" displayname="connection.conditionout" />
+      <output name="fuel_percentage_left" displayname="connection.fuelpercentageout" />
+    </ConnectionPanel>
+    <ItemContainer capacity="4" maxstacksize="1" canbeselected="true" hudpos="0.5,0.15" slotsperrow="1" uilabel="FuelRods">
+      <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="192,448,64,64" origin="0.5,0.5" />
+      <SlotIcon slotindex="1" texture="Content/UI/StatusMonitorUI.png" sourcerect="192,448,64,64" origin="0.5,0.5" />
+      <SlotIcon slotindex="2" texture="Content/UI/StatusMonitorUI.png" sourcerect="192,448,64,64" origin="0.5,0.5" />
+      <SlotIcon slotindex="3" texture="Content/UI/StatusMonitorUI.png" sourcerect="192,448,64,64" origin="0.5,0.5" />
+      <RequiredItem items="idcard" type="Picked" msg="ItemMsgUnauthorizedAccess" ignoreineditor="true" />
+      <Containable items="fuelrod">
+        <StatusEffect type="OnContaining" target="This" AvailableFuel="80.0" disabledeltatime="true" />
+      </Containable>
+      <Containable items="fulguriumfuelrod">
+        <StatusEffect type="OnContaining" target="This" AvailableFuel="150.0" disabledeltatime="true" />
+      </Containable>
+      <Containable items="thoriumfuelrod">
+        <StatusEffect type="OnContaining" target="This" AvailableFuel="100.0" disabledeltatime="true" />
+      </Containable>
+      <Containable items="fulguriumfuelrodvolatile">
+        <StatusEffect type="OnContaining" target="This" AvailableFuel="150.0" disabledeltatime="true" />
+      </Containable>
+      <Containable items="huskfigurine">
+        <StatusEffect type="OnContaining" target="This" AvailableFuel="0" disabledeltatime="true" />
+      </Containable>
+    </ItemContainer>
+    <Repairable selectkey="Action" header="electricalrepairsheader" deteriorationspeed="0.125" mindeteriorationdelay="120" maxdeteriorationdelay="720" MinDeteriorationCondition="10" minsabotagecondition="10" AIRepairThreshold="50" fixDurationHighSkill="5" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI" />
+      <RequiredSkill identifier="electrical" level="55" />
+      <RequiredItem items="wrench" type="equipped" />
+      <ParticleEmitter particle="damagebubbles" particlespersecond="2" scalemin="0.5" scalemax="1.5" anglemax="360" velocitymin="-10" velocitymax="10" mincondition="0.0" maxcondition="50.0" />
+      <ParticleEmitter particle="smoke" particlespersecond="2" scalemin="1" scalemax="2.5" anglemax="360" velocitymin="-50" velocitymax="50" mincondition="15.0" maxcondition="50.0" />
+      <ParticleEmitter particle="heavysmoke" particlespersecond="2" scalemin="1.0" scalemax="2.5" anglemax="360" distancemax="60" mincondition="0.0" maxcondition="15.0" />
+      <StatusEffect type="OnFailure" target="Character" targetlimbs="LeftHand,RightHand" AllowWhenBroken="true">
+        <Sound file="Content/Sounds/Damage/Electrocution1.ogg" range="1000" />
+        <Explosion range="100.0" force="1.0" flames="false" shockwave="false" sparks="true" underwaterbubble="false" />
+        <Affliction identifier="stun" strength="4" probability="0.5" />
+        <Affliction identifier="electricshock" strength="60"/>
+        <Affliction identifier="burn" strength="5" />
+        <ParticleEmitter particle="ElectricShock" DistanceMin="10" DistanceMax="25" ParticleAmount="5" ScaleMin="0.1" ScaleMax="0.12" />
+      </StatusEffect>
+    </Repairable>
+    <SkillRequirementHint identifier="electrical" level="50" />
+  </Item>
+  <Item name="" nameidentifier="oxygenerator" identifier="outpostoxygenerator" tags="oxygengenerator" category="Machine" linkable="true" allowedlinks="vent" damagedbyexplosions="true" scale="0.5" explosiondamagemultiplier="0.2">
+    <Sprite texture="Content/Map/Outposts/Art/GenericAssets2.png" depth="0.8" sourcerect="52,1197,360,410" origin="0.5,0.5" />
+    <BrokenSprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="52,1617,360,410" depth="0.79" origin="0.5,0.5" maxcondition="80" fadein="true" />
+    <BrokenSprite texture="Content/Map/Outposts/Art/GenericAssets2.png" sourcerect="623,336,360,410" depth="0.79" origin="0.5,0.5" maxcondition="10" fadein="true" />
+    <UpgradePreviewSprite scale="2.5" texture="Content/UI/WeaponUI.png" sourcerect="384,960,64,64" origin="0.5,0.45" />
+    <OxygenGenerator powerconsumption="1000.0" minvoltage="0.5" generatedamount="5000" canbeselected="true" msg="ItemMsgInteractSelect">
+      <poweronsound file="Content/Items/PowerOnLight2.ogg" range="1500" loop="false" />
+      <sound file="Content/Items/OxygenGenerator/OxygenGenerator.ogg" type="OnActive" range="1000.0" volumeproperty="CurrFlow" volume="0.001" loop="true" />
+      <StatusEffect type="OnFire" target="This" Condition="-0.5" />
+      <StatusEffect type="OnActive" targettype="Contained" targets="oxygentank" Condition="2.0" />
+      <StatusEffect type="OnBroken" targettype="This" disabledeltatime="true">
+        <sound file="Content/Items/Weapons/ExplosionMedium1.ogg" range="3000" />
+        <sound file="Content/Items/Weapons/ExplosionMedium2.ogg" range="3000" />
+        <sound file="Content/Items/Weapons/ExplosionMedium3.ogg" range="3000" />
+        <Explosion range="50" stun="0" force="3.0" flames="false" shockwave="false" sparks="true" debris="true" underwaterbubble="false" />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="This">
+        <sound file="Content/Items/Weapons/ExplosionDebris3.ogg" range="2000" />
+      </StatusEffect>
+    </OxygenGenerator>
+    <trigger />
+    <ItemContainer capacity="5" maxstacksize="1" canbeselected="true" hideitems="false" itempos="163,-290" iteminterval="42,0" msg="ItemMsgOxygenRefill">
+      <GuiFrame relativesize="0.25,0.2" anchor="Center" style="ItemUI" />
+      <Containable items="oxygentank" />
+    </ItemContainer>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="power_in" displayname="connection.powerin" />
+      <output name="condition_out" displayname="connection.conditionout" />
+    </ConnectionPanel>
+    <Repairable selectkey="Action" header="mechanicalrepairsheader" deteriorationspeed="0.125" mindeteriorationdelay="120" maxdeteriorationdelay="750" mindeteriorationcondition="0" AIRepairThreshold="50" fixDurationHighSkill="5" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI" />
+      <RequiredSkill identifier="mechanical" level="55" />
+      <RequiredItem items="wrench" type="equipped" />
+      <ParticleEmitter particle="damagebubbles" particlespersecond="2" scalemin="0.5" scalemax="1.5" anglemax="360" velocitymin="-10" velocitymax="10" mincondition="0.0" maxcondition="50.0" />
+      <ParticleEmitter particle="smoke" particlespersecond="2" scalemin="1" scalemax="2.5" anglemax="360" velocitymin="-50" velocitymax="50" mincondition="15.0" maxcondition="50.0" />
+      <ParticleEmitter particle="heavysmoke" particlespersecond="2" scalemin="1.0" scalemax="2.5" anglemax="360" distancemax="60" maxcondition="15.0" />
+      <StatusEffect type="OnFailure" target="Character" targetlimbs="LeftHand,RightHand" AllowWhenBroken="true">
+        <Sound file="Content/Items/MechanicalRepairFail.ogg" range="1000" />
+        <Affliction identifier="lacerations" strength="5" />
+        <Affliction identifier="stun" strength="4" />
+      </StatusEffect>
+    </Repairable>
+  </Item>
+  <Item name="" identifier="outpostterminal" category="Machine" Tags="smallitem" cargocontaineridentifier="metalcrate" scale="0.5" impactsoundtag="impact_metal_light" isshootable="true">
+    <Upgrade gameversion="0.10.0.0" scale="0.5" />
+    <Sprite texture="Content/Map/Outposts/Art/Storage.png" depth="0.8" sourcerect="1544,506,142,149" origin="0.5,0.5" />
+    <LightComponent range="0.0" lightcolor="255,255,255,0" powerconsumption="0" IsOn="true" castshadows="false" alphablend="false" allowingameediting="false">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/Storage.png" depth="0.025" sourcerect="1709,506,142,149" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+    <LightComponent range="0.0" lightcolor="255,255,255,0" powerconsumption="0" IsOn="true" castshadows="false" alphablend="false" allowingameediting="false" blinkfrequency="1">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="Content/Map/Outposts/Art/Storage.png" depth="0.025" sourcerect="1869,506,142,149" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+    <OutpostTerminal canbeselected="true" msg="ItemMsgInteractSelect" AllowInGameEditing="false" />
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem identifier="screwdriver" type="Equipped" />
+      <input name="signal_in" displayname="connection.signalin" />
+      <output name="signal_out" displayname="connection.signalout" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" identifier="opdeco_officechair" tags="chair" allowattachitems="false" texturescale="1.0,1.0" scale="0.45" category="Decorative" subcategory="office" canflipy="false">
+    <sprite texture="Content/Map/Outposts/Art/ManagerOfficeAssets.png" sourcerect="570,341,180,267" depth="0.55" premultiplyalpha="false" origin="0.5,0.5" />
+    <Controller UserPos="10,30" direction="Right" hidehud="false" canbeselected="true" issecondaryitem="true" drawuserbehind="true">
+      <limbposition limb="Head" position="90,15" />
+      <limbposition limb="Torso" position="85,-60" />
+      <limbposition limb="Waist" position="90,-130" />
+      <limbposition limb="RightFoot" position="140,-250" />
+      <limbposition limb="LeftFoot" position="140,-250" />
+      <limbposition limb="RightHand" position="140,-105" allowusinglimb="true" />
+      <limbposition limb="LeftHand" position="140,-105" allowusinglimb="true" />
+    </Controller>
+  </Item>
+  <Item name="" identifier="opdeco_chair1" nameidentifier="opdeco_officechair" tags="chair" allowattachitems="true" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="office" canflipy="false">
+    <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1233,31,144,240" depth="0.55" premultiplyalpha="false" origin="0.5,0.5" />
+    <Controller UserPos="-10,30" direction="Left" hidehud="false" canbeselected="true" issecondaryitem="true" drawuserbehind="true">
+      <limbposition limb="Head" position="82,18" />
+      <limbposition limb="Torso" position="80,-52" />
+      <limbposition limb="Waist" position="73,-105" />
+      <limbposition limb="RightFoot" position="-10,-230" />
+      <limbposition limb="LeftFoot" position="-10,-230" />
+      <limbposition limb="RightHand" position="40,-120" allowusinglimb="true" />
+      <limbposition limb="LeftHand" position="40,-120" allowusinglimb="true" />
+    </Controller>
+  </Item>
+  <Item name="" identifier="opdeco_chair2" nameidentifier="opdeco_officechair" tags="chair" allowattachitems="true" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="office" canflipy="false">
+    <sprite texture="Content/Map/Outposts/Art/MedicalColonyAssets.png" sourcerect="744,784,144,240" depth="0.55" premultiplyalpha="false" origin="0.5,0.5" />
+    <Controller UserPos="10,30" direction="Right" hidehud="false" canbeselected="true" issecondaryitem="true" drawuserbehind="true">
+      <limbposition limb="Head" position="40,15" />
+      <limbposition limb="Torso" position="55,-60" />
+      <limbposition limb="Waist" position="60,-130" />
+      <limbposition limb="RightFoot" position="100,-230" />
+      <limbposition limb="LeftFoot" position="100,-230" />
+      <limbposition limb="RightHand" position="100,-100" allowusinglimb="true" />
+      <limbposition limb="LeftHand" position="100,-100" allowusinglimb="true" />
+    </Controller>
+  </Item>
+  <Item name="" identifier="opdeco_cabinetsdorm" allowattachitems="false" width="110" height="398" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="generic">
+    <Upgrade gameversion="0.16.2.0" refreshrect="true" PositionY="-88" />
+    <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1760,1360,117,309" depth="0.84" premultiplyalpha="false" origin="0.5,0.5" />
+    <ItemContainer capacity="6" slotsperrow="3" canbeselected="true" hideitems="true" msg="ItemMsgInteractSelect">
+      <GuiFrame relativesize="0.16,0.22" anchor="Center" style="ItemUI" />
+      <Containable items="smallitem,mediumitem" excludedidentifiers="mobilecontainer" />
+    </ItemContainer>
+    <!-- backwards compatibility for older versions in which mobile containers like storage containers were containable in any cabinet -->
+    <Upgrade gameversion="1.1.0.0" campaignsaveonly="true">
+      <ItemContainer>
+        <Containable items="smallitem,mediumitem" />
+        <ClearSubContainerRestrictions />
+      </ItemContainer>
+    </Upgrade>
+  </Item>
+  <Item name="" identifier="opdeco_trashcan" tags="outposttrashcan" width="122" height="201" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="generic" AllowStealingContainedItems="true">
+    <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1662,914,125,205" depth="0.97" premultiplyalpha="false" origin="0.5,0.5" />
+    <ItemContainer capacity="3" slotsperrow="3" canbeselected="true" hideitems="true" msg="ItemMsgInteractSelect">
+      <GuiFrame relativesize="0.18,0.25" anchor="Center" style="ItemUI" />
+      <Containable items="smallitem,mediumitem" />
+    </ItemContainer>
+  </Item>
+  <Item name="" identifier="opdeco_hrflyers" requirecampaigninteract="true" allowattachitems="true" width="416" height="224" texturescale="1.0,1.0" scale="0.5" category="Decorative" subcategory="office">
+    <sprite texture="Content/Map/Outposts/Art/HumanResourcesAssets.png" sourcerect="0,672,416,224" depth="0.98" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="opdeco_medcurtain" aliases="opdeco_medcurtainclosed,opdeco_medcurtainopen" category="Decorative" subcategory="researchmedical" width="416" height="32" scale="0.5">
+    <Sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="96,128,416,32" depth="0.49" premultiplyalpha="false" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="512,128,384,368" depth="0.48" premultiplyalpha="false" origin="0.5,0.05">
+      <Conditional targetitemcomponent="Controller" State="eq true" />
+    </DecorativeSprite>
+    <DecorativeSprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="896,128,128,368" depth="0.48" premultiplyalpha="false" origin="1.5,0.05">
+      <Conditional targetitemcomponent="Controller" State="ne true" />
+    </DecorativeSprite>
+    <Controller direction="None" canbepicked="true" istoggle="true" msg="ItemMsgPressSelect" />
+  </Item>
+  <Item name="" identifier="opdeco_medcurtain2" aliases="opdeco_medcurtainclosed,opdeco_medcurtainopen" nameidentifier="opdeco_medcurtain" category="Decorative" subcategory="researchmedical" width="416" height="32" scale="0.5">
+    <Sprite texture="Content/Map/Outposts/Art/MedBayAssets.png" sourcerect="96,128,416,32" depth="0.49" premultiplyalpha="false" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/MedicalColonyAssets.png" sourcerect="391,0,373,364" depth="0.48" premultiplyalpha="false" origin="0.5,0.05">
+      <Conditional targetitemcomponent="Controller" State="eq true" />
+    </DecorativeSprite>
+    <DecorativeSprite texture="Content/Map/Outposts/Art/MedicalColonyAssets.png" sourcerect="764,0,104,364" depth="0.48" premultiplyalpha="false" origin="1.5,0.05">
+      <Conditional targetitemcomponent="Controller" State="ne true" />
+    </DecorativeSprite>
+    <Controller direction="None" canbepicked="true" istoggle="true" msg="ItemMsgPressSelect" />
+  </Item>
+  <Item name="" identifier="defendableposition" tags="defendable" type="Controller" HiddenInGame="true" width="63" height="112" scale="0.5" category="Weapon">
+    <sprite texture="Content/Map/Outposts/Art/EngineerColonyModule.png" sourcerect="872,182,63,112" depth="0.0" premultiplyalpha="false" origin="0.5,0.5" />
+    <Controller allowingameediting="false" UserPos="5.0, -50.0" direction="Right" canbeselected="true"
+                AllowSelectingWhenSelectedByBot="false" AllowSelectingWhenSelectedByOther="true" msg="ItemMsgInteractSelect" />
+  </Item> 
+  <Item name="" identifier="discoball" nameidentifier="barequipment" width="101" height="99" scale="0.5" noninteractable="true" category="Decorative" subcategory="cafeteria">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="1,768,101,99" depth="0.899" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="bigspeaker" nameidentifier="barspeaker" width="190" height="175" scale="0.5" category="Decorative" subcategory="cafeteria">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="463,849,190,175" depth="0.899" premultiplyalpha="false" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="958,250,66,68" depth="0.48" premultiplyalpha="false" origin="0.5,0.5" offset="0,37" scaleanim="Sine" scaleanimspeed="52" scaleanimamount="0.02,0.02">
+      <AnimationConditional IsActive="true" targetitemcomponent="Powered" />
+      <AnimationConditional PowerConsumption="gt 0" targetitemcomponent="Powered" />
+    </DecorativeSprite>
+    <DecorativeSprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="958,250,66,68" depth="0.48" premultiplyalpha="false" origin="0.5,0.5" offset="0,-37" scaleanim="Sine" scaleanimspeed="52" scaleanimamount="0.02,0.02">
+      <AnimationConditional IsActive="true" targetitemcomponent="Powered" />
+      <AnimationConditional PowerConsumption="gt 0" targetitemcomponent="Powered" />
+    </DecorativeSprite>
+    <Powered IsActive="true" PowerConsumption="100">
+      <sound file="Content/Sounds/ClubMusic_ztrr.ogg" type="OnActive" range="1000.0" loop="true" volume="0.01" volumeproperty="PowerConsumption" selectionmode="Manual" mutebackgroundmusic="true" />
+      <sound file="Content/Sounds/ClubMusic_seafloor.ogg" type="OnActive" range="1000.0" loop="true" volume="0.01" volumeproperty="PowerConsumption" selectionmode="Manual" mutebackgroundmusic="true" />
+      <sound file="Content/Sounds/ClubMusic_alien.ogg" type="OnActive" range="1000.0" loop="true" volume="0.01" volumeproperty="PowerConsumption" selectionmode="Manual" mutebackgroundmusic="true" />
+      <sound file="Content/Sounds/ClubMusic_accordion.ogg" type="OnActive" range="1000.0" loop="true" volume="0.01" volumeproperty="PowerConsumption" selectionmode="Manual" mutebackgroundmusic="true" />
+      <TriggerComponent triggeredby="Human" force="0" radius="50">
+        <StatusEffect type="OnActive" target="This,Character" interval="0.5" CheckConditionalAlways="true" disabledeltatime="true">
+          <Conditional PowerConsumption="gt 0" targetitemcomponent="Powered" />
+          <Conditional IsBot="true" />
+          <Affliction identifier="stun" amount="0.22" />
+        </StatusEffect>
+      </TriggerComponent>
+    </Powered>
+    <CustomInterface canbeselected="true" ElementStates="true,0,100">
+      <GuiFrame relativesize="0.2,0.15" anchor="CenterLeft" pivot="BottomLeft" relativeoffset="0.006,-0.05" style="ItemUI" />      
+      <TickBox text="speaker.on" targetitemcomponent="Powered" propertyname="IsActive" ContinuousSignal="false" GetValueInterval="1" />
+      <IntegerInput text="speaker.trackselection" propertyname="ManuallySelectedSound" targetitemcomponent="Powered" min="0" max="3">
+        <StatusEffect type="OnUse" targettype="This">
+          <sound file="Content/Sounds/ClubMusic_transitionScratch.ogg" range="1000.0" />
+        </StatusEffect>
+      </IntegerInput>
+      <IntegerInput text="speaker.volume" targetitemcomponent="Powered" propertyname="PowerConsumption" min="0" max="100" step="10"/>
+    </CustomInterface>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <input name="toggle" displayname="connection.togglestate" />
+      <input name="set_state" displayname="connection.setstate" />
+    </ConnectionPanel>
+  </Item>
+  <Item name="" identifier="mediumspeaker" variantof="bigspeaker" width="142" height="246">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="883,0,142,246" depth="0.899" premultiplyalpha="false" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="896,328,118,118" depth="0.889" premultiplyalpha="false" origin="0.5,0.5" offset="0,-54" scaleanim="Sine" scaleanimspeed="20" scaleanimamount="0.01,0.01" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="958,250,66,68" depth="0.889" premultiplyalpha="false" origin="0.5,0.5" offset="-30,33" scale="0.8" scaleanim="Sine" scaleanimspeed="50" scaleanimamount="0.02,0.02" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="958,250,66,68" depth="0.889" premultiplyalpha="false" origin="0.5,0.5" offset="30,33" scale="0.8" scaleanim="Sine" scaleanimspeed="52" scaleanimamount="0.02,0.02" >
+      <AnimationConditional IsActive="true" targetitemcomponent="Powered" />
+      <AnimationConditional PowerConsumption="gt 0" targetitemcomponent="Powered" />
+    </DecorativeSprite>
+    <DecorativeSprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="901,250,51,53" depth="0.889" premultiplyalpha="false" origin="0.5,0.5" offset="-31,87" scaleanim="Sine" scaleanimspeed="50" scaleanimamount="0.02,0.02" >
+      <AnimationConditional IsActive="true" targetitemcomponent="Powered" />
+      <AnimationConditional PowerConsumption="gt 0" targetitemcomponent="Powered" />
+    </DecorativeSprite>
+    <DecorativeSprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="901,250,51,53" depth="0.889" premultiplyalpha="false" origin="0.5,0.5" offset="31,87" scaleanim="Sine" scaleanimspeed="52" scaleanimamount="0.02,0.02" >
+      <AnimationConditional IsActive="true" targetitemcomponent="Powered" />
+      <AnimationConditional PowerConsumption="gt 0" targetitemcomponent="Powered" />
+    </DecorativeSprite>
+  </Item>
+  <Item name="" identifier="smallspeaker" variantof="bigspeaker" width="67" height="119">
+    <sprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="796,102,67,119" depth="0.899" premultiplyalpha="false" origin="0.5,0.5" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="958,250,66,68" depth="0.889" premultiplyalpha="false" origin="0.5,0.5" offset="0,26" scale="0.8" scaleanim="Sine" scaleanimspeed="52" scaleanimamount="0.02,0.02" />
+    <DecorativeSprite texture="Content/Map/Outposts/Art/AdminResidentAssets.png" sourcerect="901,250,51,53" depth="0.889" premultiplyalpha="false" origin="0.5,0.5" offset="0,-30" scaleanim="Sine" scaleanimspeed="50" scaleanimamount="0.02,0.02" />
+  </Item>  
+  <Item name="" identifier="bucket" nameidentifier="bathhouseequipment" width="79" height="110" scale="0.5" noninteractable="true" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/Shop.png" sourcerect="491,5,79,110" depth="0.89" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="ladle" nameidentifier="bathhouseequipment" width="136" height="20" scale="0.5" noninteractable="true" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Outposts/Art/Shop.png" sourcerect="885,288,136,20" depth="0.89" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+  <Item name="" identifier="float" nameidentifier="shop_decoration" width="142" height="142" scale="0.5" noninteractable="true" category="Decorative" subcategory="shop">
+    <sprite texture="Content/Map/Outposts/Art/Shop.png" sourcerect="258,756,142,142" depth="0.89" premultiplyalpha="false" origin="0.5,0.5" />
+  </Item>
+</Items>

--- a/Reactorfix/OutpostItems.xml
+++ b/Reactorfix/OutpostItems.xml
@@ -984,22 +984,8 @@
       <SlotIcon slotindex="1" texture="Content/UI/StatusMonitorUI.png" sourcerect="192,448,64,64" origin="0.5,0.5" />
       <SlotIcon slotindex="2" texture="Content/UI/StatusMonitorUI.png" sourcerect="192,448,64,64" origin="0.5,0.5" />
       <SlotIcon slotindex="3" texture="Content/UI/StatusMonitorUI.png" sourcerect="192,448,64,64" origin="0.5,0.5" />
-      <RequiredItem items="idcard" type="Picked" msg="ItemMsgUnauthorizedAccess" ignoreineditor="true" />
-      <Containable items="fuelrod">
-        <StatusEffect type="OnContaining" target="This" AvailableFuel="80.0" disabledeltatime="true" />
-      </Containable>
-      <Containable items="fulguriumfuelrod">
-        <StatusEffect type="OnContaining" target="This" AvailableFuel="150.0" disabledeltatime="true" />
-      </Containable>
-      <Containable items="thoriumfuelrod">
-        <StatusEffect type="OnContaining" target="This" AvailableFuel="100.0" disabledeltatime="true" />
-      </Containable>
-      <Containable items="fulguriumfuelrodvolatile">
-        <StatusEffect type="OnContaining" target="This" AvailableFuel="150.0" disabledeltatime="true" />
-      </Containable>
-      <Containable items="huskfigurine">
-        <StatusEffect type="OnContaining" target="This" AvailableFuel="0" disabledeltatime="true" />
-      </Containable>
+      <RequiredItem items="idcard" type="Picked" msg="ItemMsgUnauthorizedAccess" ignoreineditor="true" />      
+      <Containable items="reactorfuel,reactoritem" />      
     </ItemContainer>
     <Repairable selectkey="Action" header="electricalrepairsheader" deteriorationspeed="0.125" mindeteriorationdelay="120" maxdeteriorationdelay="720" MinDeteriorationCondition="10" minsabotagecondition="10" AIRepairThreshold="50" fixDurationHighSkill="5" fixDurationLowSkill="25" msg="ItemMsgRepairWrench" hudpriority="10">
       <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI" />

--- a/Reactorfix/engineer_talent_items.xml
+++ b/Reactorfix/engineer_talent_items.xml
@@ -1,0 +1,822 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Items>
+  <Item name="" identifier="depletedfuel" category="Fuel,Material" maxstacksize="8"  Tags="smallitem" canbepicked="true" cargocontaineridentifier="metalcrate" allowasextracargo="true" inventoryiconcolor="110,120,110,255" spritecolor="110,120,110" scale="0.4" impactsoundtag="impact_metal_light">
+    <PreferredContainer primary="reactorcab"/>    
+    <Price baseprice="75" sold="false">
+      <Price storeidentifier="merchantoutpost" multiplier="1.3" />
+      <Price storeidentifier="merchantcity" multiplier="1.25" />
+      <Price storeidentifier="merchantresearch" />
+      <Price storeidentifier="merchantmilitary" multiplier="0.9" />
+      <Price storeidentifier="merchantmine" multiplier="0.9" />
+    </Price>
+    <Fabricate suitablefabricators="fabricator" requiredtime="15" requiresrecipe="true">
+      <RequiredSkill identifier="electrical" level="35" />
+      <RequiredItem identifier="fuelrod" mincondition="0.0" maxcondition="0.1" usecondition="false" />
+      <RequiredItem identifier="steel" />
+    </Fabricate>
+    <Fabricate suitablefabricators="fabricator" requiredtime="15" requiresrecipe="true">
+      <RequiredSkill identifier="electrical" level="35" />
+      <RequiredItem identifier="thoriumfuelrod" mincondition="0.0" maxcondition="0.1" usecondition="false" />
+      <RequiredItem identifier="steel" />
+    </Fabricate>
+    <Fabricate suitablefabricators="fabricator" requiredtime="25" requiresrecipe="true" amount="2">
+      <RequiredSkill identifier="electrical" level="35" />
+      <RequiredItem identifier="fulguriumfuelrod" mincondition="0.0" maxcondition="0.1" usecondition="false" />
+      <RequiredItem identifier="steel" />
+    </Fabricate>
+    <Fabricate suitablefabricators="fabricator" requiredtime="25" requiresrecipe="true" amount="2">
+      <RequiredSkill identifier="electrical" level="35" />
+      <RequiredItem identifier="fulguriumfuelrodvolatile" mincondition="0.0" maxcondition="0.1" usecondition="false" />
+      <RequiredItem identifier="steel" />
+    </Fabricate>
+    <Deconstruct time="30">
+      <Item identifier="steel" />
+    </Deconstruct>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="384,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" depth="0.55" sourcerect="452,1,19,68" />
+    <Body width="50" height="25" density="30" />
+    <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" handle1="0,0" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
+    </Holdable>
+    <AiTarget sightrange="1000" static="true" />
+  </Item>
+
+  <Item name="" identifier="coilgunammoboxdepletedfuel" scale="0.5" tags="coilgunequipment,coilgunammo,ammobox" allowasextracargo="true" category="Weapon" linkable="true" impactsoundtag="impact_metal_heavy">
+    <PreferredContainer primary="coilgunammoloader,ammoboxcontainer" mincondition="1"/>
+    <Price baseprice="280" sold="false" displaynonempty="true">
+      <Price storeidentifier="merchantoutpost" multiplier="1.3" />
+      <Price storeidentifier="merchantcity" multiplier="1.2" />
+      <Price storeidentifier="merchantresearch" multiplier="1.3" />
+      <Price storeidentifier="merchantmilitary" multiplier="0.9" />
+      <Price storeidentifier="merchantmine" multiplier="1.2" />
+    </Price>
+    <Fabricate suitablefabricators="fabricator" requiredtime="20" requiresrecipe="true">
+      <RequiredSkill identifier="weapons" level="40" />
+      <RequiredItem identifier="depletedfuel" />
+      <RequiredItem identifier="depletedfuel" />
+      <RequiredItem tag="munition_jacket" amount="2" description="fabricationdescription.munition_jacket" />
+      <RequiredItem identifier="aluminium" />
+    </Fabricate>
+    <Fabricate suitablefabricators="fabricator" displayname="recycleitem" requiredtime="15" requiresrecipe="true">
+      <RequiredSkill identifier="weapons" level="30" />
+      <RequiredItem identifier="depletedfuel" />
+      <RequiredItem identifier="depletedfuel" />
+      <RequiredItem tag="munition_jacket" amount="2" description="fabricationdescription.munition_jacket" />
+      <RequiredItem tag="ammobox" mincondition="0.0" maxcondition="0.1" usecondition="false" description="fabricationdescription.ammoboxrecycle" header="fabricationheader.ammoboxrecycle" defaultitem="coilgunammoboxdepletedfuel" />
+    </Fabricate>
+    <Deconstruct time="10">
+      <Item identifier="depletedfuel" mincondition="0.95" />
+      <Item identifier="aluminium" />
+    </Deconstruct>
+    <Sprite texture="Content/Items/Containers/containers.png" depth="0.54" sourcerect="560,878,95,78" origin="0.5,0.5" />
+    <Body width="115" height="88" density="30" />
+    <Holdable canbecombined="true" removeoncombined="false" slots="RightHand,LeftHand" holdpos="0,-30" handle1="0,-30" aimable="false" msg="ItemMsgPickUpSelect">
+      <StatValue stattype="MovementSpeed" value="-0.2" />
+    </Holdable>
+    <ItemContainer hideitems="true" capacity="1" drawinventory="false" canbeselected="false" canbecombined="true" ShowConditionInContainedStateIndicator="true" removecontaineditemsondeconstruct="true" containedstateindicatorstyle="bullet">
+      <StatusEffect type="OnUse" target="This" disabledeltatime="true">
+        <SpawnItem identifiers="depletedfuelbolt" spawnposition="ThisInventory" />
+      </StatusEffect>
+      <StatusEffect type="OnUse" target="This" condition="-0.5" disabledeltatime="true">
+        <RequiredItem items="depletedfuelbolt" type="Contained" />
+      </StatusEffect>
+      <Containable items="depletedfuelbolt" />
+    </ItemContainer>
+  </Item>
+  <Item name="" identifier="depletedfuelbolt" category="Weapon" scale="0.5" sonarsize="2" hideinmenus="true">
+    <Sprite texture="Content/Items/Weapons/weapons_new.png" sourcerect="143,425,113,9" depth="0.55" origin="0.5,0.5" />
+    <Body width="160" height="10" density="20" />
+    <Holdable slots="RightHand+LeftHand" holdpos="0,-50" handle1="-10,0" handle2="10,0" aimable="false" />
+    <Projectile characterusable="false" launchimpulse="80.0">
+      <Attack structuredamage="20" itemdamage="10" severlimbsprobability="0.25" penetration="0.4">
+        <Affliction identifier="lacerations" strength="15" />
+        <Affliction identifier="bleeding" strength="1.0" />
+        <Affliction identifier="stun" strength="0.025" />
+        <StatusEffect type="OnUse" target="UseTarget" disabledeltatime="true">
+          <Affliction identifier="radiationsickness" strength="12" />
+        </StatusEffect>
+      </Attack>
+      <StatusEffect type="OnActive" target="This" lifetime="2">
+        <ParticleEmitter particle="ammotrailwater" copyentityangle="true" anglemin="-5" anglemax="5" particleamount="5" velocitymin="-10" velocitymax="-100" scalemin="0.5" scalemax="1" colormultiplier="80,100,80" />
+      </StatusEffect>
+      <StatusEffect type="OnNotContained" target="This" stackable="false" delay="3">
+        <Remove />
+      </StatusEffect>
+      <StatusEffect type="OnImpact" target="This">
+        <ParticleEmitter particle="underwaterexplosion" copyentityangle="true" anglemin="0" anglemax="360" particleamount="1" scalemin="0.1" scalemax="0.25" colormultiplier="80,100,80" />
+        <ParticleEmitter particle="shrapnel" copyentityangle="true" anglemin="0" anglemax="360" particleamount="10" velocitymin="100" velocitymax="2000" scalemin="0.1" scalemax="0.25" />
+        <Remove />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
+    </Projectile>
+  </Item>
+  <Item name="" identifier="wrenchhardened" variantof="wrench" allowasextracargo="true" inventoryiconcolor="110,120,110,255" spritecolor="110,120,110" addedrepairspeedmultiplier="0.4">
+    <Preferredcontainer secondary="respawncontainer" amount="1"  spawnprobability="0" notcampaign="true"/>
+    <PreferredContainer primary="engcab"  spawnprobability="0"/>
+    <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab,piratestoragecab"  spawnprobability="0" />
+    <PreferredContainer primary="wreckengcab,abandonedengcab,pirateengcab,pirateengcab,outpostengcab,beaconengcab"  spawnprobability="0"/>
+    <PreferredContainer secondary="outpostcrewcabinet" spawnprobability="0"/>
+    <PreferredContainer secondary="outposttrashcan" spawnprobability="0" />
+    <Price baseprice="200" sold="false">
+      <Price storeidentifier="merchantoutpost" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" />
+      <Price storeidentifier="merchantresearch" />
+      <Price storeidentifier="merchantmilitary" />
+      <Price storeidentifier="merchantmine" />
+    </Price>
+    <Deconstruct>
+      <Item identifier="iron" />
+      <Item identifier="depletedfuel" />
+    </Deconstruct>
+    <Fabricate requiresrecipe="true">
+      <RequiredItem identifier="depletedfuel" amount="2" />
+      <RequiredItem identifier="wrench" />
+    </Fabricate>
+    <MeleeWeapon>
+      <Attack targetimpulse="8" penetration="0.25">
+        <Affliction identifier="blunttrauma" strength="8" />
+        <Affliction identifier="radiationsickness" strength="1" />
+        <Affliction identifier="stun" strength="0.3" />
+      </Attack>
+    </MeleeWeapon>
+  </Item>
+  <Item name="" identifier="crowbarhardened" variantof="crowbar" allowasextracargo="true" inventoryiconcolor="110,120,110,255" spritecolor="110,120,110" addedpickingspeedmultiplier="0.6">
+    <PreferredContainer secondary="respawncontainer" amount="1" spawnprobability="0" notcampaign="true"/>
+    <PreferredContainer primary="engcab" spawnprobability="0"/>
+    <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab,piratestoragecab" spawnprobability="0" />
+    <PreferredContainer primary="wreckengcab,abandonedengcab,pirateengcab,outpostengcab,beaconengcab" spawnprobability="0" />
+    <PreferredContainer secondary="outpostcrewcabinet" spawnprobability="0" />
+    <Price baseprice="200" sold="false" />
+    <Deconstruct>
+      <Item identifier="iron" />
+      <Item identifier="depletedfuel" />
+    </Deconstruct>
+    <Fabricate requiresrecipe="true">
+      <RequiredItem identifier="depletedfuel" amount="2" />
+      <RequiredItem identifier="crowbar" />
+    </Fabricate>
+    <MeleeWeapon>
+      <Attack targetimpulse="13" penetration="0.25">
+        <Affliction identifier="blunttrauma" strength="18" />
+        <Affliction identifier="radiationsickness" strength="1" />
+        <Affliction identifier="stun" strength="0.6" />
+      </Attack>
+    </MeleeWeapon>
+  </Item>
+  <Item name="" identifier="screwdriverhardened" variantof="screwdriver" allowasextracargo="true" inventoryiconcolor="110,120,110,255" spritecolor="110,120,110" addedrepairspeedmultiplier="0.4">
+    <PreferredContainer secondary="respawncontainer" spawnprobability="0" notcampaign="true"/>
+    <PreferredContainer primary="reactorcab,engcab" spawnprobability="0"/>
+    <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab,piratestoragecab"  spawnprobability="0"/>
+    <PreferredContainer primary="wreckengcab,abandonedengcab,pirateengcab,outpostengcab,beaconengcab" spawnprobability="0"/>
+    <PreferredContainer primary="wreckreactorcab,abandonedreactorcab,piratereactorcab" spawnprobability="0" />
+    <PreferredContainer secondary="outpostcrewcabinet" spawnprobability="0" />
+    <PreferredContainer secondary="outposttrashcan" spawnprobability="0" />
+    <Price baseprice="200" sold="false" />
+    <Deconstruct>
+      <Item identifier="iron" />
+      <Item identifier="depletedfuel" />
+    </Deconstruct>
+    <Fabricate requiresrecipe="true">
+      <RequiredItem identifier="depletedfuel" amount="2" />
+      <RequiredItem identifier="screwdriver" />
+    </Fabricate>
+    <MeleeWeapon>
+      <Attack targetimpulse="8" penetration="0.25">
+        <Affliction identifier="lacerations" strength="7" />
+        <Affliction identifier="radiationsickness" strength="1" />
+        <Affliction identifier="stun" strength="0.08" />
+        <Affliction identifier="bleeding" strength="2" />
+      </Attack>
+    </MeleeWeapon>
+  </Item>
+  <Item name="" identifier="divingknifehardened" variantof="divingknife" allowasextracargo="true" inventoryiconcolor="110,120,110,255" spritecolor="110,120,110">
+    <PreferredContainer secondary="wreckarmcab,abandonedarmcab,piratearmcab" spawnprobability="0"/>
+    <PreferredContainer secondary="abandonedstoragecab,piratestoragecab" spawnprobability="0"/>
+    <PreferredContainer secondary="beaconsupplycab" spawnprobability="0"/>
+    <PreferredContainer primary="armcab,secarmcab" spawnprobability="0" />
+    <Price baseprice="200" sold="false">
+      <Price storeidentifier="merchantoutpost" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" />
+      <Price storeidentifier="merchantresearch" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" />
+      <Price storeidentifier="merchantmine" />
+    </Price>
+    <Deconstruct>
+      <Item identifier="iron" />
+      <Item identifier="depletedfuel" />
+    </Deconstruct>
+    <Fabricate requiresrecipe="true">
+      <RequiredItem identifier="depletedfuel" amount="2" />
+      <RequiredItem identifier="divingknife" />
+    </Fabricate>
+    <MeleeWeapon>
+      <Attack targetimpulse="4" itemdamage="4" penetration="0.25">
+        <Affliction identifier="lacerations" strength="15" />
+        <Affliction identifier="bleeding" strength="5" />
+        <Affliction identifier="radiationsickness" strength="1" />
+        <Affliction identifier="stun" strength="0.2" />
+      </Attack>
+    </MeleeWeapon>
+  </Item>
+  <Item name="" identifier="revolverrounddepletedfuel" variantof="revolverround" allowasextracargo="true" inventoryiconcolor="110,120,110,255" spritecolor="110,120,110">
+    <PreferredContainer primary="revolver" spawnprobability="0"/>
+    <PreferredContainer primary="armcab" spawnprobability="0"/>
+    <PreferredContainer secondary="wrecksecarmcab,abandonedsecarmcab,piratesecarmcab" spawnprobability="0"/>
+    <PreferredContainer secondary="wreckarmcab,abandonedarmcab,piratearmcab" spawnprobability="0"/>
+    <PreferredContainer secondary="secarmcab" spawnprobability="0"/>
+    <PreferredContainer secondary="respawncontainer_kingofthehull" spawnprobability="0"/>
+    <Price baseprice="20" sold="false">
+      <Price storeidentifier="merchantoutpost" multiplier="1.4" />
+      <Price storeidentifier="merchantcity" />
+      <Price storeidentifier="merchantresearch" />
+      <Price storeidentifier="merchantmilitary" />
+      <Price storeidentifier="merchantmine" />
+    </Price>
+    <Fabricate suitablefabricators="fabricator" requiredtime="20" requiresrecipe="true" amount="12">
+      <RequiredSkill identifier="weapons" level="30" />
+      <RequiredSkill identifier="electrical" level="30" />
+      <RequiredItem tag="munition_propulsion" description="fabricationdescription.munition_propulsion" />
+      <RequiredItem identifier="depletedfuel" amount="1" />
+      <RequiredItem tag="munition_jacket" description="fabricationdescription.munition_jacket" />
+    </Fabricate>
+    <Sprite texture="Content/Items/Weapons/weapons_new.png" />
+    <Projectile>
+      <ParticleEmitter colormultiplier="200,255,80,175" />
+      <Attack structuredamage="10" targetforce="10" itemdamage="10" severlimbsprobability="0.2" penetration="0.25">
+        <Affliction identifier="bleeding" strength="10" />
+        <Affliction identifier="gunshotwound" strength="35" />
+        <Affliction identifier="stun" strength="0.3" />
+        <StatusEffect type="OnUse" target="UseTarget" disabledeltatime="true">
+          <Affliction identifier="radiationsickness" strength="16" />
+        </StatusEffect>
+      </Attack>
+    </Projectile>
+  </Item>
+  <Item name="" identifier="smgmagazinedepletedfuel" variantof="smgmagazine" allowasextracargo="true" inventoryiconcolor="110,120,110,255" spritecolor="110,120,110">
+    <PreferredContainer primary="smg,smgunique" spawnprobability="0"/>
+    <PreferredContainer primary="secarmcab" spawnprobability="0"/>
+    <PreferredContainer primary="outpostsecarmcab" spawnprobability="0"/>
+    <PreferredContainer primary="wrecksecarmcab" spawnprobability="0"/>
+    <PreferredContainer secondary="secarmcab" spawnprobability="0" />
+    <PreferredContainer secondary="respawncontainer_kingofthehull" spawnprobability="0"/>
+    <Price baseprice="160" sold="false" />
+    <Fabricate suitablefabricators="fabricator" requiredtime="30" requiresrecipe="true">
+      <RequiredSkill identifier="weapons" level="40" />
+      <RequiredSkill identifier="electrical" level="30" />
+      <RequiredItem tag="munition_propulsion" description="fabricationdescription.munition_propulsion" />
+      <RequiredItem identifier="depletedfuel" />
+      <RequiredItem tag="munition_jacket" description="fabricationdescription.munition_jacket" />
+      <RequiredItem identifier="steel" />
+    </Fabricate>
+    <Fabricate suitablefabricators="fabricator" requiredtime="18" requiresrecipe="true" displayname="recycleitem">
+      <RequiredSkill identifier="weapons" level="40" />
+      <RequiredSkill identifier="electrical" level="30" />
+      <RequiredItem tag="munition_propulsion" description="fabricationdescription.munition_propulsion" />
+      <RequiredItem identifier="depletedfuel" />
+      <RequiredItem tag="munition_jacket" description="fabricationdescription.munition_jacket" />
+      <RequiredItem identifier="smgmagazinedepletedfuel" mincondition="0.0" maxcondition="0.1" usecondition="false" />
+    </Fabricate>
+    <Deconstruct time="15">
+      <Item identifier="depletedfuel" mincondition="0.95" />
+      <Item identifier="steel" />
+    </Deconstruct>
+    <ItemContainer SpawnWithId="smgrounddepletedfuel">
+      <Containable items="smgrounddepletedfuel" />
+      <StatusEffect type="OnUse" target="This" condition="-4.8" disabledeltatime="true">
+        <SpawnItem identifiers="smgrounddepletedfuel" spawnposition="ThisInventory" />
+      </StatusEffect>
+    </ItemContainer>
+  </Item>
+  <Item name="" identifier="smgrounddepletedfuel" variantof="smground" inventoryiconcolor="110,120,110,255" spritecolor="110,120,110">
+    <Projectile>
+      <ParticleEmitter colormultiplier="200,255,80,175" />
+      <Attack structuredamage="5" targetforce="5" itemdamage="5" severlimbsprobability="0.1" penetration="0.25">
+        <Affliction identifier="bleeding" strength="5" />
+        <Affliction identifier="gunshotwound" strength="15" />
+        <Affliction identifier="stun" strength="0.15" />
+        <StatusEffect type="OnUse" target="UseTarget" disabledeltatime="true">
+          <Affliction identifier="radiationsickness" strength="8" />
+        </StatusEffect>
+      </Attack>
+    </Projectile>
+  </Item>
+  <Item name="" identifier="thermalgoggles" scale="0.5" category="Equipment" tags="smallitem" allowasextracargo="true" cargocontaineridentifier="metalcrate" description="" impactsoundtag="impact_metal_light">
+    <PreferredContainer primary="engcab"/>
+    <Price baseprice="350" sold="false">
+      <Price storeidentifier="merchantoutpost" multiplier="1.3" />
+      <Price storeidentifier="merchantcity" multiplier="1.2" />
+      <Price storeidentifier="merchantresearch" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" />
+      <Price storeidentifier="merchantmine" />
+    </Price>
+    <Deconstruct time="20">
+      <Item identifier="copper" />
+      <Item identifier="plastic" amount="2" />
+      <Item identifier="fulgurium" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="40" requiresrecipe="true">
+      <RequiredSkill identifier="electrical" level="50" />
+      <RequiredItem identifier="fpgacircuit" />
+      <RequiredItem identifier="plastic" />
+      <RequiredItem identifier="fulgurium" />
+    </Fabricate>
+    <InventoryIcon texture="Content/Items/JobGear/TalentGear.png" sourcerect="0,224,63,31" origin="0.5,0.5" />
+    <Sprite name="Thermal Goggles" texture="Content/Items/JobGear/TalentGear.png" sourcerect="0,224,64,31" depth="0.6" origin="0.5,0.5" />
+    <Body width="70" height="24" density="15" />
+    <Wearable limbtype="Head" slots="Any,Head" msg="ItemMsgPickUpSelect">
+      <sprite name="Thermal Goggles Wearable" texture="Content/Items/Jobgear/TalentGear.png" limb="Head" inheritlimbdepth="true" inheritscale="true" ignorelimbscale="true" scale="0.65" sourcerect="1,192,64,31" origin="0.4,0.5" />
+    </Wearable>
+    <StatusHUD drawhudwhenequipped="true" overlaycolor="176,0,0,120" range="3000" thermalgoggles="true" showdeadcharacters="false" showtexts="false" />
+  </Item>
+
+  <Item name="" identifier="reactorpda" category="Equipment" Tags="smallitem" cargocontaineridentifier="metalcrate" allowasextracargo="true" scale="0.5" impactsoundtag="impact_metal_light">
+    <PreferredContainer primary="engcab"/>    
+    <Price baseprice="150" sold="false">
+      <Price storeidentifier="merchantoutpost" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" />
+      <Price storeidentifier="merchantmine" />
+    </Price>
+    <Deconstruct time="15">
+      <Item identifier="copper" />
+      <Item identifier="plastic" amount="2" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="20" requiresrecipe="true">
+      <RequiredSkill identifier="electrical" level="30" />
+      <RequiredItem identifier="fpgacircuit" />
+      <RequiredItem identifier="plastic" />
+    </Fabricate>
+    <InventoryIcon texture="Content/Items/JobGear/TalentGear.png" sourcerect="160,1,40,58" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/JobGear/TalentGear.png" sourcerect="64,32,29,39" depth="0.55" origin="0.5,0.5" />
+    <Body width="30" height="40" density="15" />
+    <Holdable slots="Any,RightHand,LeftHand" holdangle="30" handle1="-10,0" msg="ItemMsgPickUpSelect" />
+    <RemoteController target="reactor" onlyinownsub="true" msg="ItemMsgInteractSelect" AllowInGameEditing="false" drawhudwhenequipped="true" />
+  </Item>
+
+  <Item name="" identifier="skillbookhandyseaman" cargocontaineridentifier="metalcrate" allowasextracargo="true" category="Misc" Tags="smallitem,skillbook" maxstacksize="8" scale="0.5" impactsoundtag="impact_soft">
+    <PreferredContainer primary="crewcab"/>
+    <Price baseprice="350" buyingpricemodifier="2.5" minleveldifficulty="40">
+      <Price storeidentifier="merchantoutpost" maxavailable="1" />
+      <Price storeidentifier="merchantcity" />
+      <Price storeidentifier="merchantresearch" maxavailable="1" />
+      <Price storeidentifier="merchantmilitary" />
+      <Price storeidentifier="merchantmine" />
+    </Price>
+    <Deconstruct time="20">
+      <Item identifier="carbon" />
+    </Deconstruct>
+    <InventoryIcon texture="Content/Items/JobGear/TalentGear.png" sourcerect="42,368,40,56" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/JobGear/TalentGear.png" sourcerect="36,74,32,39" devpth="0.6" origin="0.5,0.5" />
+    <Body width="28" height="36" density="20" />
+    <MeleeWeapon slots="Any,RightHand+LeftHand" aimable="false" aimpos="40,-20" handle1="5,0" holdangle="80" swingamount="0,3" swingspeed="0.5" swingwhenaiming="true" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="OnSecondaryUse" target="This" Condition="-10.0" />
+      <StatusEffect type="OnSecondaryUse" target="This,Character" disabledeltatime="true">
+        <Conditional Condition="lte 0" />
+        <GiveSkill skillidentifier="electrical" amount="7" triggertalents="false" />
+        <GiveSkill skillidentifier="mechanical" amount="7" triggertalents="false" />
+        <RemoveItem />
+      </StatusEffect>
+    </MeleeWeapon>
+  </Item>
+  <Item name="" identifier="nucleargun" category="Weapon" cargocontaineridentifier="metalcrate" allowasextracargo="true" tags="mediumitem,weapon,gun,mountableweapon,provocativetohumanai" Scale="0.5" impactsoundtag="impact_metal_heavy">
+    <PreferredContainer primary="secarmcab" secondary="weaponholder,armcab"/>
+    <Price baseprice="900" sold="false">
+      <Price storeidentifier="merchantoutpost" multiplier="1.5" />
+      <Price storeidentifier="merchantcity" multiplier="1.25" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" />
+      <Price storeidentifier="merchantmilitary" multiplier="0.9" minavailable="1" maxavailable="2" sold="true">
+        <Reputation faction="coalition" min="70"/>
+      </Price>
+      <Price storeidentifier="merchantmine" multiplier="1.25" />
+    </Price>
+    <Deconstruct time="10">
+      <Item identifier="copper" />
+      <Item identifier="plastic" />
+      <Item identifier="lead" />
+      <Item identifier="titaniumaluminiumalloy" />
+      <Item identifier="fulgurium" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="70" requiresrecipe="true">
+      <RequiredSkill identifier="electrical" level="65" />
+      <RequiredItem identifier="fpgacircuit" />
+      <RequiredItem identifier="lead" amount="2"/>
+      <RequiredItem identifier="titaniumaluminiumalloy" amount="2" />
+      <RequiredItem identifier="fulgurium" amount="2" />
+    </Fabricate>
+    <Sprite texture="Content/Items/JobGear/TalentGear.png" sourcerect="271,127,240,66" depth="0.55" origin="0.5,0.5" />
+    <Body width="238" height="63" density="25" />
+    <Holdable slots="RightHand+LeftHand" controlpose="true" holdpos="60,-15" aimpos="70,4" handle1="-50,-10" handle2="10,-3" holdangle="-25" />
+    <Wearable slots="Bag" msg="ItemMsgEquipSelect" canbeselected="false" canbepicked="true" pickkey="Select">
+      <sprite name="Nuclear Gun Worn" texture="Content/Items/JobGear/TalentGear.png" canbehiddenbyotherwearables="false" rotation="90" depth="0.6" sourcerect="270,127,240,66" limb="Torso" depthlimb="LeftArm" scale="0.5" origin="0.5,0.8" />
+    </Wearable>
+    <RangedWeapon reload="0.5" holdtrigger="true" barrelpos="118,14" spread="0" unskilledspread="10" combatPriority="80" drawhudwhenequipped="true" crosshairscale="0.2" maxchargetime="0.75" ChargeSoundWindupPitchSlide="0.5,1.5">
+      <Crosshair texture="Content/Items/Weapons/Crosshairs.png" sourcerect="0,256,256,256" />
+      <CrosshairPointer texture="Content/Items/Weapons/Crosshairs.png" sourcerect="256,256,256,256" />
+      <ParticleEmitter particle="FlareBubbles" scalemin="1.4" scalemax="1.8" particleamount="14" anglemin="0" anglemax="360" velocitymin="0" velocitymax="50" />
+      <ParticleEmitter particle="GlowDot" scalemin="4.0" scalemax="4.0" particleamount="20" anglemin="0" anglemax="360" velocitymin="0" velocitymax="0" colormultiplier="10,235,195,255" />
+      <ParticleEmitterCharge particle="chargenucleargun" particlespersecond="60" scalemultiplier="0.75,0.75" scalemin="1.0" scalemax="1.0" anglemax="360" />
+      <Sound file="Content/Items/JobGear/Engineer/WEAPONS_rapidFissileAccelerator.ogg" type="OnUse" range="3000" selectionmode="Random" />
+      <Sound file="Content/Items/JobGear/Engineer/WEAPONS_rapidFissileAccelerator2.ogg" type="OnUse" range="3000" />
+      <Sound file="Content/Items/JobGear/Engineer/WEAPONS_rapidFissileAccelerator3.ogg" type="OnUse" range="3000" />
+      <Sound file="Content/Items/JobGear/Engineer/WEAPONS_rapidFissileAccelerator4.ogg" type="OnUse" range="3000" />
+      <ChargeSound file="Content/Items/JobGear/Engineer/WEAPONS_rapidFissileAcceleratorStartLoop.ogg" range="1000" />
+      <StatusEffect type="OnUse" target="This">
+        <Explosion range="150.0" force="3" shockwave="false" smoke="false" flash="true" sparks="false" flames="false" underwaterbubble="false" camerashake="6.0" />
+      </StatusEffect>
+      <StatusEffect type="OnUse" target="Contained">
+        <Use />
+      </StatusEffect>
+      <RequiredItems items="reactorfuel" type="Contained" msg="ItemMsgAmmoRequired" />
+      <RequiredSkill identifier="weapons" level="25" />
+      <RequiredSkill identifier="electrical" level="45" />
+    </RangedWeapon>
+    <ItemContainer capacity="1" maxstacksize="1" hideitems="false" itempos="10,-5" containedspritedepths="0.562,0.561" containedstateindicatorstyle="default" containedstateindicatorslot="0">
+      <Containable items="reactorfuel" rotation="90"/>
+      <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="192,448,64,64" origin="0.5,0.5" />
+      <SlotIcon slotindex="1" texture="Content/UI/StatusMonitorUI.png" sourcerect="320,448,64,64" origin="0.5,0.5" />
+      <SubContainer capacity="1" maxstacksize="1">
+        <Containable items="flashlight" hide="false" itempos="25,0" setactive="true"/>
+      </SubContainer>
+    </ItemContainer>
+    <aitarget sightrange="3000" soundrange="5000" fadeouttime="5" />
+    <Quality>
+      <QualityStat stattype="FirepowerMultiplier" value="0.1" />
+    </Quality>
+    <SkillRequirementHint identifier="weapons" level="25" />
+    <SkillRequirementHint identifier="electrical" level="45" />
+  </Item>
+  <Item name="nucleargunbolt" identifier="nucleargunbolt" category="Weapon" scale="0.5" sonarsize="2" hideinmenus="true">
+    <Sprite texture="Content/Items/Weapons/weapons_new.png" sourcerect="143,414,113,9" depth="0.55" origin="0.5,0.5" />
+    <Body width="170" height="10" density="20" />
+    <Holdable slots="RightHand+LeftHand" holdpos="0,-50" handle1="-10,0" handle2="10,0" aimable="false" />
+    <Projectile characterusable="false" hitscan="true" removeonhit="true">
+      <ParticleEmitter particle="tracernucleargun" particleamount="1" velocitymin="0" velocitymax="0" scalemultiplier="1,0.75" />
+      <ParticleEmitter particle="FlareBubbles" emitacrossrayinterval="50" />
+      <Attack structuredamage="35" targetforce="5" itemdamage="35" severlimbsprobability="0.5" penetration="0.5">
+        <Affliction identifier="explosiondamage" strength="50" />
+        <Affliction identifier="radiationsickness" strength="25" />
+        <Affliction identifier="stun" strength="0.5" />
+      </Attack>
+      <StatusEffect type="OnImpact" target="UseTarget">
+        <ParticleEmitter particle="muzzleflashnucleargun" anglemin="0" anglemax="360" particleamount="10" velocitymin="0" scalemin="0.5" scalemax="0.8" scalemultiplier="0.75,0.75" />
+        <ParticleEmitter particle="weldspark" particleamount="5" anglemin="0" anglemax="360" velocitymin="300" velocitymax="350" scalemin="1.5" scalemax="1.9" drawontop="true" colormultiplier="150,255,195,180" />
+        <ParticleEmitter particle="FlareBubbles" particleamount="3" anglemin="0" anglemax="360" velocitymin="0" velocitymax="50" />
+      </StatusEffect>
+      <StatusEffect type="OnImpact" target="UseTarget">
+        <Conditional entitytype="eq Structure" />
+        <Conditional hastag="eq door" />
+        <ParticleEmitter particle="spark" copyentityangle="true" anglemin="-10" anglemax="10" particleamount="5" velocitymin="-10" velocitymax="-200" scalemin="0.5" scalemax="1" />
+      </StatusEffect>
+      <StatusEffect type="OnImpact" target="UseTarget" disabledeltatime="true">
+        <Explosion range="125.0" ballastfloradamage="50" structuredamage="0" itemdamage="0" force="5.0" flames="false" smoke="false" sparks="false" underwaterbubble="false" flashcolor="255,0,0,255" penetration="1">
+          <Affliction identifier="burn" strength="25" />
+          <Affliction identifier="radiationsickness" strength="80" />
+          <Affliction identifier="stun" strength="1" />
+        </Explosion>
+      </StatusEffect>
+      <StatusEffect type="OnNotContained" target="This">
+        <Remove />
+      </StatusEffect>
+    </Projectile>
+  </Item>
+  <Item name="" identifier="cargoscooter" category="Equipment,Diving" Tags="mediumitem,provocative,scooter,mobilecontainer" allowasextracargo="true" cargocontaineridentifier="metalcrate" description="" Scale="0.5" impactsoundtag="impact_metal_heavy" isshootable="true">
+    <PreferredContainer primary="divingcab"/>    
+    <Price baseprice="400" sold="false">
+      <Price storeidentifier="merchantoutpost" multiplier="0.9" />
+      <Price storeidentifier="merchantcity" multiplier="0.85" />
+      <Price storeidentifier="merchantresearch" />
+      <Price storeidentifier="merchantmilitary" />
+      <Price storeidentifier="merchantmine" multiplier="1.25" />
+    </Price>
+    <Deconstruct time="20">
+      <Item identifier="aluminium" />
+      <Item identifier="copper" />
+      <Item identifier="tin" />
+      <Item identifier="plastic" />
+      <Item identifier="titaniumaluminiumalloy" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="30" requiresrecipe="true">
+      <RequiredSkill identifier="mechanical" level="30" />
+      <RequiredItem identifier="underwaterscooter" />
+      <RequiredItem identifier="titaniumaluminiumalloy" amount="2" />
+    </Fabricate>
+    <InventoryIcon texture="Content/Items/JobGear/TalentGear.png" sourcerect="131,123,53,58" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/JobGear/TalentGear.png" depth="0.55" sourcerect="295,195,149,105" origin="0.5,0.5" />
+    <Body width="140" height="100" density="10" />
+    <Holdable slots="RightHand+LeftHand" aimpos="90,0" handle1="-35,32" handle2="-27,34" msg="ItemMsgPickUpSelect" holdangle="-10">
+      <LightComponent LightColor="220,255,150,200" range="500" powerconsumption="10" IsOn="true">
+        <Upgrade gameversion="1.1.2.0" powerconsumption="10" />
+        <LightTexture texture="Content/Lights/lightcone.png" origin="-0.01, 0.5" size="1.0,1.0" />
+      </LightComponent>
+      <!-- activates the light when holding aim -->
+      <StatusEffect type="OnSecondaryUse" target="This" voltage="1.0" setvalue="true">
+        <RequiredItem items="mobilebattery" type="Contained" />
+      </StatusEffect>
+      <!-- Battery drain when using the light, adds up with propulsion -->
+      <StatusEffect type="OnSecondaryUse" target="Contained" targetslot="0" Condition="-0.05" />
+    </Holdable>
+    <Propulsion force="150" usablein="water" particles="bubbles">
+      <RequiredItems items="mobilebattery" targetslot="0" type="Contained" msg="ItemMsgBatteryCellRequired" />
+      <StatusEffect type="OnUse" target="Contained" targetslot="0" Condition="-0.2">
+        <RequiredItem items="mobilebattery" type="Contained" />
+      </StatusEffect>
+      <sound file="Content/Items/Diving/ScooterLoop.ogg" type="OnUse" range="500.0" loop="true" />
+    </Propulsion>
+    <ItemContainer capacity="1" maxstacksize="1" slotsperrow="3" hideitems="true" containedstateindicatorslot="0" containedstateindicatorstyle="battery">
+      <Containable items="mobilebattery" />
+      <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="128,448,64,64" origin="0.5,0.5" />
+      <SubContainer capacity="11" maxstacksize="32">
+        <Containable items="smallitem,mediumitem" excludeditems="toolbelt,toolbox,bandolier,cargoscooter,largemobilecontainer" />
+      </SubContainer>
+    </ItemContainer>
+    <AiTarget soundrange="3000" maxsightrange="3000" />
+  </Item>
+  <Item name="" identifier="handheldelectricalmonitor" category="Equipment" Tags="smallitem,sonar,provocative" allowasextracargo="true" cargocontaineridentifier="metalcrate" Scale="0.5" impactsoundtag="impact_metal_light">
+    <PreferredContainer primary="engcab"/>
+    <Price baseprice="150" sold="false">
+      <Price storeidentifier="merchantoutpost" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" />
+      <Price storeidentifier="merchantmine" />
+    </Price>
+    <Deconstruct time="15">
+      <Item identifier="copper" />
+      <Item identifier="plastic" amount="2" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="20" requiresrecipe="true">
+      <RequiredSkill identifier="electrical" level="25" />
+      <RequiredItem identifier="fpgacircuit" />
+      <RequiredItem identifier="plastic" />
+    </Fabricate>
+    <InventoryIcon texture="Content/Items/JobGear/TalentGear.png" sourcerect="139,64,52,57" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/JobGear/TalentGear.png" sourcerect="97,35,33,36" depth="0.55" origin="0.5,0.5" />
+    <Body width="32" height="35" density="20" />
+    <AiTarget sight="500" staticsight="true" />
+    <Holdable slots="Any,RightHand,LeftHand" holdangle="30" handle1="-10,0" msg="ItemMsgPickUpSelect" />
+    <MiniMap enableitemfinder="false" enablehullstatus="false" enablehullcondition="false" drawhudwhenequipped="true" displaybordersize="-0.1" characterusable="false" allowuioverlap="true">
+      <GuiFrame relativesize="0.4,0.4" anchor="CenterRight" relativeoffset="0.006,-0.01" style="ItemUI" />
+    </MiniMap>
+  </Item>
+  <Item name="" identifier="pucs" category="Equipment,Diving" tags="diving,deepdiving,divinggear_wearableindoors,human" allowasextracargo="true" scale="0.5" fireproof="true" description="" allowdroppingonswapwith="diving" impactsoundtag="impact_metal_heavy" botpriority="5" cargocontaineridentifier="">
+    <PreferredContainer primary="divingsuitcontainer" spawnprobability="0.0" />    
+    <Price baseprice="670" sold="false">
+      <Price storeidentifier="merchantoutpost" />
+      <Price storeidentifier="merchantcity" minavailable="0" maxavailable="3" sold="true">
+        <Reputation faction="coalition" min="70"/>
+      </Price>
+      <Price storeidentifier="merchantresearch" multiplier="1.2" />
+      <Price storeidentifier="merchantmilitary" />
+      <Price storeidentifier="merchantmine" multiplier="1.1" />
+    </Price>
+    <Deconstruct time="45">
+      <Item identifier="titaniumaluminiumalloy" />
+      <Item identifier="titaniumaluminiumalloy" />
+      <Item identifier="rubber" />
+      <Item identifier="lead" />
+      <Item identifier="physicorium" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="80" requiresrecipe="true">
+      <RequiredSkill identifier="electrical" level="60" />
+      <RequiredItem identifier="combatdivingsuit" />
+      <RequiredItem identifier="lead" />
+      <RequiredItem identifier="physicorium" />
+    </Fabricate>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas2.png" sourcerect="384,704,128,128" origin="0.5,0.5" />
+    <Sprite name="PUCS Item" texture="Content/Items/Jobgear/Engineer/PUCS_Items.png" sourcerect="0,0,154,134" depth="0.55" origin="0.5,0.5" />
+    <ContainedSprite name="PUCS In Vertical Locker" allowedcontainertags="divingsuitcontainervertical" texture="Content/Items/Jobgear/Engineer/PUCS_Items.png" sourcerect="164,0,87,190" depth="0.55" origin="0.5,0.5" />
+    <ContainedSprite name="PUCS Behind Window" allowedcontainertags="divingsuitcontainerwindow" texture="pucs.png" sourcerect="430,0,80,207" depth="0.55" origin="-0.12,-0.14" />
+    <ContainedSprite name="PUCS In Horizontal Locker" allowedcontainertags="divingsuitcontainerhorizontal" texture="Content/Items/Jobgear/Engineer/PUCS_Items.png" sourcerect="0,191,225,66" depth="0.55" origin="0.6,0.5" />
+    <Body radius="45" width="34" density="20" />
+    <Wearable slots="OuterClothes" msg="ItemMsgEquipSelect" displaycontainedstatus="true" canbeselected="false" canbepicked="true" pickkey="Select">
+      <sprite name="PUCS Helmet Wearable" texture="Content/Items/Jobgear/headgears.png" limb="Head" inheritlimbdepth="true" inheritscale="true" ignorelimbscale="true" scale="0.65" hidelimb="false" alphaclipotherwearables="true" sourcerect="127,520,105,124" origin="0.57,0.38">
+        <LightComponent range="200.0" lightcolor="250,224,165,255" powerconsumption="10" IsOn="true" allowingameediting="false">
+          <StatusEffect type="OnWearing" target="This,Character" Voltage="1.0" Interval="0.1" setvalue="true">
+            <Conditional IsDead="false" />
+          </StatusEffect>
+          <LightTexture texture="Content/Lights/divinghelmetlight.png" origin="0.05, 0.5" size="1.0,1.0" />
+        </LightComponent>
+      </sprite>
+      <sprite name="pucs Torso" texture="pucs.png" limb="Torso" hidelimb="true" inherittexturescale="true" hideotherwearables="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="pucs Right Hand" texture="pucs.png" limb="RightHand" hidelimb="true" inherittexturescale="true" hideotherwearables="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="pucs Left Hand" texture="pucs.png" limb="LeftHand" hidelimb="true" inherittexturescale="true" hideotherwearables="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="pucs Right Upper Arm" texture="pucs.png" limb="RightArm" depthlimb="RightForearm" hidelimb="true" inherittexturescale="true" hideotherwearables="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="pucs Left Upper Arm" texture="pucs.png" limb="LeftArm" hidelimb="true" inherittexturescale="true" hideotherwearables="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="pucs Right Lower Arm" texture="pucs.png" limb="RightForearm" depthlimb="RightArm" hidelimb="true" inherittexturescale="true" hideotherwearables="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="pucs Left Lower Arm" texture="pucs.png" limb="LeftForearm" hidelimb="true" inherittexturescale="true" hideotherwearables="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="pucs Waist" texture="pucs.png" limb="Waist" hidelimb="true" inherittexturescale="true" hideotherwearables="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="pucs Right Thigh" texture="pucs.png" limb="RightThigh" hidelimb="true" inherittexturescale="true" hideotherwearables="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="pucs Left Thigh" texture="pucs.png" limb="LeftThigh" hidelimb="true" inherittexturescale="true" hideotherwearables="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="pucs Right Leg" texture="pucs.png" limb="RightLeg" hidelimb="true" inherittexturescale="true" hideotherwearables="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="pucs Left Leg" texture="pucs.png" limb="LeftLeg" hidelimb="true" inherittexturescale="true" hideotherwearables="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="pucs Left Shoe" texture="pucs.png" limb="LeftFoot" sound="footstep_armor_heavy" hidelimb="true" inherittexturescale="true" hideotherwearables="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="pucs Right Shoe" texture="pucs.png" limb="RightFoot" sound="footstep_armor_heavy" hidelimb="true" inherittexturescale="true" hideotherwearables="true" inheritorigin="true" inheritsourcerect="true" />
+      <StatusEffect type="OnWearing" target="Character" UseHullOxygen="true" ObstructVisionAmount="0.5" PressureProtection="6200.0" LowPassMultiplier="0.2" setvalue="true" disabledeltatime="true">
+        <Sound file="Content/Items/Diving/DivingSuitLoop1.ogg" range="250" loop="true"/>
+        <Sound file="Content/Items/Diving/DivingSuitLoop2.ogg" range="250" loop="true"/>
+        <TriggerAnimation Type="Walk" FileName="HumanWalkDivingSuit" priority="1" ExpectedSpecies="Human" />
+        <!-- high prio for run animation so e.g. affliction-based run animations won't make the character run faster -->
+        <TriggerAnimation Type="Run" FileName="HumanRunDivingSuit" priority="10" ExpectedSpecies="Human" />
+      </StatusEffect>
+      <!-- Refill oxygen when the suit is contained. -->
+      <StatusEffect type="OnContained" target="Contained" Condition="1.0" targetslot="0" interval="1" disabledeltatime="true">
+        <Conditional Voltage="gt 0.01" targetcontainer="true" targetgrandparent="true" targetitemcomponent="Powered" />
+        <RequiredItem items="refillableoxygensource" type="Contained" excludebroken="false" />
+      </StatusEffect>      
+      <StatusEffect type="OnWearing" target="Contained,Character" UseHullOxygen="false" OxygenAvailable="1000.0" comparison="And" targetslot="0">
+        <RequiredItem items="oxygensource" type="Contained" />
+      </StatusEffect>
+      <!-- consume oxygen if not in water and there's not enough oxygen in the hull -->
+      <StatusEffect type="OnWearing" target="Contained" UseHullOxygen="false" Condition="-0.3" comparison="And" targetslot="0">
+        <Conditional targetcontainer="true" targetgrandparent="true" IsDead="false" />
+        <Conditional targetcontainer="true" targetgrandparent="true" DecreasedOxygenConsumption="lt 99" />
+        <Conditional targetcontainer="true" targetgrandparent="true" HullOxygenPercentage="lt 50" />
+        <Conditional targetcontainer="true" targetgrandparent="true" NeedsAir="true" />
+        <Conditional InWater="false" />        
+        <RequiredItem items="oxygensource" type="Contained" />
+      </StatusEffect>
+      <!-- consume oxygen if in water -->
+      <StatusEffect type="OnWearing" target="Contained" UseHullOxygen="false" Condition="-0.3" comparison="And" targetslot="0">
+        <Conditional targetcontainer="true" targetgrandparent="true" IsDead="false" />
+        <Conditional targetcontainer="true" targetgrandparent="true" DecreasedOxygenConsumption="lt 99" />
+        <Conditional targetcontainer="true" targetgrandparent="true" NeedsAir="true" />
+        <Conditional InWater="true" />
+        <RequiredItem items="oxygensource" type="Contained" />
+      </StatusEffect>
+      <damagemodifier armorsector="0.0,360.0" afflictionidentifiers="blunttrauma,gunshotwound,bitewounds,lacerations,bleeding,explosiondamage" damagemultiplier="0.8" damagesound="LimbArmor" deflectprojectiles="true" />
+      <damagemodifier armorsector="0.0,360.0" afflictiontypes="burn" damagemultiplier="0.1" damagesound="" deflectprojectiles="true" />
+      <damagemodifier armorsector="0.0,360.0" afflictionidentifiers="radiationsickness" damagemultiplier="0.25" damagesound="LimbArmor" />
+      <damagemodifier armorsector="0.0,360.0" afflictionidentifiers="huskinfection" probabilitymultiplier="0.5" damagesound="LimbArmor" />
+      <StatValue stattype="WalkingSpeed" value="0.3" />
+      <StatValue stattype="SwimmingSpeed" value="0.05" />
+      <StatValue stattype="PropulsionSpeed" value="-0.2" />
+      <ItemComponent IsActiveConditionalComparison="Or">
+        <IsActive HullOxygenPercentage="lt 50" />
+        <IsActive InWater="eq true" />
+        <StatusEffect type="OnActive" target="Contained,Character" comparison="And">
+          <RequiredItem items="oxygensource" type="Contained" />
+          <Conditional condition="lt 5.0" />
+          <Sound file="Content/Items/WarningBeepSlow.ogg" range="250" loop="true"/>
+        </StatusEffect>
+        <StatusEffect type="OnActive" target="Contained" playsoundonrequireditemfailure="true">
+          <RequiredItem items="oxygensource" type="Contained" matchonempty="true" />
+          <Conditional condition="lte 0.0" />
+          <Sound file="Content/Items/WarningBeep.ogg" range="250" loop="true"/>
+        </StatusEffect>
+      </ItemComponent>
+    </Wearable>
+    <Holdable slots="RightHand+LeftHand" controlpose="true" holdpos="0,-50" handle1="-10,-20" handle2="10,-20" holdangle="45" msg="ItemMsgPickUpUse" canbeselected="false" canbepicked="true" pickkey="Use" />
+    <ItemContainer capacity="0" maxstacksize="0" hideitems="true" containedstateindicatorstyle="tank" containedstateindicatorslot="0" autoinject="true">
+      <Containable items="none" />
+      <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
+      <SlotIcon slotindex="1" texture="Content/UI/StatusMonitorUI.png" sourcerect="384,448,64,64" origin="0.5,0.5" />
+      <SubContainer capacity="1" maxstacksize="1">
+        <Containable items="oxygensource,weldingtoolfuel" excludeditems="oxygenitetank" />
+        <Containable items="oxygenitetank">
+          <StatusEffect type="OnWearing" target="Character" SpeedMultiplier="1.2" setvalue="true" comparison="And" targetslot="0">
+            <Conditional IsDead="false" />
+            <Conditional HullOxygenPercentage="lt 50" />
+            <Conditional DecreasedOxygenConsumption="lt 99" />
+            <Conditional NeedsAir="true" />
+          </StatusEffect>
+        </Containable>
+        <Containable items="weldingfueltank" blameequipperfordeath="true">
+          <StatusEffect type="OnWearing" target="Contained" Condition="-0.5" comparison="And">
+            <Conditional TargetContainer="true" TargetGrandparent="true" IsDead="false" />
+            <Conditional TargetContainer="true" TargetGrandparent="true" DecreasedOxygenConsumption="lt 99" />
+            <Conditional TargetContainer="true" TargetGrandparent="true" NeedsAir="true" />
+          </StatusEffect>
+          <StatusEffect type="OnWearing" target="Character" OxygenAvailable="-100.0" Oxygen="-5.0" comparison="And">
+            <Conditional IsDead="false" />
+            <Conditional DecreasedOxygenConsumption="lt 99" />
+            <Conditional NeedsAir="true" />
+          </StatusEffect>
+        </Containable>
+        <Containable items="incendiumfueltank" blameequipperfordeath="true">
+          <StatusEffect type="OnWearing" target="Contained" Condition="-0.5" comparison="And">
+            <Conditional TargetContainer="true" TargetGrandparent="true" IsDead="false" />
+            <Conditional TargetContainer="true" TargetGrandparent="true" DecreasedOxygenConsumption="lt 99" />
+            <Conditional TargetContainer="true" TargetGrandparent="true" NeedsAir="true" />
+          </StatusEffect>
+          <StatusEffect type="OnWearing" target="Character" OxygenAvailable="-100.0" comparison="And" targetlimb="Torso">
+            <Affliction identifier="burn" amount="20.0"  />
+            <Conditional IsDead="false" />
+            <Conditional DecreasedOxygenConsumption="lt 99" />
+            <Conditional NeedsAir="true" />
+          </StatusEffect>
+        </Containable>
+      </SubContainer>
+      <SubContainer capacity="1" maxstacksize="1">
+        <Containable items="chem,syringe" />
+      </SubContainer>
+    </ItemContainer>
+    <aitarget maxsightrange="1500" />
+  </Item>
+  <Item name="" identifier="fulguriumfuelrodvolatile" category="Fuel" Tags="smallitem,reactorfuel" maxstacksize="8" allowasextracargo="true" cargocontaineridentifier="metalcrate" health="400" scale="0.5">
+    <PreferredContainer primary="reactorcab"/>
+    <Price baseprice="400" sold="false" displaynonempty="true">
+      <Price storeidentifier="merchantoutpost" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" />
+      <Price storeidentifier="merchantmine" multiplier="1.1" />
+    </Price>
+    <Deconstruct time="15">
+      <Item identifier="steel" />
+      <Item identifier="lead" />
+      <Item identifier="fulgurium" mincondition="0.95" />
+      <Item identifier="thorium" mincondition="0.95" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="25" requiresrecipe="true">
+      <RequiredSkill identifier="electrical" level="70" />
+      <RequiredItem identifier="steel" />
+      <RequiredItem identifier="lead" amount="2" />
+      <RequiredItem identifier="fulgurium" />
+      <RequiredItem identifier="thorium" />
+    </Fabricate>
+    <Fabricate suitablefabricators="fabricator" displayname="recycleitem" requiredtime="10" requiresrecipe="true">
+      <RequiredSkill identifier="electrical" level="70" />
+      <RequiredItem identifier="fulgurium" />
+      <RequiredItem identifier="thorium" />
+      <RequiredItem identifier="fulguriumfuelrodvolatile" mincondition="0.0" maxcondition="0.1" usecondition="false" />
+    </Fabricate>
+    <InventoryIcon texture="Content/Items/JobGear/TalentGear.png" sourcerect="67,176,62,61" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/JobGear/TalentGear.png" depth="0.55" sourcerect="190,60,20,71" origin="0.5,0.5" />
+    <Body radius="6" height="55" density="30" />
+    <LightComponent allowingameediting="false" lightcolor="60,200,150,150" canbeselected="false" range="300.0" ison="true" />
+    <Holdable handle1="0,0" slots="Any,RightHand,LeftHand" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="Always" target="NearbyCharacters" range="125" interval="1" disabledeltatime="true">
+        <Affliction identifier="radiationsickness" strength="1" />
+      </StatusEffect>
+    </Holdable>
+    <ItemContainer hideitems="true" capacity="1" itemrotation="90" drawinventory="false" canbeselected="false" SpawnWithId="nucleargunbolt" removecontaineditemsondeconstruct="true" showcontainedstateindicator="false">
+      <Containable items="nucleargunbolt" />
+      <StatusEffect type="OnUse" target="This" condition="-20" disabledeltatime="true">
+        <SpawnItem identifiers="nucleargunbolt" spawnposition="ThisInventory" />
+      </StatusEffect>
+    </ItemContainer>
+    <Quality>
+      <QualityStat stattype="Condition" value="0.1" />
+    </Quality>
+  </Item>
+
+  <Item name="" identifier="arcemitter" tags="mediumitem,weapon,gun,mountableweapon,provocativetohumanai" category="Weapon" isshootable="true" Scale="0.5">
+    <Sprite texture="Content/Items/JobGear/TalentGear.png" sourcerect="207,430,131,61" depth="0.55" origin="0.5,0.5" />
+    <Price baseprice="740" sold="false">
+      <Price storeidentifier="merchantoutpost" multiplier="1.5" />
+      <Price storeidentifier="merchantcity" multiplier="1.25" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" />
+      <Price storeidentifier="merchantmilitary" multiplier="0.9" />
+      <Price storeidentifier="merchantmine" multiplier="1.25" />
+    </Price>
+    <Fabricate suitablefabricators="fabricator" requiredtime="75" requiresrecipe="true">
+      <RequiredSkill identifier="electrical" level="65" />
+      <RequiredItem identifier="fulgurium" amount="2" />
+      <RequiredItem identifier="titaniumaluminiumalloy" amount="3" />
+      <RequiredItem identifier="copper" />
+    </Fabricate>
+    <Deconstruct time="35">
+      <Item identifier="fulgurium" amount="2" />
+      <Item identifier="titaniumaluminiumalloy" amount="2" />
+      <Item identifier="copper" />
+    </Deconstruct>
+    <ElectricalDischarger duration="0.15" reload="5.0" ignoreuser="true" characterusable="true" raycastrange="500" range="150" rangemultiplierinwalls="1.25" outdoorsonly="false" powerconsumption="100" pickkey="Select">
+      <Attack targetimpulse="50">
+        <Affliction identifier="stun" strength="5"/>
+        <Affliction identifier="burn" strength="10"/>
+        <Affliction identifier="electricshock" strength="80"/>
+      </Attack>
+      <StatusEffect target="This" type="OnUse" forceplaysounds="true">
+        <sound file="Content/Items/Weapons/WEAPONS_electricalDischarge1.ogg" range="20000" selectionmode="random"/>
+        <sound file="Content/Items/Weapons/WEAPONS_electricalDischarge2.ogg" range="20000" />
+        <Explosion range="500.0" camerashake="15" stun="0" force="0.0" flames="false" shockwave="false" sparks="true" underwaterbubble="false" />
+      </StatusEffect>
+      <StatusEffect type="OnUse" target="Contained" Condition="-25" disabledeltatime="true">
+        <RequiredItem items="mobilebattery" type="Contained" />
+      </StatusEffect>
+      <RequiredItems items="mobilebattery" type="Contained" msg="ItemMsgBatteryCellRequired" />
+    </ElectricalDischarger>
+    <RangedWeapon reload="5.0" barrelpos="118,14" combatPriority="80" spread="30" drawhudwhenequipped="true" crosshairscale="0.5">
+      <Crosshair texture="Content/Items/Weapons/Crosshairs.png" sourcerect="0,256,256,256" />
+      <CrosshairPointer texture="Content/Items/Weapons/Crosshairs.png" sourcerect="256,256,256,256" />
+    </RangedWeapon>
+    <Body width="130" height="55" density="25" />
+    <Holdable slots="RightHand+LeftHand" controlpose="true" holdpos="60,-15" aimpos="70,4" handle1="-50,-10" handle2="10,-3" holdangle="-25" />
+    <Wearable slots="Bag" msg="ItemMsgEquipSelect" canbeselected="false" canbepicked="true" pickkey="Select">
+      <sprite name="Arc Emitter Worn" texture="Content/Items/JobGear/TalentGear.png" canbehiddenbyotherwearables="false" rotation="90" inheritlimbdepth="false" depth="0.6" sourcerect="207,430,131,61" limb="Torso" scale="0.5" origin="0.5,0.9" />
+    </Wearable>
+    <ItemContainer itemrotation="90" capacity="1" maxstacksize="1" hideitems="false" itempos="10,-5" containedspritedepth="0.56" containedstateindicatorstyle="battery">
+      <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="128,448,64,64" origin="0.5,0.5" />
+      <Containable items="mobilebattery">
+        <StatusEffect type="OnContaining" targettype="This" Voltage="1.0" setvalue="true" />
+      </Containable>
+    </ItemContainer>
+    <aitarget sightrange="3000" soundrange="5000" fadeouttime="5" />
+  </Item>
+  
+</Items>

--- a/Reactorfix/engineer_talent_items.xml
+++ b/Reactorfix/engineer_talent_items.xml
@@ -717,6 +717,7 @@
     </ItemContainer>
     <aitarget maxsightrange="1500" />
   </Item>
+  
   <Item name="" identifier="fulguriumfuelrodvolatile" category="Fuel" Tags="smallitem,reactorfuel" maxstacksize="8" allowasextracargo="true" cargocontaineridentifier="metalcrate" health="400" scale="0.5">
     <PreferredContainer primary="reactorcab"/>
     <Price baseprice="400" sold="false" displaynonempty="true">
@@ -750,6 +751,7 @@
     <Body radius="6" height="55" density="30" />
     <LightComponent allowingameediting="false" lightcolor="60,200,150,150" canbeselected="false" range="300.0" ison="true" />
     <Holdable handle1="0,0" slots="Any,RightHand,LeftHand" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="OnContained" target="Parent" AvailableFuel="150.0" disabledeltatime="true" />
       <StatusEffect type="Always" target="NearbyCharacters" range="125" interval="1" disabledeltatime="true">
         <Affliction identifier="radiationsickness" strength="1" />
       </StatusEffect>
@@ -763,7 +765,7 @@
     <Quality>
       <QualityStat stattype="Condition" value="0.1" />
     </Quality>
-  </Item>
+  </Item>  
 
   <Item name="" identifier="arcemitter" tags="mediumitem,weapon,gun,mountableweapon,provocativetohumanai" category="Weapon" isshootable="true" Scale="0.5">
     <Sprite texture="Content/Items/JobGear/TalentGear.png" sourcerect="207,430,131,61" depth="0.55" origin="0.5,0.5" />

--- a/Reactorfix/reactor.xml
+++ b/Reactorfix/reactor.xml
@@ -1,0 +1,150 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Items>
+  <Item name="" identifier="reactor1" tags="reactor" type="Reactor" scale="0.5" linkable="true" category="Machine" damagedbyexplosions="true" explosiondamagemultiplier="0.2">
+    <Upgrade gameversion="0.10.0.0" scale="*0.5" />
+    <trigger />
+    <Sprite texture="reactor.png" sourcerect="0,0,528,336" origin="0.5,0.45" depth="0.8" />
+    <UpgradePreviewSprite scale="3.0" texture="Content/UI/WeaponUI.png" sourcerect="0,960,64,64" origin="0.5,0.45" />
+    <BrokenSprite texture="reactor.png" sourcerect="0,338,528,336" depth="0.8" origin="0.5,0.45" maxcondition="40" />
+    <BrokenSprite texture="reactor.png" sourcerect="0,676,528,336" depth="0.8" origin="0.5,0.45" maxcondition="0" />
+    <aitarget sightrange="500" soundrange="4000" />
+    <Reactor canbeselected="true" firedelay="20" meltdowndelay="120" maxpoweroutput="5000" fuelconsumptionrate="0.2" vulnerabletoemp="false" msg="ItemMsgInteractSelect">
+      <StatusEffect type="InWater" target="This" condition="-0.5">
+        <Conditional condition="gt 10" />
+      </StatusEffect>
+      <TemperatureBoostSoundUp file="Content/Items/Reactor/ReactorTemperatureBoostUp.ogg" range="500.0" />
+      <TemperatureBoostSoundDown file="Content/Items/Reactor/ReactorTemperatureBoostDown.ogg" range="500.0" />
+      <GuiFrame relativesize="0.5,0.45" minsize="700,350" maxsize="2688,1166" anchor="Center" relativeoffset="0.1,0" style="ItemUI" />
+      <GraphLine texture="Content/Items/Reactor/graphLine.png">
+        <Sprite name="ReactorGraphLine" texture="Content/Items/Reactor/graphLine.png" sourcerect="0,0,32,32" />
+      </GraphLine>
+      <FissionRateMeter>
+        <Sprite name="FissionRateMeter" texture="Content/Items/Reactor/reactor.png" sourcerect="544,770,441,240" origin="0.5,1" />
+      </FissionRateMeter>
+      <TurbineOutputMeter>
+        <Sprite name="TurbineOutputMeter" texture="Content/Items/Reactor/reactor.png" sourcerect="544,770,441,240" origin="0.5,1" />
+      </TurbineOutputMeter>
+      <MeterPointer>
+        <Sprite name="MeterPointer" texture="Content/UI/UIAtlasDevices.png" sourcerect="938,846,31,167 " origin="0.5,0.9" />
+      </MeterPointer>
+      <SectorSprite>
+        <Sprite name="SectorSprite" texture="Content/UI/UIAtlasDevices.png" sourcerect="769,326,238,455" origin="0.95,0.5" />
+      </SectorSprite>
+      <TempMeterFrame>
+        <Sprite name="TempMeterFrame" texture="Content/UI/UIAtlasDevices.png" sourcerect="92,517,59,265" origin="0,0" size="0.5,1" />
+      </TempMeterFrame>
+      <TempMeterBar>
+        <Sprite name="TempMeterBar" texture="Content/UI/UIAtlasDevices.png" sourcerect="270,414,106,47" origin="0.5,0" />
+      </TempMeterBar>
+      <TempRangeIndicator>
+        <Sprite name="TempRangeIndicator" texture="Content/UI/UIAtlasDevices.png" sourcerect="31,614,52,25" origin="0.5,0.5" size="0.6,0.6" />
+      </TempRangeIndicator>
+      <RequiredSkill identifier="electrical" level="50" />
+      <sound file="Content/Items/Reactor/Reactor.ogg" type="OnActive" range="2000.0" volumeproperty="FissionRate" volume="0.02" loop="true" />
+      <StatusEffect type="OnBroken" target="This" FissionRate="0.0" disabledeltatime="true">
+        <Conditional AvailableFuel="gt 1" />
+        <sound file="Content/Items/Weapons/ExplosionLarge1.ogg" range="50000" />
+        <sound file="Content/Items/Weapons/ExplosionLarge2.ogg" range="50000" />
+        <Explosion range="750" ballastfloradamage="1000" structuredamage="300" itemdamage="500" force="25.0" camerashake="0" flashrange="10000" flashduration="5.0" debris="true" screencolor="255,255,255,255" screencolorrange="5000" screencolorduration="3.0" decal="explosion" decalsize="1">
+          <Affliction identifier="explosiondamage" strength="500" />
+          <Affliction identifier="burn" strength="500" />
+          <Affliction identifier="stun" strength="15" />
+        </Explosion>
+        <Explosion range="2000" force="0.0" camerashake="200" camerashakerange="50000" showEffects="false" empstrength="1.25" applyfireeffects="false" ignorecover="true">
+          <Affliction identifier="radiationsickness" strength="75" />
+          <Affliction identifier="emp" strength="50" multiplybymaxvitality="true" />
+        </Explosion>
+        <ParticleEmitter particle="underwaterexplosion" anglemin="0" anglemax="360" particleamount="3" velocitymin="0" velocitymax="0" scalemin="15" scalemax="15" />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="This">
+        <sound file="Content/Items/Weapons/ExplosionDebris4.ogg" range="5000" />
+        <sound file="Content/Items/Weapons/ExplosionDebris5.ogg" range="5000" />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="Contained" Condition="0.0" setvalue="true" />
+      <SkillRequirementHint identifier="electrical" level="50" />
+    </Reactor>
+    <LightComponent range="10.0" lightcolor="255,255,255,0" powerconsumption="0" IsOn="false" castshadows="false" alphablend="false" allowingameediting="false">
+      <Upgrade gameversion="0.9.600.0" lightcolor="255,255,255,0" />
+      <IsActive targetitemcomponent="Reactor" temperature="gt 2" />
+      <sprite texture="Content/Items/Reactor/reactor.png" depth="0.025" sourcerect="523,0,482,336" origin="0.5,0.45" alpha="1.0" />
+    </LightComponent>
+    <LightComponent range="10.0" lightcolor="255,255,255,0" powerconsumption="0" IsOn="false" castshadows="false" alphablend="false" allowingameediting="false" blinkfrequency="1">
+      <Upgrade gameversion="0.9.600.0" lightcolor="255,255,255,0" />
+      <IsActive targetitemcomponent="Reactor" temperaturecritical="eq true" />
+      <sprite texture="Content/Items/Reactor/reactor.png" depth="0.025" sourcerect="523,337,482,336" origin="0.5,0.45" alpha="1.0" />
+      <StatusEffect type="OnActive" target="This">
+        <ParticleEmitter particle="smoke" particlespersecond="2" scalemin="1" scalemax="2.5" anglemax="360" velocitymin="-50" velocitymax="50" mincondition="15.0" maxcondition="40.0" />
+        <ParticleEmitter particle="DarkSmoke" particlespersecond="20" scalemin="2.5" scalemax="3.5" anglemin="50" anglemax="130" velocitymin="10" velocitymax="50" mincondition="0.0" maxcondition="60.0" />
+        <ParticleEmitter particle="DarkSmoke" particlespersecond="40" scalemin="2.5" scalemax="3.5" distancemin="-15" distancemax="15" anglemin="50" anglemax="130" velocitymin="10" velocitymax="100" mincondition="0.0" maxcondition="20.0" />
+        <ParticleEmitter particle="swirlysmoke" particlespersecond="3" scalemin="1" scalemax="2" anglemin="0" anglemax="360" velocitymin="0" velocitymax="10" />
+        <sound file="Content/Items/Reactor/ReactorOverheatAlarm.ogg" type="OnUse" range="10000.0" loop="true" volume="1.0" />
+      </StatusEffect>
+    </LightComponent>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.3,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel" />
+      <RequiredSkill identifier="electrical" level="55" />
+      <StatusEffect type="OnFailure" target="Character" targetlimbs="LeftHand,RightHand" AllowWhenBroken="true">
+        <Sound file="Content/Sounds/Damage/Electrocution1.ogg" range="1000" />
+        <Explosion range="100.0" force="1.0" flames="false" shockwave="false" sparks="true" underwaterbubble="false" />
+        <Affliction identifier="stun" strength="4" probability="0.5" />
+        <Affliction identifier="electricshock" strength="60"/>
+        <Affliction identifier="burn" strength="5" />
+        <ParticleEmitter particle="ElectricShock" DistanceMin="10" DistanceMax="25" ParticleAmount="5" ScaleMin="0.1" ScaleMax="0.12" />
+      </StatusEffect>
+      <RequiredItem items="screwdriver" type="Equipped" />
+      <output name="power_out" displayname="connection.powerout" maxwires="1" />
+      <output name="temperature_out" displayname="connection.temperatureout" />
+      <input name="shutdown" displayname="connection.shutdown" />
+      <output name="meltdown_warning" displayname="connection.meltdownwarning"/>
+      <input name="set_fissionrate" displayname="connection.setfissionrate" />
+      <input name="set_turbineoutput" displayname="connection.setturbineoutput" />
+      <output name="power_value_out" displayname="connection.powervalueout" />
+      <output name="load_value_out" displayname="connection.loadvalueout" />
+      <output name="fuel_out" displayname="connection.availablefuelout" />
+      <output name="condition_out" displayname="connection.conditionout" />
+      <output name="fuel_percentage_left" displayname="connection.fuelpercentageout" />
+    </ConnectionPanel>
+    <ItemContainer capacity="4" maxstacksize="1" canbeselected="true" hudpos="0.5,0.15" slotsperrow="1" uilabel="FuelRods">
+      <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="192,448,64,64" origin="0.5,0.5" />
+      <SlotIcon slotindex="1" texture="Content/UI/StatusMonitorUI.png" sourcerect="192,448,64,64" origin="0.5,0.5" />
+      <SlotIcon slotindex="2" texture="Content/UI/StatusMonitorUI.png" sourcerect="192,448,64,64" origin="0.5,0.5" />
+      <SlotIcon slotindex="3" texture="Content/UI/StatusMonitorUI.png" sourcerect="192,448,64,64" origin="0.5,0.5" />
+      <Containable items="fuelrod">
+        <StatusEffect type="OnContaining" target="This" AvailableFuel="80.0" disabledeltatime="true" />
+      </Containable>
+      <Containable items="fulguriumfuelrod">
+        <StatusEffect type="OnContaining" target="This" AvailableFuel="150.0" disabledeltatime="true" />
+      </Containable>
+      <Containable items="thoriumfuelrod">
+        <StatusEffect type="OnContaining" target="This" AvailableFuel="100.0" disabledeltatime="true" />
+      </Containable>
+      <Containable items="fulguriumfuelrodvolatile">
+        <StatusEffect type="OnContaining" target="This" AvailableFuel="150.0" disabledeltatime="true" />
+      </Containable>
+      <Containable items="huskfigurine">
+        <StatusEffect type="OnContaining" target="This" AvailableFuel="0" disabledeltatime="true" />
+      </Containable>
+    </ItemContainer>
+    <Repairable selectkey="Action" header="electricalrepairsheader" deteriorationspeed="0.125" mindeteriorationdelay="120" maxdeteriorationdelay="720" MinDeteriorationCondition="10" minsabotagecondition="10" RepairThreshold="50" fixDurationHighSkill="5" fixDurationLowSkill="25" msg="ItemMsgRepairScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI" />
+      <RequiredSkill identifier="electrical" level="55" />
+      <RequiredItem items="screwdriver" type="equipped" />
+      <ParticleEmitter particle="damagebubbles" particlespersecond="2" scalemin="0.5" scalemax="1.5" anglemax="360" velocitymin="-10" velocitymax="10" mincondition="0.0" maxcondition="50.0" />
+      <ParticleEmitter particle="DarkSmoke" particlespersecond="8" scalemin="1.8" scalemax="2.5" anglemax="360" distancemax="60" velocitymin="-50" velocitymax="50" mincondition="0.0" maxcondition="50.0" />
+      <ParticleEmitter particle="heavysmoke" particlespersecond="2" scalemin="1.0" scalemax="2.5" anglemax="360" distancemax="60" mincondition="0.0" maxcondition="15.0" />
+      <StatusEffect type="OnFailure" target="Character" targetlimbs="LeftHand,RightHand" AllowWhenBroken="true">
+        <Sound file="Content/Sounds/Damage/Electrocution1.ogg" range="1000" />
+        <Explosion range="100.0" force="1.0" flames="false" shockwave="false" sparks="true" underwaterbubble="false" />
+        <Affliction identifier="stun" strength="4" probability="0.5" />
+        <Affliction identifier="electricshock" strength="60"/>
+        <Affliction identifier="burn" strength="5" />
+        <ParticleEmitter particle="ElectricShock" DistanceMin="10" DistanceMax="25" ParticleAmount="5" ScaleMin="0.1" ScaleMax="0.12" />
+      </StatusEffect>
+    </Repairable>
+    <Upgrade gameversion="0.1500.6.0">
+      <Repairable header="electricalrepairsheader" msg="ItemMsgRepairScrewdriver">
+        <RequiredItem items="screwdriver" type="equipped" />
+      </Repairable>
+    </Upgrade>
+  </Item>
+</Items>

--- a/Reactorfix/reactor.xml
+++ b/Reactorfix/reactor.xml
@@ -1,12 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Items>
   <Item name="" identifier="reactor1" tags="reactor" type="Reactor" scale="0.5" linkable="true" category="Machine" damagedbyexplosions="true" explosiondamagemultiplier="0.2">
-    <Upgrade gameversion="0.10.0.0" scale="*0.5" />
     <trigger />
-    <Sprite texture="reactor.png" sourcerect="0,0,528,336" origin="0.5,0.45" depth="0.8" />
+    <Sprite texture="Content/Items/Reactor/reactor.png" sourcerect="0,0,528,336" origin="0.5,0.45" depth="0.8" />
     <UpgradePreviewSprite scale="3.0" texture="Content/UI/WeaponUI.png" sourcerect="0,960,64,64" origin="0.5,0.45" />
-    <BrokenSprite texture="reactor.png" sourcerect="0,338,528,336" depth="0.8" origin="0.5,0.45" maxcondition="40" />
-    <BrokenSprite texture="reactor.png" sourcerect="0,676,528,336" depth="0.8" origin="0.5,0.45" maxcondition="0" />
+    <BrokenSprite texture="Content/Items/Reactor/reactor.png" sourcerect="0,338,528,336" depth="0.8" origin="0.5,0.45" maxcondition="40" />
+    <BrokenSprite texture="Content/Items/Reactor/reactor.png" sourcerect="0,676,528,336" depth="0.8" origin="0.5,0.45" maxcondition="0" />
     <aitarget sightrange="500" soundrange="4000" />
     <Reactor canbeselected="true" firedelay="20" meltdowndelay="120" maxpoweroutput="5000" fuelconsumptionrate="0.2" vulnerabletoemp="false" msg="ItemMsgInteractSelect">
       <StatusEffect type="InWater" target="This" condition="-0.5">
@@ -108,22 +107,8 @@
       <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="192,448,64,64" origin="0.5,0.5" />
       <SlotIcon slotindex="1" texture="Content/UI/StatusMonitorUI.png" sourcerect="192,448,64,64" origin="0.5,0.5" />
       <SlotIcon slotindex="2" texture="Content/UI/StatusMonitorUI.png" sourcerect="192,448,64,64" origin="0.5,0.5" />
-      <SlotIcon slotindex="3" texture="Content/UI/StatusMonitorUI.png" sourcerect="192,448,64,64" origin="0.5,0.5" />
-      <Containable items="fuelrod">
-        <StatusEffect type="OnContaining" target="This" AvailableFuel="80.0" disabledeltatime="true" />
-      </Containable>
-      <Containable items="fulguriumfuelrod">
-        <StatusEffect type="OnContaining" target="This" AvailableFuel="150.0" disabledeltatime="true" />
-      </Containable>
-      <Containable items="thoriumfuelrod">
-        <StatusEffect type="OnContaining" target="This" AvailableFuel="100.0" disabledeltatime="true" />
-      </Containable>
-      <Containable items="fulguriumfuelrodvolatile">
-        <StatusEffect type="OnContaining" target="This" AvailableFuel="150.0" disabledeltatime="true" />
-      </Containable>
-      <Containable items="huskfigurine">
-        <StatusEffect type="OnContaining" target="This" AvailableFuel="0" disabledeltatime="true" />
-      </Containable>
+      <SlotIcon slotindex="3" texture="Content/UI/StatusMonitorUI.png" sourcerect="192,448,64,64" origin="0.5,0.5" />       
+      <Containable items="reactorfuel,reactoritem" />
     </ItemContainer>
     <Repairable selectkey="Action" header="electricalrepairsheader" deteriorationspeed="0.125" mindeteriorationdelay="120" maxdeteriorationdelay="720" MinDeteriorationCondition="10" minsabotagecondition="10" RepairThreshold="50" fixDurationHighSkill="5" fixDurationLowSkill="25" msg="ItemMsgRepairScrewdriver" hudpriority="10">
       <GuiFrame relativesize="0.2,0.16" minsize="400,180" maxsize="480,280" anchor="Center" relativeoffset="0.0,0.27" style="ItemUI" />
@@ -141,10 +126,5 @@
         <ParticleEmitter particle="ElectricShock" DistanceMin="10" DistanceMax="25" ParticleAmount="5" ScaleMin="0.1" ScaleMax="0.12" />
       </StatusEffect>
     </Repairable>
-    <Upgrade gameversion="0.1500.6.0">
-      <Repairable header="electricalrepairsheader" msg="ItemMsgRepairScrewdriver">
-        <RequiredItem items="screwdriver" type="equipped" />
-      </Repairable>
-    </Upgrade>
   </Item>
 </Items>

--- a/Reactorfix/tools.xml
+++ b/Reactorfix/tools.xml
@@ -1,0 +1,1588 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Items>
+  <Item name="" identifier="toolbelt" category="Equipment" tags="mediumitem,mobilecontainer,tool" showcontentsintooltip="true" Scale="0.5" fireproof="true" description="" impactsoundtag="impact_soft">
+    <PreferredContainer primary="engcab"/>
+    <PreferredContainer primary="wreckstoragecab,abandonedstoragecab,piratestoragecab" amount="1" spawnprobability="0.05"/>
+    <PreferredContainer primary="outpostcrewcabinet" amount="1" spawnprobability="0.1"/>
+    <Deconstruct time="10">
+      <Item identifier="organicfiber" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="20">
+      <Item identifier="organicfiber" amount="2" />
+    </Fabricate>
+    <Price baseprice="65">
+      <Price storeidentifier="merchantoutpost" minavailable="4" />
+      <Price storeidentifier="merchantcity" minavailable="6" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" minavailable="1" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" minavailable="1" />
+      <Price storeidentifier="merchantmine" multiplier="1.25" minavailable="8" />
+      <Price storeidentifier="merchantengineering" minavailable="4" multiplier="0.9"/>
+    </Price>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="832,576,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="256,102,112,54" depth="0.6" />
+    <Body width="100" height="45" density="15" />
+    <Wearable slots="Bag" msg="ItemMsgEquipSelect" canbeselected="false" canbepicked="true" pickkey="Select">
+      <sprite name="ToolBelt" texture="Content/Items/Tools/tools.png" sourcerect="256,102,112,54" limb="Torso" inherittexturescale="true" origin="0.5,-0.2" />
+    </Wearable>
+    <Holdable slots="RightHand+LeftHand" holdpos="0,-70" handle1="-5,0" handle2="10,-20" holdangle="0" msg="ItemMsgPickUpUse" canbeselected="false" canbepicked="true" pickkey="Use" allowswappingwhenpicked="false" />
+    <ItemContainer capacity="6" maxstacksize="32" depth="0.5" >
+      <Containable items="smallitem" excludeditems="toolbelt,toolbox,bandolier" />
+    </ItemContainer>
+    <Upgrade gameversion="0.10.0.0" scale="0.5" />
+  </Item>
+  
+  <Item name="" identifier="backpack" category="Equipment" tags="mediumitem,mobilecontainer,largemobilecontainer,tool" showcontentsintooltip="true" Scale="0.5" fireproof="true" description="" impactsoundtag="impact_soft">
+    <PreferredContainer primary="engcab"/>
+    <PreferredContainer primary="wreckstoragecab,abandonedstoragecab,piratestoragecab" />
+    <PreferredContainer primary="outpostcrewcabinet" />
+    <Deconstruct time="10">
+      <Item identifier="organicfiber" amount="3" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="20" requiresrecipe="true">
+      <Item identifier="organicfiber" amount="5" />
+    </Fabricate>
+    <Price baseprice="200" minleveldifficulty="50">
+      <Price storeidentifier="merchantoutpost" minavailable="4" />
+      <Price storeidentifier="merchantcity" minavailable="6" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" minavailable="1" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" minavailable="1" />
+      <Price storeidentifier="merchantmine" multiplier="1.25" minavailable="8" />
+      <Price storeidentifier="merchantengineering" minavailable="4" multiplier="0.9"/>
+    </Price>
+    <InventoryIcon texture="Content/Items/Tools/tools.png" sourcerect="3,259,68,110" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="3,259,68,110" depth="0.6" />
+    <Body width="60" height="100" density="15" />
+    <Wearable slots="Bag" msg="ItemMsgEquipSelect" canbeselected="false" canbepicked="true" pickkey="Select">
+      <StatusEffect type="OnWearing" target="Character" setvalue="true" disabledeltatime="true" />
+      <sprite name="Backpack" CanBeHiddenByOtherWearables="false" CanBeHiddenByItem="deepdivinglarge" texture="Content/Items/Tools/tools.png" sourcerect="3,259,68,110" limb="Torso" depthlimb="Waist" inherittexturescale="true" origin="1.1,0.5" />
+      <StatValue stattype="MovementSpeed" value="-0.3" />
+      <StatValue stattype="PropulsionSpeed" value="-0.3" />
+    </Wearable>
+    <Holdable slots="RightHand+LeftHand" holdpos="0,-70" handle1="-5,50" handle2="10,50" holdangle="0" msg="ItemMsgPickUpUse" canbeselected="false" canbepicked="true" pickkey="Use" allowswappingwhenpicked="false">
+      <StatusEffect type="OnActive" target="Character" SpeedMultiplier="0.7" setvalue="true" disabledeltatime="true" />
+      <StatValue stattype="PropulsionSpeed" value="-0.3" />
+    </Holdable>
+    <ItemContainer capacity="12" maxstacksize="32" depth="0.5" >
+      <Containable items="smallitem" excludeditems="toolbelt,toolbox,bandolier" />
+    </ItemContainer>
+  </Item>
+  
+  <Item name="" identifier="toolbox" category="Equipment" tags="mediumitem,mobilecontainer,tool" cargocontaineridentifier="" showcontentsintooltip="true" Scale="0.5" fireproof="true" description="" impactsoundtag="impact_metal_heavy" RequireAimToUse="True">
+    <PreferredContainer primary="locker"/>
+    <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab,piratestoragecab"/>
+    <PreferredContainer secondary="outpostcrewcabinet"/>
+    <Deconstruct time="10">
+      <Item identifier="steel" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="20">
+      <RequiredSkill identifier="mechanical" level="20" />
+      <Item identifier="steel" amount="2" />
+    </Fabricate>
+    <Price baseprice="60">
+      <Price storeidentifier="merchantoutpost" minavailable="1" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" minavailable="2" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" minavailable="1" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" minavailable="1" />
+      <Price storeidentifier="merchantmine" multiplier="1.25" minavailable="4" />
+    </Price>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="640,256,64,64" origin="0.5,0.6" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="314,1,94,74" origin="0.5,0.5" depth="0.6" />
+    <Body width="90" height="60" density="20" />
+    <MeleeWeapon slots="RightHand,LeftHand" controlpose="true" aimpos="45,10" handle1="0,18" holdangle="90" reload="1" range="50" combatpriority="6" msg="ItemMsgPickUpSelect" DisableWhenRangedWeaponEquipped="true">
+      <Attack structuredamage="0" itemdamage="1" targetimpulse="2">
+        <Affliction identifier="blunttrauma" strength="2" />
+        <Affliction identifier="stun" strength="0.6" />
+        <StatusEffect type="OnUse" target="UseTarget">
+          <Conditional entitytype="eq Character"/>
+          <Sound file="Content/Items/Weapons/Smack1.ogg" selectionmode="random" range="500"/>
+          <Sound file="Content/Items/Weapons/Smack2.ogg" range="500" />
+        </StatusEffect>
+      </Attack>
+    </MeleeWeapon>
+    <ItemContainer capacity="12" maxstacksize="32" keepopenwhenequipped="true" movableframe="true" QuickUseMovesItemsInside="false">
+      <Containable items="smallitem" />
+    </ItemContainer>
+    <aitarget sightrange="1000" soundrange="1000" fadeouttime="2" />
+    <Upgrade gameversion="0.10.0.0" scale="0.5" />
+    <!-- the item used to have the (default) 64 max stack size, i.e. stack size was only limited by the max stack size of the contained items -->
+    <!-- set the stack size back in old saves/subs to prevent items from dropping from containers -->
+    <Upgrade gameversion="1.1.0.0" maxstacksize="64">
+      <ItemContainer maxstacksize="64" />
+    </Upgrade>
+  </Item>
+  
+  <Item name="" identifier="weldingtool" category="Equipment" Tags="smallitem,weldingequipment,tool,mountableweapon" cargocontaineridentifier="metalcrate" description="" Scale="0.5" impactsoundtag="impact_metal_light">
+    <PreferredContainer secondary="respawncontainer_kingofthehull" amount="2" spawnprobability="1" notcampaign="true"/>
+    <PreferredContainer primary="engcab" amount="1" spawnprobability="1" notcampaign="true"/>
+    <PreferredContainer secondary="supplycab" amount="1" spawnprobability="0.2" notcampaign="true" notpvp="true"/>
+    <PreferredContainer primary="outpostsupplycab" amount="1" spawnprobability="0.5"/>
+    <PreferredContainer primary="outpostcrewcabinet" amount="1" spawnprobability="0.1"/>
+    <PreferredContainer primary="wrecksupplycab,beaconsupplycab" amount="1" spawnprobability="0.05"/>
+    <PreferredContainer primary="wreckstoragecab,abandonedstoragecab,piratestoragecab" amount="1" spawnprobability="0.05"/>
+    <PreferredContainer primary="wreckengcab,abandonedengcab,pirateengcab,outpostengcab,beaconengcab" amount="1" spawnprobability="0.1"/>
+    <Price baseprice="150">
+      <Price storeidentifier="merchantoutpost" minavailable="3" />
+      <Price storeidentifier="merchantcity" minavailable="2" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" minavailable="2" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" minavailable="2" />
+      <Price storeidentifier="merchantmine" multiplier="0.9" minavailable="10" />
+      <Price storeidentifier="merchantengineering" minavailable="5" multiplier="0.9"/>
+    </Price>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="64,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="0,3,152,88" depth="0.55" origin="0.5,0.5" />
+    <!-- the item takes 10 seconds to break down in a deconstructor and turns into steel and plastic -->
+    <Deconstruct time="10">
+      <Item identifier="steel" />
+      <Item identifier="plastic" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="20">
+      <RequiredSkill identifier="mechanical" level="30" />
+      <RequiredItem identifier="steel" amount="2" />
+      <RequiredItem identifier="plastic" amount="2" />
+    </Fabricate>
+    <!-- physics body -->
+    <Body width="150" height="60" density="25" />
+    <!-- the character will hold the item 50 pixels in front of him, with his hands at the handle1 and handle2 positions -->
+    <Holdable slots="Any,RightHand+LeftHand" controlpose="true" aimpos="60,0" handle1="-62,-16" handle2="-10,-6" msg="ItemMsgPickUpSelect" />
+    <RepairTool firedamage="10.0" structurefixamount="2.0" range="150" barrelpos="35,12" particles="weld" repairmultiple="true" repairthroughwalls="false" combatpriority="3" levelwallfixamount="-0.425" targetforce="10">
+      <!-- the item must contain a welding fuel tank for it to work -->
+      <RequiredItems items="weldingtoolfuel,oxygensource" type="Contained" msg="ItemMsgWeldingFuelRequired" />
+      <RequiredSkill identifier="mechanical" level="50" />
+      <ParticleEmitter particle="weld" particlespersecond="50" copyentityangle="true"/>
+      <ParticleEmitterHitStructure particle="weldspark" particlespersecond="200" anglemin="-40" anglemax="40" velocitymin="200" velocitymax="800" />
+      <ParticleEmitterHitStructure particle="GlowDot" particlespersecond="60" emitinterval="0.7" particleamount="10" scalemin="0.9" scalemax="1.0" anglemin="0" anglemax="360" velocitymin="10" velocitymax="50" />
+      <ParticleEmitterHitStructure particle="MistSmoke" particlespersecond="20" anglemin="-10" anglemax="10" velocitymin="0" velocitymax="50" />
+      <ParticleEmitterHitItem identifiers="door,hatch,ductblock" particle="weldspark" particlespersecond="200" anglemin="-40" anglemax="40" velocitymin="200" velocitymax="800" />
+      <ParticleEmitterHitItem identifiers="door,hatch,ductblock" particle="MistSmoke" particlespersecond="20" anglemin="-10" anglemax="10" velocitymin="10" velocitymax="100" />
+      <ParticleEmitterHitCharacter particle="fleshsmoke" particlespersecond="3" anglemin="-5" anglemax="5" velocitymin="0" velocitymax="50" />
+      <sound file="Content/Items/Tools/WeldingLoop.ogg" type="OnUse" range="500.0" loop="true" />
+      <!-- when using, the contained welding fuel tank will detoriate (= lose fuel) -->
+      <StatusEffect type="OnUse" targettype="Contained" targets="weldingfueltank" Condition="-1.0" />
+      <StatusEffect type="OnUse" targettype="Contained" targets="incendiumfueltank" Condition="-0.6" />
+      <!-- welding a door, it will get stuck after a while -->
+      <StatusEffect type="OnSuccess" targettype="UseTarget" targets="weldable" Stuck="5.0" />
+      <StatusEffect type="OnSuccess" targettype="UseTarget" targets="item" Condition="-3.0">
+        <Conditional HasTag="neq weldable"/>
+      </StatusEffect>
+      <!-- do burn damage to characters -->
+      <StatusEffect type="OnSuccess" targettype="Limb">
+        <Affliction identifier="burn" amount="2.5" />
+      </StatusEffect>
+      <StatusEffect type="OnUse" targettype="Contained" targets="oxygentank" delay="1.0" stackable="false" Condition="0" setvalue="true">
+        <sound file="Content/Items/Weapons/ExplosionSmall1.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionSmall2.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionSmall3.ogg" range="2000" />
+        <Explosion range="150.0" force="3" applyfireeffects="false" >
+          <Affliction identifier="burn" strength="25" />
+          <Affliction identifier="stun" strength="5" />
+        </Explosion>
+      </StatusEffect>
+      <StatusEffect type="OnUse" targettype="Contained" targets="oxygenitetank" delay="1.0" stackable="false" Condition="0" setvalue="true">
+        <sound file="Content/Items/Weapons/ExplosionSmall1.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionSmall2.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionSmall3.ogg" range="2000" />
+        <Explosion range="150.0" force="6" applyfireeffects="false" >
+          <Affliction identifier="burn" strength="50" />
+          <Affliction identifier="stun" strength="10" />
+        </Explosion>
+      </StatusEffect>
+      <!-- the tool can fix structures, i.e. walls and windows -->
+      <Fixable identifier="structure" />
+      <NonFixable identifier="thalamus,ice" />
+      <LightComponent LightColor="255,229,178,100" Range="150" Flicker="0.5">
+        <sprite texture="Content/Items/Electricity/lightsprite.png" origin="0.5,0.5" />
+      </LightComponent>
+    </RepairTool>
+    <!-- one welding fuel or oxygen tank can be contained inside the welding tool -->
+    <ItemContainer capacity="1" maxstacksize="1" hideitems="false" itempos="8,-35" containedspritedepth="0.56" containedstateindicatorstyle="tank">
+      <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
+      <Containable items="weldingtoolfuel,oxygensource" />
+    </ItemContainer>
+    <aitarget sightrange="2000" soundrange="500" fadeouttime="3" />
+    <Quality>
+      <QualityStat stattype="RepairToolStructureRepairMultiplier" value="0.1"/>
+    </Quality>
+    <Upgrade gameversion="0.10.0.0" scale="0.5" />
+    <Upgrade gameversion="0.14.0.0">
+      <RepairTool>
+        <RequiredItems items="weldingtoolfuel,oxygensource" type="Contained" msg="ItemMsgWeldingFuelRequired" />
+      </RepairTool>
+    </Upgrade>
+    <Upgrade gameversion="0.15.4.0">
+      <ItemContainer itempos="8,-35"/>
+    </Upgrade>
+    <SkillRequirementHint identifier="mechanical" level="50" />
+  </Item>
+  
+  <Item name="" identifier="plasmacutter" category="Equipment" Tags="smallitem,cuttingequipment,tool,mountableweapon" cargocontaineridentifier="metalcrate" description="" Scale="0.5" impactsoundtag="impact_metal_light">
+    <Preferredcontainer secondary="respawncontainer" amount="1" spawnprobability="1" notcampaign="true"/>
+    <PreferredContainer secondary="outpostcrewcabinet" amount="1" spawnprobability="0.05"/>
+    <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab,piratestoragecab,wreckdivingcab" amount="1" spawnprobability="0.05"/>
+    <PreferredContainer primary="divingcab" secondary="engcab"/>
+    <Price baseprice="150">
+      <Price storeidentifier="merchantoutpost" minavailable="3" />
+      <Price storeidentifier="merchantcity" minavailable="2" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" minavailable="2" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" minavailable="2" />
+      <Price storeidentifier="merchantmine" multiplier="0.9" minavailable="10" />
+      <Price storeidentifier="merchantengineering" minavailable="5" multiplier="0.9"/>
+    </Price>
+    <Deconstruct time="10">
+      <Item identifier="steel" />
+      <Item identifier="plastic" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="20">
+      <RequiredSkill identifier="mechanical" level="30" />
+      <RequiredItem identifier="steel" amount="2" />
+      <RequiredItem identifier="plastic" amount="2" />
+    </Fabricate>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="704,0,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="0,166,159,87" depth="0.55" origin="0.5,0.5" />
+    <Body radius="40" width="60" density="25" />
+    <Holdable slots="Any,RightHand+LeftHand" controlpose="true" aimpos="60,0" handle1="-60,-21" handle2="-21,-20" msg="ItemMsgPickUpSelect" />
+    <RepairTool firedamage="10.0" structurefixamount="-0.5" range="150" barrelpos="55,10" combatpriority="5" repairmultiple="true" repairthroughwalls="false" maxoverlappingwalldist="0.0" repairthroughholes="true" levelwallfixamount="-5.0" targetforce="10">
+      <RequiredItems items="oxygensource,weldingtoolfuel" type="Contained" msg="ItemMsgOxygenTankRequired" />
+      <RequiredSkill identifier="mechanical" level="50" />
+      <StatusEffect type="OnUse" targettype="Contained" targets="oxygensource" Condition="-1.0" />
+      <StatusEffect type="OnSuccess" targettype="UseTarget" targets="weldable" Stuck="-20.0" />
+      <StatusEffect type="OnSuccess" targettype="UseTarget" Condition="-15.0" />
+      <StatusEffect type="OnSuccess" targettype="Limb" severlimbsprobability="0.005">      
+        <Affliction identifier="burn" amount="4.0" />
+      </StatusEffect>
+      <StatusEffect type="OnUse" targettype="Contained" targets="weldingfueltank" delay="1.0" stackable="false" Condition="0" setvalue="true">
+        <sound file="Content/Items/Weapons/ExplosionSmall1.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionSmall2.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionSmall3.ogg" range="2000" />
+        <Explosion range="150.0" force="3" applyfireeffects="false" >
+          <Affliction identifier="burn" strength="25" />
+          <Affliction identifier="stun" strength="5" />
+        </Explosion>
+      </StatusEffect>
+      <StatusEffect type="OnUse" targettype="Contained" targets="incendiumfueltank" delay="1.0" stackable="false" Condition="0" setvalue="true">
+        <sound file="Content/Items/Weapons/ExplosionSmall1.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionSmall2.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionSmall3.ogg" range="2000" />
+        <Explosion range="150.0" ballastfloradamage="50" force="6" applyfireeffects="true" ignorefireeffectsfortags="incendiumfueltank">
+          <Affliction identifier="burn" strength="100" />
+          <Affliction identifier="stun" strength="10" />
+        </Explosion>
+      </StatusEffect>
+      <ParticleEmitter particle="plasma" particlespersecond="50" copyentityangle="true"/>
+      <ParticleEmitterHitStructure particle="plasmaspark" particlespersecond="100" anglemin="-40" anglemax="40" velocitymin="100" velocitymax="800" />
+      <ParticleEmitterHitStructure particle="plasmasmoke" particlespersecond="3" anglemin="-5" anglemax="5" velocitymin="10" velocitymax="20" />
+      <ParticleEmitterHitItem identifiers="door,hatch,ductblock" particle="plasmaspark" particlespersecond="100" anglemin="-40" anglemax="40" velocitymin="100" velocitymax="800" />
+      <ParticleEmitterHitItem identifiers="door,hatch,ductblock" particle="plasmasmoke" particlespersecond="3" anglemin="-5" anglemax="5" velocitymin="10" velocitymax="100" />
+      <ParticleEmitterHitItem identifiers="ore" particle="iceshards" particlespersecond="5" anglemin="-40" anglemax="40" velocitymin="10" velocitymax="300" scalemin="0.5" scalemax="1.0" />
+      <ParticleEmitterHitCharacter particle="fleshsmoke" particlespersecond="3" anglemin="-5" anglemax="5" velocitymin="0" velocitymax="50" />
+      <sound file="Content/Items/Tools/PlasmaCutterLoop.ogg" type="OnUse" range="750.0" loop="true" />
+      <Fixable identifier="structure" />
+      <LightComponent LightColor="204,178,255,100" range="150" Flicker="0.5">
+        <sprite texture="Content/Items/Electricity/lightsprite.png" origin="0.5,0.5" />
+      </LightComponent>      
+    </RepairTool>
+    <ItemContainer capacity="1" maxstacksize="1" hideitems="false" itempos="0,-39" containedspritedepth="0.56" containedstateindicatorstyle="tank">
+      <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
+      <Containable items="weldingtoolfuel,oxygensource" />
+    </ItemContainer>
+    <aitarget sightrange="2000" soundrange="500" fadeouttime="3" />
+    <Quality>
+      <QualityStat stattype="RepairToolStructureDamageMultiplier" value="0.1"/>
+      <QualityStat stattype="RepairToolDeattachTimeMultiplier" value="0.1"/>
+    </Quality>
+    <Upgrade gameversion="0.10.0.0" scale="0.5" />
+    <Upgrade gameversion="0.14.0.0">
+      <RepairTool>
+        <RequiredItems identifier="oxygensource,weldingtoolfuel" type="Contained" msg="ItemMsgOxygenTankRequired" />
+      </RepairTool>
+    </Upgrade>
+    <SkillRequirementHint identifier="mechanical" level="50" />
+  </Item>
+  
+  <Item name="" identifier="weldingfueltank" category="Equipment,Fuel" health="200" maxstacksize="8" maxstacksizecharacterinventory="1" MaxStackSizeHoldableOrWearableInventory="1" Tags="smallitem,weldingtoolfuel,weldingfuel" cargocontaineridentifier="metalcrate" scale="0.5" impactsoundtag="impact_metal_light">
+    <PreferredContainer primary="weldingtool,flamer" spawnprobability="1"/>
+    <PreferredContainer primary="engcab" minamount="4" maxamount="6" spawnprobability="1" notcampaign="true"/>
+    <PreferredContainer primary="wreckengcab,abandonedengcab,pirateengcab,outpostengcab,beaconengcab" minamount="1" maxamount="3" spawnprobability="0.2"/>
+    <PreferredContainer primary="wreckstoragecab,abandonedstoragecab,piratestoragecab" amount="1" spawnprobability="0.05"/>
+    <PreferredContainer secondary="supplycab"/>
+    <Price baseprice="120" displaynonempty="true">
+      <Price storeidentifier="merchantoutpost" minavailable="6" />
+      <Price storeidentifier="merchantcity" minavailable="7" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" minavailable="3" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" minavailable="3" />
+      <Price storeidentifier="merchantmine" multiplier="0.9" minavailable="15" />
+      <Price storeidentifier="merchantengineering" minavailable="10" multiplier="0.9"/>
+      <Price storeidentifier="merchanttutorial" multiplier="0.5" minavailable="3" />
+    </Price>
+    <Deconstruct time="10">
+      <Item identifier="aluminium" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="10">
+      <RequiredSkill identifier="mechanical" level="20" />
+      <RequiredItem identifier="aluminium" amount="2" />
+      <RequiredItem identifier="ethanol" />
+    </Fabricate>
+    <Fabricate suitablefabricators="fabricator" displayname="recycleitem" requiredtime="5">
+      <RequiredSkill identifier="mechanical" level="15" />
+      <RequiredItem identifier="weldingfueltank" mincondition="0.0" maxcondition="0.1" usecondition="false"/>
+      <RequiredItem identifier="ethanol" />
+    </Fabricate>
+    <Fabricate suitablefabricators="vendingmachine" requiredtime="1" requiredmoney="190" fabricationlimitmin="0" fabricationlimitmax="4" quality="0"/>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="960,0,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="436,71,22,66" depth="0.55" />
+    <Body width="20" height="65" density="9.7" />
+    <Holdable canbecombined="true" slots="Any,RightHand,LeftHand" holdpos="30,-15" handle1="0,5" handle2="0,-5" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="OnFire" target="This" Condition="-10.0" statuseffecttags="onfire" duration="1" stackable="false" />
+      <StatusEffect type="OnBroken" target="This" delay="1" stackable="false">
+        <Conditional HasStatusTag="onfire" />
+        <sound file="Content/Items/Weapons/ExplosionSmall1.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionSmall2.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionSmall3.ogg" range="2000" />
+        <Explosion range="150.0" force="3">
+          <Affliction identifier="burn" strength="25" />
+          <Affliction identifier="stun" strength="5" />
+        </Explosion>
+      </StatusEffect>
+    </Holdable>
+    <Quality>
+      <QualityStat stattype="Condition" value="0.1"/>
+    </Quality>
+    <Upgrade gameversion="0.10.0.0" scale="0.5" />
+  </Item>
+  
+  <Item name="" identifier="incendiumfueltank" category="Equipment,Fuel" health="200" maxstacksize="8" maxstacksizecharacterinventory="1" MaxStackSizeHoldableOrWearableInventory="1" Tags="smallitem,weldingtoolfuel,weldingfuel" cargocontaineridentifier="metalcrate" scale="0.5" impactsoundtag="impact_metal_light">
+    <PreferredContainer primary="engcab" secondary="supplycab"/>
+    <PreferredContainer primary="wreckengcab,abandonedengcab,pirateengcab" amount="1" spawnprobability="0.05"/>
+    <PreferredContainer primary="wreckstoragecab,abandonedstoragecab,piratestoragecab" amount="1" spawnprobability="0.02"/> 
+    <Price baseprice="250" sold="false" displaynonempty="true">
+      <Price storeidentifier="merchantoutpost" multiplier="1.1" />
+      <Price storeidentifier="merchantcity" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" />
+      <Price storeidentifier="merchantmine" multiplier="1.4" />
+    </Price>
+    <Deconstruct time="10">
+      <Item identifier="aluminium" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="15">
+      <RequiredSkill identifier="mechanical" level="40" />
+      <RequiredItem identifier="aluminium" amount="2" />
+      <RequiredItem identifier="incendium" />
+    </Fabricate>
+    <Fabricate suitablefabricators="fabricator" displayname="recycleitem" requiredtime="10">
+      <RequiredSkill identifier="mechanical" level="30" />
+      <RequiredItem identifier="incendiumfueltank" mincondition="0.0" maxcondition="0.1" usecondition="false"/>
+      <RequiredItem identifier="incendium" />
+    </Fabricate>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="256,901,62,60" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="460,71,24,66" depth="0.55" origin="0.5,0.5" />
+    <Body width="22" height="65" density="8" />
+    <Holdable canbecombined="true" slots="Any,RightHand,LeftHand" holdpos="30,-15" handle1="0,5" handle2="0,-5" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="OnFire" target="This" Condition="-10.0" statuseffecttags="onfire" duration="1" stackable="false" />
+      <StatusEffect type="OnBroken" target="This" delay="1" stackable="false">
+        <Conditional HasStatusTag="onfire" />
+        <sound file="Content/Items/Weapons/ExplosionSmall1.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionSmall2.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionSmall3.ogg" range="2000" />
+        <Explosion range="150.0" ballastfloradamage="50" force="6" >
+          <Affliction identifier="burn" strength="100" />
+          <Affliction identifier="stun" strength="10" />
+        </Explosion>
+      </StatusEffect>
+    </Holdable>
+    <Quality>
+      <QualityStat stattype="Condition" value="0.1"/>
+    </Quality>
+    <Upgrade gameversion="0.10.0.0" scale="0.5" />
+  </Item>
+  <Item name="" identifier="extinguisher" category="Equipment" Tags="mediumitem,fireextinguisher,provocative" cargocontaineridentifier="metalcrate" description="" Scale="0.5" impactsoundtag="impact_metal_light" donttransferbetweensubs="true">
+    <Upgrade gameversion="0.9.600.0" Tags="mediumitem,fireextinguisher,provocative" />
+    <PreferredContainer primary="extinguisherholder" spawnprobability="1.0"/>
+    <PreferredContainer primary="wreckextinguisherholder" spawnprobability="0.6"/>
+    <PreferredContainer secondary="engcab,reactorcab"/>
+    <Price baseprice="100" displaynonempty="true">
+      <Price storeidentifier="merchantoutpost" minavailable="3" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" minavailable="4" />
+      <Price storeidentifier="merchantresearch" minavailable="2" />
+      <Price storeidentifier="merchantmilitary" minavailable="2" />
+      <Price storeidentifier="merchantmine" minavailable="2" />
+    </Price>
+    <Deconstruct time="10">
+      <Item identifier="aluminium" />
+      <Item identifier="sodium" mincondition="0.5" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="10">
+      <RequiredSkill identifier="mechanical" level="20" />
+      <RequiredItem identifier="aluminium" />
+      <RequiredItem identifier="sodium" amount="2" />
+    </Fabricate>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="0,0,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" depth="0.55" sourcerect="161,105,64,128" origin="0.5,0.5" />
+    <Body width="30" height="100" density="8" />
+    <Holdable slots="RightHand+LeftHand" controlpose="true" aimpos="40,-20" handle1="-6,10" handle2="-10,40" msg="ItemMsgPickUpSelect" />
+    <RepairTool extinguishamount="60.0" range="500" barrelpos="21,25" repairthroughholes="true" hititems="false" IgnoreCharacters="true">
+      <ParticleEmitter particle="extinguisher" velocitymin="1000.0" velocitymax="1650.0" particlespersecond="100" />
+      <StatusEffect type="OnUse" targettype="This" Condition="-2.0" />
+      <sound file="Content/Items/Tools/Extinguisher.ogg" type="OnUse" range="500.0" loop="true" />
+    </RepairTool>
+    <RepairTool range="500" barrelpos="21,25" IgnoreCharacters="false">
+      <!-- Remove 'burning' affliction from characters-->
+      <StatusEffect type="OnUse" target="UseTarget">
+        <ReduceAffliction identifier="burning" amount="15.0" />
+      </StatusEffect>
+    </RepairTool>
+    <Propulsion force="-80" usablein="water" particles="bubbles" />
+    <aitarget sightrange="1000" soundrange="1000" fadeouttime="1" />
+    <Upgrade gameversion="0.10.0.0" scale="0.5" />
+  </Item>
+
+  <Item name="" identifier="sprayer" category="Equipment" Tags="smallitem,tool,mountableweapon" cargocontaineridentifier="metalcrate" description="" Scale="0.5" impactsoundtag="impact_metal_light">
+    <PreferredContainer primary="engcab"/>
+    <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab,piratestoragecab" amount="1" spawnprobability="0.05"/>
+    <PreferredContainer primary="wreckengcab,abandonedengcab,pirateengcab,outpostengcab" amount="1" spawnprobability="0.1"/>
+    <Price baseprice="120">
+      <Price storeidentifier="merchantoutpost" minavailable="3" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" minavailable="5" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" minavailable="2" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" minavailable="2" />
+      <Price storeidentifier="merchantmine" multiplier="0.9" minavailable="10" />
+    </Price>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas2.png" sourcerect="128,256,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="373,165,124,73" depth="0.55" origin="0.5,0.5" />
+    <!-- the item takes 25 seconds to break down in a deconstructor and turns into steel and plastic -->
+    <Deconstruct time="25">
+      <Item identifier="steel" />
+      <Item identifier="plastic" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="35">
+      <RequiredSkill identifier="mechanical" level="30" />
+      <RequiredItem identifier="steel" />
+      <RequiredItem identifier="plastic" />
+      <RequiredItem identifier="plastic" />
+    </Fabricate>
+    <!-- physics body -->
+    <Body width="150" height="60" density="25" />
+    <!-- the character will hold the item 50 pixels in front of him, with his hands at the handle1 and handle2 positions -->
+    <Holdable slots="Any,RightHand+LeftHand" controlpose="true" aimpos="50,-10" handle1="-39,-20" handle2="-10,-10" msg="ItemMsgPickUpSelect" />
+    <Sprayer barrelpos="34,8" spread="0" unskilledspread="0" drawhudwhenequipped="true" crosshairscale="0.1" spraystrength="6.0" range="300">
+      <Crosshair texture="Content/Items/Weapons/Crosshairs.png" sourcerect="0,256,256,256" />
+      <CrosshairPointer texture="Content/Items/Weapons/Crosshairs.png" sourcerect="256,256,256,256" />
+      <ParticleEmitter particle="spray" velocitymin="500.0" velocitymax="650.0" particlespersecond="100" />
+      <RequiredItems items="ethanol, paint" type="Contained" msg="ItemMsgPaintOrCleaningAgentRequired" />
+      <sound file="Content/Items/Tools/Sprayer.ogg" type="OnUse" range="500.0" loop="true" />
+      <!--When containing paint, reduce its condition by 1.5 when used-->
+      <StatusEffect type="OnUse" target="Contained" Condition="-1.5">
+        <RequiredItem items="paint" type="Contained" />
+      </StatusEffect>
+      <!--Reduce ethanol condition slower than paint-->
+      <StatusEffect type="OnUse" target="Contained" Condition="-0.75">
+        <RequiredItem items="ethanol" type="Contained" />
+      </StatusEffect>
+      <PaintColors>
+        <PaintColor paintitem="ethanol" color="200,200,200,0" />
+        <PaintColor paintitem="redpaint" color="128,0,0,180" />
+        <PaintColor paintitem="greenpaint" color="0,128,0,180" />
+        <PaintColor paintitem="bluepaint" color="0,0,128,180" />
+        <PaintColor paintitem="blackpaint" color="0,0,0,180" />
+        <PaintColor paintitem="whitepaint" color="128,128,128,180" />
+      </PaintColors>
+    </Sprayer>
+    <!-- one welding fuel or oxygen tank can be contained inside the welding tool -->
+    <ItemContainer capacity="1" maxstacksize="1" hideitems="false" itempos="8,-35" containedspritedepth="0.56" containedstateindicatorstyle="tank">
+      <Containable items="ethanol, paint" />
+    </ItemContainer>
+    <aitarget sightrange="2000" soundrange="500" fadeouttime="3" />
+  </Item>
+  
+  <Item name="" identifier="screwdriver" category="Equipment" Tags="smallitem,simpletool,tool,electricalrepairtool,screwdriveritem" cargocontaineridentifier="metalcrate" Scale="0.5" impactsoundtag="impact_metal_light" RequireAimToUse="True">
+    <Preferredcontainer secondary="respawncontainer" amount="1" spawnprobability="1" notcampaign="true"/>
+    <PreferredContainer primary="engcab" secondary="reactorcab"/>
+    <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab,piratestoragecab" amount="1" spawnprobability="0.2"/>  
+    <PreferredContainer primary="wreckengcab,abandonedengcab,pirateengcab,outpostengcab,beaconengcab" amount="1" spawnprobability="0.5"/>
+    <PreferredContainer primary="wreckreactorcab,abandonedreactorcab,piratereactorcab" amount="1" spawnprobability="0.5"/>   
+    <PreferredContainer secondary="outpostcrewcabinet" amount="1" spawnprobability="0.3"/>
+    <PreferredContainer secondary="outposttrashcan" amount="1" spawnprobability="0.1" />
+    <Price baseprice="10" minavailable="10">
+      <Price storeidentifier="merchantoutpost" />
+      <Price storeidentifier="merchantcity" minavailable="5"  />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" />
+      <Price storeidentifier="merchantmine" />
+      <Price storeidentifier="merchantengineering" minavailable="10" multiplier="0.9"/>
+    </Price>
+    <Deconstruct time="20">
+      <Item identifier="iron" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="10">
+      <RequiredSkill identifier="mechanical" level="20" />
+      <RequiredItem identifier="iron" amount="2" />
+    </Fabricate>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="512,0,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="227,188,64,14" depth="0.55" origin="0.5,0.5" />
+    <Body width="60" height="12" density="25" />
+    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="-10,0" holdangle="60" reload="1.0" range="50" combatpriority="7" msg="ItemMsgPickUpSelect">
+      <Attack structuredamage="0" itemdamage="2" targetimpulse="2">
+        <Affliction identifier="lacerations" strength="5" />
+        <Affliction identifier="bleeding" strength="2" />
+        <Affliction identifier="stun" strength="0.05" />
+        <StatusEffect type="OnUse" target="UseTarget">
+          <Conditional entitytype="eq Character"/>
+          <Sound file="Content/Sounds/Damage/LimbSlash1.ogg" selectionmode="random" range="500" />
+          <Sound file="Content/Sounds/Damage/LimbSlash2.ogg" range="500" />
+          <Sound file="Content/Sounds/Damage/LimbSlash3.ogg" range="500" />
+          <Sound file="Content/Sounds/Damage/LimbSlash4.ogg" range="500" />
+          <Sound file="Content/Sounds/Damage/LimbSlash5.ogg" range="500" />
+          <Sound file="Content/Sounds/Damage/LimbSlash6.ogg" range="500" />
+        </StatusEffect>
+      </Attack>
+    </MeleeWeapon>
+    <aitarget sightrange="500" soundrange="250" fadeouttime="1" />
+    <Quality>
+      <QualityStat stattype="RepairSpeed" value="0.1"/>
+    </Quality>
+    <Upgrade gameversion="0.10.0.0" scale="0.5" />
+  </Item>
+  
+  <Item name="" identifier="wrench" category="Equipment" Tags="smallitem,tool,simpletool,mechanicalrepairtool,wrenchitem,mountableweapon,deattachtool" cargocontaineridentifier="metalcrate" Scale="0.5" impactsoundtag="impact_metal_light" RequireAimToUse="True">
+    <Preferredcontainer secondary="respawncontainer" amount="1" spawnprobability="1" notcampaign="true"/>
+    <PreferredContainer primary="engcab"/>
+    <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab,piratestoragecab" amount="1" spawnprobability="0.2"/>
+    <PreferredContainer primary="wreckengcab,abandonedengcab,pirateengcab,outpostengcab,beaconengcab" amount="1" spawnprobability="0.5"/>
+    <PreferredContainer secondary="outpostcrewcabinet" amount="1" spawnprobability="0.3"/>
+    <PreferredContainer secondary="outposttrashcan" amount="1" spawnprobability="0.1" />
+    <Price baseprice="20" minavailable="10">
+      <Price storeidentifier="merchantoutpost" />
+      <Price storeidentifier="merchantcity" minavailable="5" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" />
+      <Price storeidentifier="merchantmine" />
+      <Price storeidentifier="merchantengineering" minavailable="10" multiplier="0.9"/>
+    </Price>
+    <Deconstruct time="10">
+      <Item identifier="iron" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="10">
+      <RequiredSkill identifier="mechanical" level="20" />
+      <RequiredItem identifier="iron" amount="2" />
+    </Fabricate>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="450,0,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="161,235,64,20" depth="0.55" origin="0.5,0.5" />
+    <Body width="60" height="15" density="30" />
+    <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="-8,0" holdangle="60" reload="1.0" range="50" combatpriority="8" msg="ItemMsgPickUpSelect">
+      <Attack structuredamage="0" itemdamage="2" targetimpulse="5">
+        <Affliction identifier="blunttrauma" strength="4" />
+        <Affliction identifier="stun" strength="0.2" />
+        <StatusEffect type="OnUse" target="UseTarget">
+          <Conditional entitytype="eq Character"/>
+          <Sound file="Content/Items/Weapons/Smack1.ogg" selectionmode="random" range="500"/>
+          <Sound file="Content/Items/Weapons/Smack2.ogg" range="500" />
+        </StatusEffect>
+      </Attack>
+    </MeleeWeapon>
+    <aitarget sightrange="500" soundrange="500" fadeouttime="1" />
+    <Quality>
+      <QualityStat stattype="RepairSpeed" value="0.1"/>
+    </Quality>
+    <Upgrade gameversion="0.10.0.0" scale="0.5" />
+  </Item>
+  
+  <Item name="" identifier="crowbar" category="Equipment" Tags="smallitem,tool,simpletool,dooropeningtool,crowbaritem,mountableweapon" cargocontaineridentifier="metalcrate" Scale="0.5" impactsoundtag="impact_metal_light" RequireAimToUse="True">
+    <Preferredcontainer secondary="respawncontainer" amount="1" spawnprobability="1" notcampaign="true"/>
+    <PreferredContainer primary="engcab"/>
+    <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab,piratestoragecab" amount="1" spawnprobability="0.1"/>
+    <PreferredContainer primary="wreckengcab,abandonedengcab,pirateengcab,outpostengcab,beaconengcab" amount="1" spawnprobability="0.2"/>
+    <PreferredContainer secondary="outpostcrewcabinet" amount="1" spawnprobability="0.2"/>
+    <Price baseprice="20" minavailable="10">
+      <Price storeidentifier="merchantoutpost" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" minavailable="15" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" />
+      <Price storeidentifier="merchantmine" />
+    </Price>
+    <Deconstruct time="10">
+      <Item identifier="iron" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="20">
+      <RequiredSkill identifier="mechanical" level="30" />
+      <RequiredItem identifier="iron" amount="2" />
+    </Fabricate>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="576,0,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="227,225,130,30" depth="0.55" origin="0.5,0.5" />
+    <Body width="120" height="20" density="30" />
+    <MeleeWeapon slots="RightHand+LeftHand,Any" controlpose="true" aimpos="45,10" handle1="-10,0" handle2="0,5" holdangle="60" reload="1" range="100" combatpriority="20" msg="ItemMsgPickUpSelect">
+      <Attack structuredamage="8" itemdamage="8" targetimpulse="10">
+        <Affliction identifier="blunttrauma" strength="10" />
+        <Affliction identifier="stun" strength="0.5" />
+        <StatusEffect type="OnUse" target="UseTarget">
+          <Conditional entitytype="eq Character"/>
+          <Sound file="Content/Items/Weapons/Smack1.ogg" selectionmode="random" range="500"/>
+          <Sound file="Content/Items/Weapons/Smack2.ogg" range="500" />
+        </StatusEffect>
+      </Attack>
+    </MeleeWeapon>
+    <aitarget sightrange="1000" soundrange="500" fadeouttime="1" />
+    <Quality>
+      <QualityStat stattype="StrikingPowerMultiplier" value="0.1"/>
+    </Quality>
+    <Upgrade gameversion="0.10.0.0" scale="0.5" />
+  </Item>
+  
+  <Item name="" identifier="handheldsonar" category="Equipment,Diving" Tags="smallitem,sonar,provocative" cargocontaineridentifier="metalcrate" Scale="0.5" impactsoundtag="impact_metal_light">
+    <Preferredcontainer secondary="respawncontainer" amount="1" spawnprobability="1" notcampaign="true"/>
+    <PreferredContainer primary="divingcab" amount="1" spawnprobability="1" notcampaign="true" notpvp="true"/>
+    <PreferredContainer secondary="wreckstoragecab,wreckdivingcab" amount="1" spawnprobability="0.05"/>
+    <Price baseprice="150" minavailable="1">
+      <Price storeidentifier="merchantoutpost" />
+      <Price storeidentifier="merchantcity" minavailable="1" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" minavailable="2" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" />
+      <Price storeidentifier="merchantmine" />
+      <Price storeidentifier="merchantengineering" multiplier="0.9" minavailable="2" />
+    </Price>
+    <Deconstruct time="15">
+      <Item identifier="copper" />
+      <Item identifier="plastic" amount="2" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="20">
+      <RequiredSkill identifier="mechanical" level="30" />
+      <RequiredItem identifier="fpgacircuit" />
+      <RequiredItem identifier="plastic" />
+    </Fabricate>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="64,0,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="227,163,48,24" depth="0.55" origin="0.5,0.5" />
+    <Body width="40" height="22" density="12" />
+    <AiTarget sight="500" staticsight="true"/>
+    <Holdable slots="Any,RightHand,LeftHand" holdangle="30" handle1="-25,0" msg="ItemMsgPickUpSelect" />
+    <Sonar range="6000.0" powerconsumption="10" drawhudwhenequipped="true" detectsubmarinewalls="true" displaybordersize="-0.1" characterusable="false" hasmineralscanner="true" allowuioverlap="true">
+      <StatusEffect type="OnUse" targettype="Contained" Condition="-1.0" disabledeltatime="true">
+        <RequiredItem items="mobilebattery" type="Contained" />
+      </StatusEffect>
+      <sound file="Content/Items/Command/SonarPing.ogg" type="OnUse" range="1000.0" frequencymultiplier="1.5" />
+      <GuiFrame relativesize="0.4,0.4" anchor="CenterLeft" relativeoffset="0.006,-0.01"/>
+      <PingCircle texture="Content/Items/Command/pingCircle.png" origin="0.5,0.5" />
+      <DirectionalPingCircle texture="Content/Items/Command/directionalPingCircle.png" origin="0.0,0.5" />
+      <ScreenOverlay texture="Content/Items/Command/sonarOverlay.png" origin="0.5,0.5" />
+      <ScreenBackground texture="Content/Items/Command/sonarBackground.png" origin="0.5,0.5" />
+      <DirectionalPingBackground texture="Content/Items/Command/directionalPingBackground.png" origin="0.5,0.5" />
+      <DirectionalPingButton index="0" texture="Content/Items/Command/directionalPingButton.png" sourcerect="0,0,91,266" origin="-4.5275,0.5" />
+      <DirectionalPingButton index="1" texture="Content/Items/Command/directionalPingButton.png" sourcerect="133,0,91,266" origin="-4.5275,0.5" />
+      <DirectionalPingButton index="2" texture="Content/Items/Command/directionalPingButton.png" sourcerect="266,0,91,266" origin="-4.5275,0.5" />
+      <Blip texture="Content/Items/Command/sonarBlip.png" origin="0.5,0.5" />
+      <LineSprite texture="Content/Items/Command/NavUI.png" sourcerect="181,141,109,4" origin="0,0.5"/>
+      <icon identifier="outpost" texture="Content/UI/MainIconsAtlas.png" sourcerect="352,398,16,8" origin="0.5,0.5"/>
+      <icon identifier="submarine" texture="Content/UI/MainIconsAtlas.png" sourcerect="353,407,14,6" origin="0.5,0.5"/>
+      <icon identifier="shuttle" texture="Content/UI/MainIconsAtlas.png" sourcerect="336,407,8,6" origin="0.5,0.5"/>
+      <icon identifier="artifact" texture="Content/UI/MainIconsAtlas.png" sourcerect="336,414,8,8" origin="0.5,0.5"/>
+      <icon identifier="location" texture="Content/UI/MainIconsAtlas.png" sourcerect="349,435,11,11" origin="0.5,0.5"/>
+      <icon identifier="mineral" texture="Content/UI/MainIconsAtlas.png" sourcerect="336,434,7,12" origin="0.5,0.5"/>
+      <icon identifier="" texture="Content/UI/MainIconsAtlas.png" sourcerect="346,416,4,4" origin="0.5,0.5"/>
+      <LightComponent LightColor="120,255,120,255" range="25" powerconsumption="10" pulsefrequency="0.5" pulseamount="0.8" castshadows="false" IsOn="false" canbeselected="false">
+        <IsActive TargetItemComponent="Sonar" CurrentMode="Active"/>        
+      </LightComponent>
+    </Sonar>
+    <ItemContainer capacity="1" maxstacksize="1" hideitems="true" containedstateindicatorstyle="battery">
+      <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="128,448,64,64" origin="0.5,0.5" />
+      <Containable items="mobilebattery">
+        <StatusEffect type="OnContaining" targettype="This" Voltage="1.0" setvalue="true" />
+      </Containable>
+    </ItemContainer>
+    <Upgrade gameversion="0.10.0.0" scale="0.5" />
+  </Item>
+  
+  <Item name="" identifier="sonarbeacon" category="Equipment,Diving" Tags="smallitem,sonar,provocative" cargocontaineridentifier="metalcrate" Scale="0.5" impactsoundtag="impact_metal_light">
+    <PreferredContainer primary="divingcab" amount="1" spawnprobability="1" notcampaign="true" notpvp="true"/>
+    <PreferredContainer secondary="wreckstoragecab,wreckdivingcab" amount="1" spawnprobability="0.05"/>
+    <Price baseprice="150" minavailable="1">
+      <Price storeidentifier="merchantoutpost" sold="false" />
+      <Price storeidentifier="merchantcity" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" />
+      <Price storeidentifier="merchantmine" />
+      <Price storeidentifier="merchantengineering" multiplier="0.9" minavailable="2" />
+    </Price>
+    <Deconstruct time="15">
+      <Item identifier="copper" />
+      <Item identifier="plastic" amount="2" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="15">
+      <RequiredSkill identifier="mechanical" level="30" />
+      <RequiredItem identifier="fpgacircuit" />
+      <RequiredItem identifier="plastic" />
+    </Fabricate>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="832,320,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="473,1,29,65" depth="0.55" origin="0.5,0.5" />
+    <Body width="27" height="60" density="12" />
+    <Holdable slots="Any,RightHand,LeftHand" holdangle="30" handle1="0,-15" msg="ItemMsgPickUpSelect" />
+    <AiTarget soundrange="50000" sonarlabel="entityname.sonarbeacon" sight="500" staticsight="true"/>
+    <LightComponent LightColor="0.0,1.0,0.0,1.0" range="50" powerconsumption="10" blinkfrequency="2" IsOn="false" canbeselected="false">
+      <StatusEffect type="OnActive" targettype="Contained" Condition="-0.1">
+        <RequiredItem items="mobilebattery" type="Contained" />
+      </StatusEffect>
+      <StatusEffect type="OnActive" targettype="This" SoundRange="50000" setvalue="true">
+        <Conditional Voltage="gt 0.5" targetitemcomponent="LightComponent" />
+        <sound file="Content/Items/Weapons/SonarDecoy.ogg" range="500.0" loop="true" volume="0.25" />
+      </StatusEffect>
+    </LightComponent>
+    <CustomInterface canbeselected="false" drawhudwhenequipped="true" allowuioverlap="true">
+      <GuiFrame relativesize="0.16,0.15" anchor="CenterLeft" pivot="BottomLeft" relativeoffset="0.006,-0.05" style="ItemUI" />
+      <TickBox text="sonarbeacon.beaconactive">
+        <StatusEffect type="OnUse" targettype="This" IsOn="true" />
+        <StatusEffect type="OnSecondaryUse" targettype="This" IsOn="false" />
+      </TickBox>
+      <TextBox text="sonarbeacon.beaconsignal" propertyname="SonarLabel" maxtextlength="32"/>
+    </CustomInterface>
+    <ItemContainer capacity="1" maxstacksize="1" hideitems="true" containedstateindicatorstyle="battery">
+      <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="128,448,64,64" origin="0.5,0.5" />
+      <Containable items="mobilebattery">
+        <StatusEffect type="OnContaining" targettype="This" Voltage="1.0" setvalue="true" />
+      </Containable>
+    </ItemContainer>
+  </Item>
+  <Item name="" identifier="flashlight" category="Equipment" Tags="smallitem,tool,provocative" cargocontaineridentifier="metalcrate" Scale="0.5" impactsoundtag="impact_metal_light">
+    <PreferredContainer primary="divingcab" minamount="1" maxamount="2" spawnprobability="1" notcampaign="true" notpvp="true"/>
+    <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab,piratestoragecab,wrecksupplycab,beaconsupplycab" amount="1" spawnprobability="0.05"/>
+    <PreferredContainer secondary="outpostcrewcabinet" amount="1" spawnprobability="0.1"/>
+    <Price baseprice="200" minavailable="2">
+      <Price storeidentifier="merchantoutpost" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" minavailable="3" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" />
+      <Price storeidentifier="merchantmine" />
+    </Price>
+    <Fabricate suitablefabricators="fabricator" requiredtime="10">
+      <RequiredSkill identifier="mechanical" level="25" />
+      <RequiredItem identifier="aluminium" amount="2" />
+      <RequiredItem tag="lightcomponent" />
+    </Fabricate>
+    <Deconstruct time="15">
+      <Item identifier="aluminium" />
+      <Item identifier="lightcomponent" />
+    </Deconstruct>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="704,320,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="293,185,49,18" depth="0.55" origin="0.5,0.5" />
+    <Body width="48" height="15" density="15" />
+    <Holdable slots="Any,RightHand,LeftHand,Head" holdpos="30,-50" aimpos="60,0" handle1="-20,0" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="OnActive" targettype="Contained" Condition="-0.2">
+        <RequiredItem items="mobilebattery" type="Contained" />
+      </StatusEffect>
+      <!-- the child LightComponent is only active when the Holdable is active, i.e. when the item is being held -->
+      <LightComponent LightColor="0.5,0.5,0.5,1.0" directional="true" Flicker="0.02" range="800" powerconsumption="10" IsOn="true">
+        <LightTexture texture="Content/Lights/lightcone.png" origin="0.0, 0.5" size="1.0,1.0" />
+        <IsActive targetcontaineditem="true" condition="gt 1.0"/>
+      </LightComponent>
+      <LightComponent LightColor="0.5,0.5,0.5,1.0" directional="true" range="800" powerconsumption="10" IsOn="true" flicker="0.8" flickerspeed="1.0" pulsefrequency="0.1" pulseamount="0.5">
+        <LightTexture texture="Content/Lights/lightcone.png" origin="0.0, 0.5" size="1.0,1.0" />
+        <IsActive targetcontaineditem="true" condition="lte 1.0"/>
+      </LightComponent>
+    </Holdable>
+    <ItemContainer capacity="1" maxstacksize="1" hideitems="true" containedstateindicatorstyle="battery">
+      <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="128,448,64,64" origin="0.5,0.5" />
+      <Containable items="mobilebattery">
+        <StatusEffect type="OnContaining" targettype="This" Voltage="1.0" setvalue="true" />
+      </Containable>
+    </ItemContainer>
+    <AiTarget sightrange="3000" />
+    <Upgrade gameversion="0.10.0.0" scale="0.5" />
+  </Item>
+  
+  <Item name="" identifier="flare" category="Equipment" maxstacksize="32" maxstacksizecharacterinventory="8" cargocontaineridentifier="metalcrate" Scale="0.5" tags="smallitem,light,provocative" impactsoundtag="impact_soft" isshootable="true" damagedbymonsters="true" health="10">
+    <PreferredContainer primary="divingcab" minamount="2" maxamount="5" spawnprobability="1" notcampaign="true" notpvp="true"/>
+    <PreferredContainer secondary="abandonedstoragecab,piratestoragecab,wreckstoragecab" amount="1" spawnprobability="0.05"/>
+    <PreferredContainer secondary="outpostcrewcabinet" amount="1" spawnprobability="0.1"/>
+    <Price baseprice="30" minavailable="6">
+      <Price storeidentifier="merchantoutpost" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" minavailable="10" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" minavailable="8" />
+      <Price storeidentifier="merchantmine" minavailable="10" />
+      <Price storeidentifier="merchantarmory" multiplier="1.25" minavailable="8" />
+    </Price>
+    <Deconstruct time="5"/>      
+    <Fabricate suitablefabricators="fabricator" requiredtime="10" amount="12">
+      <RequiredItem identifier="flashpowder" amount="2" />
+      <RequiredItem identifier="plastic" />
+    </Fabricate>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="640,0,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="227,204,54,18" depth="0.55" origin="0.5,0.5" />
+    <Body width="50" height="15" density="10"/>
+    <Throwable slots="Any,RightHand,LeftHand" holdpos="0,0" handle1="0,0" holdangle="90" throwforce="2.0" aimpos="35,-10" msg="ItemMsgPickUpSelect" />
+    <LightComponent LightColor="255,0.0,0.0,255" Flicker="0.5" range="600" IsOn="false">
+      <StatusEffect type="OnUse" targettype="This" IsOn="true" DontCleanUp="True">
+        <Conditional IsOn="eq False" targetitemcomponent="LightComponent" />
+        <sound file="Content/Items/Tools/FlareIgnite.ogg" range="800.0" />
+      </StatusEffect>
+      <StatusEffect type="OnActive" targettype="This" Condition="-0.025" />
+      <StatusEffect type="OnActive" targettype="This">
+        <Conditional PhysicsBodyActive="eq true" />
+        <ParticleEmitter particle="flare" emitinterval="2.1" particleamount="10" particlespersecond="60" anglemin="70" anglemax="100" velocitymin="100" velocitymax="200" />
+        <ParticleEmitter particle="FlareBubbles"  particlespersecond="40" anglemin="70" anglemax="100" velocitymin="100" velocitymax="200" scalemin="0.8" scalemax="1.2" />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" targettype="This" IsOn="false" />
+      <sound file="Content/Items/Tools/FlareLoop.ogg" type="OnActive" range="800.0" loop="true" />
+    </LightComponent>
+    <AiTarget sightrange="4000"/>
+    <Upgrade gameversion="0.10.0.0" scale="0.5" />
+  </Item>
+    
+  <Item name="" identifier="alienflare" category="Equipment,Alien" maxstacksize="32" maxstacksizecharacterinventory="8" cargocontaineridentifier="metalcrate" Scale="0.5" tags="smallitem,light,provocative" impactsoundtag="impact_soft" isshootable="true" damagedbymonsters="true" health="10">
+    <PreferredContainer primary="divingcab"/>
+    <PreferredContainer secondary="abandonedstoragecab,piratestoragecab,wreckstoragecab" amount="1" spawnprobability="0.01"/>
+    <PreferredContainer primary="ruinstorage,ruinstoragesmall" minamount="1" maxamount="3" spawnprobability="0.2" />
+    <PreferredContainer primary="ruinstoragelarge" minamount="1" maxamount="3" spawnprobability="0.3" />
+    <Price baseprice="200" sold="false">
+      <Price storeidentifier="merchantoutpost" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" />
+      <Price storeidentifier="merchantmine" />
+    </Price>
+    <Deconstruct time="10">
+      <Item identifier="flashpowder" mincondition="0.9" />
+      <Item identifier="plastic" mincondition="0.9" />
+    </Deconstruct>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="68,966,54,54" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="283,204,54,18" depth="0.55" origin="0.5,0.5" />
+    <Body width="50" height="15" density="10" />
+    <Throwable slots="Any,RightHand,LeftHand" holdpos="0,0" handle1="0,0" holdangle="90" throwforce="2.0" aimpos="35,-10" msg="ItemMsgPickUpSelect" />
+    <LightComponent LightColor="0,162,232,255" Flicker="0.5" range="1000" IsOn="false">
+      <StatusEffect type="OnUse" targettype="This" IsOn="true" DontCleanUp="True">
+        <Conditional IsOn="eq False" targetitemcomponent="LightComponent" />
+        <sound file="Content/Items/Tools/FlareIgnite.ogg" range="800.0" />
+      </StatusEffect>
+      <StatusEffect type="OnActive" targettype="This" Condition="-0.0125">
+        <Conditional PhysicsBodyActive="eq true" />
+        <ParticleEmitter particle="flare" particlespersecond="30" />
+        <ParticleEmitter particle="bubbles" particlespersecond="30" />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" targettype="This" IsOn="false" />
+      <sound file="Content/Items/Tools/FlareLoop.ogg" type="OnActive" range="800.0" loop="true" />
+    </LightComponent>
+    <AiTarget sightrange="5000"/>
+    <Upgrade gameversion="0.10.0.0" scale="0.5" />
+  </Item>
+
+  <Item name="" identifier="flamer" category="Equipment" Tags="smallitem,weapon,gun,mountableweapon" cargocontaineridentifier="metalcrate" Scale="0.5" impactsoundtag="impact_metal_light">
+    <Upgrade gameversion="0.10.0.0" scale="0.5" />
+    <PreferredContainer primary="secarmcab" amount="1" spawnprobability="0.2" notcampaign="true" notpvp="true"/>
+    <PreferredContainer secondary="wrecksecarmcab,abandonedsecarmcab,piratesecarmcab" amount="1" spawnprobability="0.1"/>
+    <PreferredContainer secondary="armcab,weaponholder"/>
+    <Price baseprice="105" sold="false">
+      <Price storeidentifier="merchantoutpost" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" />
+      <Price storeidentifier="merchantmilitary" sold="true" multiplier="1.25" minavailable="1" />
+      <Price storeidentifier="merchantmine" />
+      <Price storeidentifier="merchantarmory" multiplier="1.25" minavailable="1" />
+    </Price>
+    <!--<InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="64,64,64,64" />-->
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="320,64,64,64" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="154,22,158,77" depth="0.55" origin="0.5,0.5" />
+    <!-- the item takes 10 seconds to break down in a deconstructor and turns into steel and plastic -->
+    <Deconstruct time="10">
+      <Item identifier="steel" />
+      <Item identifier="rubber" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="20" requiresrecipe="true">
+      <RequiredSkill identifier="mechanical" level="30" />
+      <RequiredSkill identifier="weapons" level="20" />
+      <RequiredItem identifier="steel" amount="2" />
+      <RequiredItem identifier="rubber" amount="2" />
+    </Fabricate>
+    <!-- physics body -->
+    <Body width="150" height="77" density="25" />
+    <!-- the character will hold the item 50 pixels in front of him, with his hands at the handle1 and handle2 positions -->
+    <Holdable slots="Any,RightHand+LeftHand" controlpose="true" aimpos="50,0" handle1="-62,-16" handle2="-11,-6" msg="ItemMsgPickUpSelect" />
+    <RepairTool firedamage="25.0" structurefixamount="0.0" usablein="Air" range="500" barrelpos="35,10" fireprobability="0.1" repairmultiple="true" RepairMultipleWalls="false" repairthroughwalls="false" repairthroughholes="true" combatpriority="50" spread="25" unskilledspread="25">
+      <!-- the item must contain a welding fuel tank for it to work -->
+      <RequiredItems items="weldingtoolfuel,oxygensource" type="Contained" msg="ItemMsgWeldingFuelRequired" />
+      <RequiredSkill identifier="weapons" level="50" />
+      <ParticleEmitterHitCharacter particle="fleshsmoke" particlespersecond="3" anglemin="265" anglemax="275" velocitymin="0" velocitymax="50" />
+      <ParticleEmitter particle="flamethrower" particlespersecond="80" anglemin="0" anglemax="0" velocitymin="1000" velocitymax="1500" highqualitycollisiondetection="true"/>
+      <ParticleEmitter particle="flamethrowersmoke" particlespersecond="80" anglemin="0" anglemax="0" velocitymin="500" velocitymax="1000"/>
+      <sound file="Content/Items/Weapons/FlameThrowerLoop.ogg" type="OnUse" range="750.0" loop="true" />
+      <StatusEffect type="OnFailure" target="This">
+        <ParticleEmitter particle="bubbles" particlespersecond="20" anglemin="-10" anglemax="10" scalemin="0.3" scalemax="0.7" velocitymin="5" velocitymax="100" copyentityangle="true"/>
+        <ParticleEmitter particle="fleshsmoke" particlespersecond="10" anglemin="-10" anglemax="10" scalemin="1" scalemax="1.5" velocitymin="5" velocitymax="200" copyentityangle="true"/>
+      </StatusEffect>
+      <StatusEffect type="OnSuccess" targettype="UseTarget" targets="item" Condition="-15.0">
+        <Conditional HasTag="neq weldable"/>
+      </StatusEffect>
+      <!-- make the item unusable when there's less than 10% oxygen -->
+      <StatusEffect type="OnUse" target="Hull,This" UsableIn="None">
+        <Conditional OxygenPercentage="lt 10"/>
+      </StatusEffect>
+      <!-- make the item usable again when there's more than 10% oxygen -->
+      <StatusEffect type="OnUse" target="Hull,This" UsableIn="Air">
+        <Conditional OxygenPercentage="gt 10"/>
+      </StatusEffect>
+      <!-- when using, the contained welding fuel tank will detoriate (= lose fuel) -->
+      <StatusEffect type="OnUse" targettype="Contained" targets="weldingfueltank" Condition="-25.0" />
+      <StatusEffect type="OnUse" targettype="Contained" targets="incendiumfueltank" Condition="-10.0" />
+      <!-- do burn damage to characters -->
+      <StatusEffect type="OnUse" target="UseTarget">
+        <Conditional InWater="false"/>
+        <Affliction identifier="burn" amount="1.25" />
+        <Affliction identifier="burning" amount="2" dividebylimbcount="true"/>
+      </StatusEffect>
+      <StatusEffect type="OnUse" target="UseTarget">
+        <RequiredItem items="incendiumfueltank" type="Contained" />
+        <Conditional InWater="false"/>
+        <Affliction identifier="burn" amount="2.5" />
+        <Affliction identifier="burning" amount="2" dividebylimbcount="true"/>
+        <Affliction identifier="stun" strength="1" probability="0.1" />
+      </StatusEffect>
+      <StatusEffect type="OnUse" target="This" firedamage="40.0" fireprobability="0.35" setvalue="true">
+        <RequiredItem items="incendiumfueltank" type="Contained" />
+      </StatusEffect>
+      <!-- explode if oxygen tanks are inserted -->
+      <StatusEffect type="OnUse" targettype="Contained" targets="oxygentank" delay="1.0" stackable="false" Condition="0" setvalue="true">
+        <sound file="Content/Items/Weapons/ExplosionSmall1.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionSmall2.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionSmall3.ogg" range="2000" />
+        <Explosion range="150.0" force="3" applyfireeffects="false" >
+          <Affliction identifier="burn" strength="25" />
+          <Affliction identifier="stun" strength="5" />
+        </Explosion>
+      </StatusEffect>
+      <StatusEffect type="OnUse" targettype="Contained" targets="oxygenitetank" delay="1.0" stackable="false" Condition="0" setvalue="true">
+        <sound file="Content/Items/Weapons/ExplosionSmall1.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionSmall2.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionSmall3.ogg" range="2000" />
+        <Explosion range="150.0" force="6" applyfireeffects="false" >
+          <Affliction identifier="burn" strength="50" />
+          <Affliction identifier="stun" strength="10" />
+        </Explosion>
+      </StatusEffect>
+      <!-- consume oxygen from the hull -->
+      <StatusEffect type="OnUse" target="Hull" Oxygen="-10000"/>
+      <!-- Self-damage on fail -->
+      <StatusEffect type="OnFailure" target="Character" targetlimbs="LeftHand,RightHand">
+        <Conditional InWater="false"/>
+        <Affliction identifier="burn" strength="7.5" probability="0.5"/>
+      </StatusEffect>
+      <StatusEffect type="OnFailure" target="Character" targetlimbs="LeftHand,RightHand">
+        <RequiredItem items="incendiumfueltank" type="Contained" />
+        <Conditional InWater="false"/>
+        <Affliction identifier="burn" strength="5.0" probability="0.5"/>
+      </StatusEffect>
+      <LightComponent LightColor="255,174,121,255" Flicker="0.5" Range="500">
+        <sprite texture="Content/Items/Electricity/lightsprite.png" origin="0.5,0.5" />
+      </LightComponent>
+    </RepairTool>
+    <!-- one welding fuel or oxygen tank can be contained inside the welding tool -->
+    <ItemContainer capacity="1" maxstacksize="1" hideitems="false" itempos="8,-20" containedspritedepth="0.56" containedstateindicatorstyle="tank">
+      <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
+      <Containable items="weldingtoolfuel,oxygensource" />
+    </ItemContainer>
+    <aitarget sightrange="5000" soundrange="500" fadeouttime="5" />
+    <SkillRequirementHint identifier="weapons" level="50" />
+  </Item>
+
+  <Item name="" identifier="syringegun" category="Equipment,Medical,Weapon" cargocontaineridentifier="metalcrate" tags="smallitem,gun,mountableweapon" scale="0.5" impactsoundtag="impact_metal_light">
+    <Upgrade gameversion="0.10.0.0" scale="0.5" />
+    <PreferredContainer primary="armcab" amount="1" spawnprobability="0.2" notcampaign="true" notpvp="true"/>
+    <PreferredContainer secondary="secarmcab,weaponholder"/>
+    <PreferredContainer secondary="wreckmedcab,abandonedmedcab,piratemedcab,wreckarmcab,abandonedarmcab,piratearmcab" amount="1" spawnprobability="0.05" />
+    <Price baseprice="190" minavailable="1">
+      <Price storeidentifier="merchantoutpost" sold="false" />
+      <Price storeidentifier="merchantcity" sold="false" multiplier="0.9" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" />
+      <Price storeidentifier="merchantmilitary" sold="false" multiplier="1.25" />
+      <Price storeidentifier="merchantmine" sold="false"/>
+      <Price storeidentifier="merchantmedical" multiplier="1.25" />
+    </Price>
+    <Deconstruct time="10">
+      <Item identifier="aluminium" />
+      <Item identifier="plastic" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="10">
+      <RequiredSkill identifier="medical" level="50" />
+      <RequiredItem identifier="aluminium" amount="2" />
+      <RequiredItem identifier="plastic" amount="2" />
+    </Fabricate>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="0,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="0,93,149,71" depth="0.7" origin="0.5,0.5" />
+    <Body width="90" radius="40" density="25" />
+    <Holdable slots="RightHand+LeftHand,Any" controlpose="true" aimpos="30,-20" handle1="0,-7" handle2="55, 20" msg="ItemMsgPickUpSelect" />
+    <RangedWeapon barrelpos="71,30" spread="0" unskilledspread="10" drawhudwhenequipped="true" crosshairscale="0.2">
+      <Crosshair texture="Content/Items/Weapons/Crosshairs.png" sourcerect="0,256,256,256" />
+      <CrosshairPointer texture="Content/Items/Weapons/Crosshairs.png" sourcerect="256,256,256,256" />
+      <Sound file="Content/Items/Weapons/SyringeGun1.ogg" type="OnUse" range="1000" volume="0.75"/>
+      <Sound file="Content/Items/Weapons/SyringeGun2.ogg" type="OnUse" range="1000" volume="0.75"/>
+      <RequiredItems items="syringe" type="Contained" msg="ItemMsgSyringeRequired" />
+      <RequiredSkill identifier="weapons" level="20" />
+      <RequiredSkill identifier="medical" level="30" />
+    </RangedWeapon>
+    <ItemContainer capacity="1" maxstacksize="4" itempos="0,25" itemrotation="-90" hideitems="false" containedstateindicatorstyle="syringe">
+      <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="384,448,64,64" origin="0.5,0.5" />
+      <Containable items="syringe" />
+    </ItemContainer>
+    <aitarget sightrange="0" soundrange="0" />
+    <SkillRequirementHint identifier="weapons" level="20" />
+    <SkillRequirementHint identifier="medical" level="30" />
+  </Item>
+
+  <Item name="" identifier="oxygentank" category="Diving,Equipment" health="200" maxstacksize="8" maxstacksizecharacterinventory="1" MaxStackSizeHoldableOrWearableInventory="1" Tags="smallitem,oxygensource,refillableoxygensource" cargocontaineridentifier="metalcrate" scale="0.5" impactsoundtag="impact_metal_light" allowdroppingonswap="true">
+    <Upgrade gameversion="0.10.0.0" scale="0.5" />
+    <Price baseprice="75">
+      <Price storeidentifier="merchantoutpost" minavailable="10"/>
+      <Price storeidentifier="merchantcity" multiplier="0.9" minavailable="15" />
+      <Price storeidentifier="merchantresearch" minavailable="10"/>
+      <Price storeidentifier="merchantmilitary" minavailable="10"/>
+      <Price storeidentifier="merchantmine" multiplier="1.25" minavailable="20" />
+    </Price>
+    <PreferredContainer secondary="respawncontainer" amount="8" spawnprobability="1" notcampaign="true"/>
+    <PreferredContainer primary="oxygentankcontainer" amount="3" spawnprobability="1"/>
+    <PreferredContainer primary="oxygengenerator" maxcondition="75"/>
+    <PreferredContainer primary="divingmask,plasmacutter,deepdiving" spawnprobability="1.0" mincondition="25"/>
+    <PreferredContainer secondary="divingcab" minamount="3" maxamount="5" spawnprobability="1" mincondition="25" notcampaign="true"/>
+    <PreferredContainer secondary="supplycab" amount="1" spawnprobability="0.5" mincondition="25" notcampaign="true" notpvp="true"/>
+    <PreferredContainer secondary="outpostsupplycab" minamount="1" maxamount="3" spawnprobability="0.5"/>
+    <PreferredContainer secondary="wrecksupplycab,beaconsupplycab" amount="1" spawnprobability="0.2"/>
+    <PreferredContainer secondary="wreckoxygentankcontainer" minamount="1" maxamount="3" spawnprobability="0.3"/>
+    <PreferredContainer secondary="outpostcrewcabinet" minamount="1" maxamount="3" spawnprobability="0.2"/>
+    <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab,piratestoragecab" minamount="1" maxamount="3" spawnprobability="0.1"/>
+    <Deconstruct time="10">
+      <Item identifier="aluminium" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" displayname="OxygenTankEmpty" outcondition="0.0">
+      <RequiredSkill identifier="mechanical" level="20" />
+      <RequiredItem identifier="aluminium" amount="2" />
+    </Fabricate>
+    <Fabricate suitablefabricators="vendingmachine" requiredtime="1" requiredmoney="120" fabricationlimitmin="0" fabricationlimitmax="4" quality="0"/>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="896,0,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="410,71,24,66" depth="0.55" origin="0.5,0.5" />
+    <Body width="22" height="64" density="9.7" />
+    <Holdable canbecombined="true" slots="Any,RightHand,LeftHand" holdpos="30,-15" handle1="0,5" handle2="0,-5" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="OnFire" target="This" Condition="-10.0" statuseffecttags="onfire" duration="1" stackable="false" />
+      <StatusEffect type="OnBroken" target="This" delay="1" stackable="false">
+        <Conditional HasStatusTag="onfire" />
+        <sound file="Content/Items/Weapons/ExplosionSmall1.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionDebris1.ogg" range="2000" />
+        <Explosion range="150.0" force="3" debris="true" >
+          <Affliction identifier="burn" strength="25" />
+          <Affliction identifier="stun" strength="5" />
+        </Explosion>  
+      </StatusEffect>
+    </Holdable>
+    <Quality>
+      <QualityStat stattype="Condition" value="0.1"/>
+    </Quality>
+  </Item>
+
+  <Item name="" identifier="oxygenitetank" category="Diving,Equipment" maxstacksize="8" maxstacksizecharacterinventory="1" MaxStackSizeHoldableOrWearableInventory="1" health="400" Tags="smallitem,oxygensource" description="" scale="0.5" impactsoundtag="impact_metal_light">
+    <Upgrade gameversion="0.10.0.0" scale="0.5" />
+    <Price baseprice="175" displaynonempty="true">
+      <Price storeidentifier="merchantoutpost" sold="false" />
+      <Price storeidentifier="merchantcity" sold="false" multiplier="0.9" />
+      <Price storeidentifier="merchantresearch" sold="false" />
+      <Price storeidentifier="merchantmilitary" sold="false" />
+      <Price storeidentifier="merchantmine" multiplier="1.25" minavailable="1"/>
+    </Price>
+    <PreferredContainer primary="oxygentankcontainer"/>
+    <PreferredContainer secondary="wrecksupplycab" amount="1" spawnprobability="0.02"/>
+    <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab,piratestoragecab" amount="1" spawnprobability="0.01"/>
+    <Deconstruct time="10">
+      <Item identifier="aluminium" />
+      <Item identifier="liquidoxygenite" mincondition="0.1" />
+      <Item identifier="liquidoxygenite" mincondition="0.9" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" outcondition="1.0" requiredtime="5">
+      <RequiredSkill identifier="mechanical" level="40" />
+      <RequiredItem identifier="aluminium" amount="2" />
+      <RequiredItem identifier="liquidoxygenite" amount="2" />
+    </Fabricate>
+    <Fabricate suitablefabricators="fabricator" displayname="recycleitem" requiredtime="5">
+      <RequiredSkill identifier="mechanical" level="40" />
+      <RequiredItem identifier="oxygenitetank" mincondition="0.0" maxcondition="0.1" usecondition="false"/>
+      <RequiredItem identifier="liquidoxygenite" amount="2" />
+    </Fabricate>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="319,901,61,61" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="486,71,24,64" depth="0.55" />
+    <Body width="22" height="64" density="9.9" />
+    <Holdable canbecombined="true" slots="Any,RightHand,LeftHand" holdpos="30,-15" handle1="0,5" handle2="0,-5" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="OnFire" target="This" Condition="-10.0" statuseffecttags="onfire" duration="1" stackable="false" />
+      <StatusEffect type="OnBroken" target="This" delay="1" stackable="false">
+        <Conditional HasStatusTag="onfire" />
+        <sound file="Content/Items/Weapons/ExplosionSmall1.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionSmall2.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionSmall3.ogg" range="2000" />
+        <Explosion range="150.0" force="6" >
+          <Affliction identifier="burn" strength="50" />
+          <Affliction identifier="stun" strength="10" />
+        </Explosion>
+      </StatusEffect>
+    </Holdable>
+    <Quality>
+      <QualityStat stattype="Condition" value="0.1"/>
+    </Quality>
+  </Item>
+
+  <Item name="" identifier="fuelrod" Category="Fuel" Tags="smallitem,reactorfuel,divingsuitfuel" maxstacksize="8" cargocontaineridentifier="metalcrate" scale="0.5">
+    <PreferredContainer primary="reactorcab"/>
+    <PreferredContainer secondary="nucleargun" minamount="1" maxamount="1" spawnprobability="1"/>
+    <PreferredContainer secondary="wreckreactorcab,abandonedreactorcab,piratereactorcab" minamount="1" maxamount="2" spawnprobability="0.5"/>
+    <PreferredContainer secondary="beaconengcab" amount="1" spawnprobability="0.2"/>
+    <PreferredContainer secondary="abandonedengcab,pirateengcab,wreckengcab" amount="1" spawnprobability="0.05"/>
+    <Price baseprice="150" displaynonempty="true" minavailable="2">
+      <Price storeidentifier="merchantoutpost" />
+      <Price storeidentifier="merchantcity" minavailable="3" />
+      <Price storeidentifier="merchantresearch" />
+      <Price storeidentifier="merchantmilitary" />
+      <Price storeidentifier="merchantmine" />
+      <Price storeidentifier="merchantengineering" multiplier="0.9" minavailable="5" />
+      <Price storeidentifier="merchanttutorial" multiplier="0.5" minavailable="3" />
+    </Price>
+    <Deconstruct time="10">
+      <Item identifier="steel" />
+      <Item identifier="uranium" mincondition="0.95"/>
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="15">
+      <RequiredSkill identifier="electrical" level="25" />
+      <RequiredItem identifier="uranium" />
+      <RequiredItem identifier="steel" />
+      <RequiredItem identifier="lead" />
+    </Fabricate>
+    <Fabricate suitablefabricators="fabricator" displayname="recycleitem" requiredtime="10">
+      <RequiredSkill identifier="electrical" level="15" />
+      <RequiredItem identifier="uranium" />
+      <RequiredItem identifier="fuelrod" mincondition="0.0" maxcondition="0.1" usecondition="false"/>
+    </Fabricate>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="576,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" depth="0.55" sourcerect="410,1,19,68" />
+    <Body radius="6" height="55" density="20" />
+    <Holdable handle1="0,0" slots="Any,RightHand,LeftHand" msg="ItemMsgPickUpSelect" >
+      <!--Status effect to cause radiation whenever handling fuel rods. Disabled for now because effect doesn't stop when no longer in contact with fuel rods.-->
+      <!--<StatusEffect type="Always" target="Character">
+        <Affliction identifier="radiationsickness" strength="0.25" />
+      </StatusEffect>-->
+    </Holdable>
+    <ItemContainer hideitems="true" capacity="1" itemrotation="90" drawinventory="false" canbeselected="false" SpawnWithId="nucleargunbolt" removecontaineditemsondeconstruct="true" showcontainedstateindicator="false">
+      <Containable items="nucleargunbolt" />
+      <StatusEffect type="OnUse" target="This" condition="-25.0" disabledeltatime="true">
+        <SpawnItem identifiers="nucleargunbolt" spawnposition="ThisInventory" />
+      </StatusEffect>
+    </ItemContainer>
+    <Quality>
+      <QualityStat stattype="Condition" value="0.1"/>
+    </Quality>
+  </Item>
+
+  <Item name="" identifier="fulguriumfuelrod" Category="Fuel" Tags="smallitem,reactorfuel,divingsuitfuel" maxstacksize="8" cargocontaineridentifier="metalcrate" health="150" scale="0.5">
+    <PreferredContainer primary="reactorcab" />
+    <PreferredContainer secondary="wreckreactorcab,abandonedreactorcab,piratereactorcab" amount="1" spawnprobability="0.2"/>
+    <PreferredContainer secondary="beaconengcab" amount="1" spawnprobability="0.05"/>
+    <PreferredContainer secondary="abandonedengcab,pirateengcab,wreckengcab" amount="1" spawnprobability="0.01"/>
+    <Price baseprice="250" sold="false" displaynonempty="true">
+      <Price storeidentifier="merchantoutpost" />
+      <Price storeidentifier="merchantcity" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" />
+      <Price storeidentifier="merchantmine" multiplier="1.1" />
+      <Price storeidentifier="merchantengineering" multiplier="0.9" minavailable="2" />
+    </Price>
+    <Deconstruct time="10">
+      <Item identifier="steel" />
+      <Item identifier="lead" />
+      <Item identifier="fulgurium" mincondition="0.95"/>
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="15">
+      <RequiredSkill identifier="electrical" level="60" />
+      <RequiredItem identifier="fulgurium" />
+      <RequiredItem identifier="lead" amount="2" />
+      <RequiredItem identifier="steel" />
+    </Fabricate>
+    <Fabricate suitablefabricators="fabricator" displayname="recycleitem" requiredtime="10">
+      <RequiredSkill identifier="electrical" level="40" />
+      <RequiredItem identifier="fulgurium" />
+      <RequiredItem identifier="fulguriumfuelrod" mincondition="0.0" maxcondition="0.1" usecondition="false"/>
+    </Fabricate>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="640,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" depth="0.55" sourcerect="431,1,19,68" />
+    <Body radius="6" height="55" density="20" />
+    <Holdable handle1="0,0" slots="Any,RightHand,LeftHand" msg="ItemMsgPickUpSelect" />
+    <ItemContainer hideitems="true" capacity="1" itemrotation="90" drawinventory="false" canbeselected="false" SpawnWithId="nucleargunbolt" removecontaineditemsondeconstruct="true" showcontainedstateindicator="false">
+      <Containable items="nucleargunbolt" />
+      <StatusEffect type="OnUse" target="This" condition="-12.5" disabledeltatime="true">
+        <SpawnItem identifiers="nucleargunbolt" spawnposition="ThisInventory" />
+      </StatusEffect>
+    </ItemContainer>
+    <Quality>
+      <QualityStat stattype="Condition" value="0.1"/>
+    </Quality>
+  </Item>
+
+  <Item name="" identifier="thoriumfuelrod" Category="Fuel" Tags="smallitem,reactorfuel,divingsuitfuel" maxstacksize="8" cargocontaineridentifier="metalcrate" health="200" scale="0.5">
+    <PreferredContainer primary="reactorcab" />
+    <PreferredContainer secondary="wreckreactorcab,abandonedreactorcab,piratereactorcab" amount="1" spawnprobability="0.1"/>
+    <PreferredContainer secondary="beaconengcab" amount="1" spawnprobability="0.02"/>
+    <PreferredContainer secondary="abandonedengcab,pirateengcab,wreckengcab" amount="1" spawnprobability="0.01"/>
+    <Price baseprice="200" displaynonempty="true">
+      <Price storeidentifier="merchantoutpost" sold="false" />
+      <Price storeidentifier="merchantcity" minavailable="1" />
+      <Price storeidentifier="merchantresearch" sold="false" multiplier="1.25" />
+      <Price storeidentifier="merchantmilitary" sold="false" multiplier="1.25" />
+      <Price storeidentifier="merchantmine" sold="false" multiplier="1.25" />
+      <Price storeidentifier="merchantengineering" multiplier="0.9" minavailable="2" />
+    </Price>
+    <Deconstruct time="10">
+      <Item identifier="steel" />
+      <Item identifier="lead" />
+      <Item identifier="thorium" mincondition="0.95"/>
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="15">
+      <RequiredSkill identifier="electrical" level="50" />
+      <RequiredItem identifier="thorium" />
+      <RequiredItem identifier="steel" />
+      <RequiredItem identifier="lead" amount="2" />
+    </Fabricate>
+    <Fabricate suitablefabricators="fabricator" displayname="recycleitem" requiredtime="10">
+      <RequiredSkill identifier="electrical" level="30" />
+      <RequiredItem identifier="thorium" />
+      <RequiredItem identifier="thoriumfuelrod" mincondition="0.0" maxcondition="0.1" usecondition="false"/>
+    </Fabricate>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="384,64,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" depth="0.55" sourcerect="452,1,19,68" />
+    <Body radius="6" width="21" height="71" density="20" />
+    <Holdable handle1="0,0" slots="Any,RightHand,LeftHand" msg="ItemMsgPickUpSelect">
+      <!--Status effect to cause radiation whenever handling fuel rods. Disabled for now because effect doesn't stop when no longer in contact with fuel rods.-->
+      <!--<StatusEffect type="Always" target="Character">
+        <Affliction identifier="radiationsickness" strength="0.5" />
+      </StatusEffect>-->
+    </Holdable>
+    <ItemContainer hideitems="true" capacity="1" itemrotation="90" drawinventory="false" canbeselected="false" SpawnWithId="nucleargunbolt" removecontaineditemsondeconstruct="true" showcontainedstateindicator="false">
+      <Containable items="nucleargunbolt" />
+      <StatusEffect type="OnUse" target="This" condition="-25.0" disabledeltatime="true">
+        <SpawnItem identifiers="nucleargunbolt" spawnposition="ThisInventory" />
+      </StatusEffect>
+    </ItemContainer>
+    <Quality>
+      <QualityStat stattype="Condition" value="0.1"/>
+    </Quality>
+  </Item>
+
+  <redpaint name="" identifier="redpaint" category="Misc" maxstacksize="8" cargocontaineridentifier="chemicalcrate" description="" Tags="smallitem,paint" spritecolor="128,0,0,255" InventoryIconColor="255,0,0,255" scale="0.5" impactsoundtag="impact_metal_light" impacttolerance="6">
+    <PreferredContainer secondary="storagecab" minamount="1" maxamount="2" spawnprobability="0.25" notcampaign="true" notpvp="true"/>
+    <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab,piratestoragecab" amount="1" spawnprobability="0.1" />
+    <Price baseprice="140" minleveldifficulty="5">
+      <Price storeidentifier="merchantoutpost" multiplier="1.1" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" minavailable="2" />
+      <Price storeidentifier="merchantresearch" multiplier="1.2" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.2" />
+      <Price storeidentifier="merchantmine" multiplier="1.2" />
+    </Price>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas2.png" sourcerect="256,320,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="379,78,27,58" depth="0.6" origin="0.5,0.5" />
+    <Body width="25" height="55" density="12" />
+    <Fabricate suitablefabricators="fabricator" requiredtime="30">
+      <RequiredSkill identifier="mechanical" level="20" />
+      <RequiredItem identifier="ethanol" />
+      <RequiredItem identifier="tin" />
+      <RequiredItem identifier="alienblood" />
+    </Fabricate>
+    <Deconstruct time="10">
+      <Item identifier="ethanol" mincondition="0.9" />
+    </Deconstruct>
+    <Throwable characterusable="true" canBeCombined="true" slots="Any,RightHand,LeftHand" throwforce="3.5" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="OnImpact" target="This" Condition="0.0" setvalue="true">
+        <Explosion range="0.0" structuredamage="0" itemdamage="0" force="0.0" severlimbsprobability="0.0" decal="fruitsplatter_red" decalsize="1.0" />
+        <ParticleEmitter particle="whitegoosplash" anglemin="0" anglemax="360" particleamount="2" velocitymin="0" velocitymax="0" scalemin="1.5" scalemax="2" colormultiplier="128,0,0,255" />
+      </StatusEffect>
+      <StatusEffect type="OnFire" target="This" Condition="-50.0" interval="1" disabledeltatime="true" />
+      <StatusEffect type="OnBroken" target="This" Condition="-100.0">
+        <Remove />
+      </StatusEffect>
+    </Throwable>
+  </redpaint>
+
+  <greenpaint name="" identifier="greenpaint" category="Misc" maxstacksize="8" cargocontaineridentifier="chemicalcrate" description="" Tags="smallitem,paint" spritecolor="0,128,0,255" InventoryIconColor="0,255,0,255" scale="0.5" impactsoundtag="impact_metal_light"  impacttolerance="6">
+    <PreferredContainer secondary="storagecab" minamount="1" maxamount="2" spawnprobability="0.25" notcampaign="true" notpvp="true"/>
+    <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab,piratestoragecab" amount="1" spawnprobability="0.1" />
+    <Price baseprice="90" minleveldifficulty="5">
+      <Price storeidentifier="merchantoutpost" multiplier="1.1" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" minavailable="2" />
+      <Price storeidentifier="merchantresearch" multiplier="1.2" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.2" />
+      <Price storeidentifier="merchantmine" multiplier="1.2" />
+    </Price>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas2.png" sourcerect="256,320,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="379,78,27,58" depth="0.6" origin="0.5,0.5" />
+    <Body width="25" height="55" density="12" />
+    <Fabricate suitablefabricators="fabricator" requiredtime="30" >
+      <RequiredSkill identifier="mechanical" level="20" />
+      <RequiredItem identifier="ethanol"  />
+      <RequiredItem identifier="tin" />
+      <RequiredItem identifier="copper" />
+    </Fabricate>
+    <Deconstruct time="10">
+      <Item identifier="ethanol" mincondition="0.9" />
+    </Deconstruct>
+    <Throwable characterusable="true" canBeCombined="true" slots="Any,RightHand,LeftHand" throwforce="3.5" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="OnImpact" target="This" Condition="0.0" setvalue="true">
+        <Explosion range="0.0" structuredamage="0" itemdamage="0" force="0.0" severlimbsprobability="0.0" decal="fruitsplatter_green" decalsize="1.0" />
+        <ParticleEmitter particle="whitegoosplash" anglemin="0" anglemax="360" particleamount="2" velocitymin="0" velocitymax="0" scalemin="1.5" scalemax="2" colormultiplier="0,128,0,255" />
+      </StatusEffect>
+      <StatusEffect type="OnFire" target="This" Condition="-50.0" interval="1" disabledeltatime="true" />
+      <StatusEffect type="OnBroken" target="This" Condition="-100.0">
+        <Remove />
+      </StatusEffect>
+    </Throwable>
+  </greenpaint>
+
+  <bluepaint name="" identifier="bluepaint" category="Misc" maxstacksize="8" cargocontaineridentifier="chemicalcrate" description="" Tags="smallitem,paint" spritecolor="0,0,128,255" InventoryIconColor="0,0,255,255" scale="0.5" impactsoundtag="impact_metal_light" impacttolerance="6">
+    <PreferredContainer secondary="storagecab" minamount="1" maxamount="2" spawnprobability="0.25" notcampaign="true" notpvp="true"/>
+    <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab,piratestoragecab" amount="1" spawnprobability="0.1" />
+    <Price baseprice="90" minleveldifficulty="5">
+      <Price storeidentifier="merchantoutpost" multiplier="1.1" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" minavailable="2" />
+      <Price storeidentifier="merchantresearch" multiplier="1.2" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.2" />
+      <Price storeidentifier="merchantmine" multiplier="1.2" />
+    </Price>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas2.png" sourcerect="256,320,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="379,78,27,58" depth="0.6" origin="0.5,0.5" />
+    <Body width="25" height="55" density="12" />
+    <Fabricate suitablefabricators="fabricator" requiredtime="30">
+      <RequiredSkill identifier="mechanical" level="20" />
+      <RequiredItem identifier="ethanol" />
+      <RequiredItem identifier="tin" />
+      <RequiredItem identifier="zinc" />
+    </Fabricate>
+    <Deconstruct time="10">
+      <Item identifier="ethanol" mincondition="0.9" />
+    </Deconstruct>
+    <Throwable characterusable="true" canBeCombined="true" slots="Any,RightHand,LeftHand" throwforce="3.5" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="OnImpact" target="This" Condition="0.0" setvalue="true">
+        <Explosion range="0.0" structuredamage="0" itemdamage="0" force="0.0" severlimbsprobability="0.0" decal="fruitsplatter_blue" decalsize="1.0" />
+        <ParticleEmitter particle="whitegoosplash" anglemin="0" anglemax="360" particleamount="2" velocitymin="0" velocitymax="0" scalemin="1.5" scalemax="2" colormultiplier="0,0,128,255" />
+      </StatusEffect>
+      <StatusEffect type="OnFire" target="This" Condition="-50.0" interval="1" disabledeltatime="true" />
+      <StatusEffect type="OnBroken" target="This" Condition="-100.0">
+        <Remove />
+      </StatusEffect>
+    </Throwable>
+  </bluepaint>
+
+  <blackpaint name="" identifier="blackpaint" category="Misc" maxstacksize="8" cargocontaineridentifier="chemicalcrate" description="" Tags="smallitem,paint" spritecolor="20,20,20,255" InventoryIconColor="20,20,20,255" scale="0.5" impactsoundtag="impact_metal_light" impacttolerance="6">
+    <PreferredContainer secondary="storagecab" minamount="1" maxamount="2" spawnprobability="0.25" notcampaign="true" notpvp="true"/>
+    <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab,piratestoragecab" amount="1" spawnprobability="0.1" />
+    <Price baseprice="90" minleveldifficulty="5">
+      <Price storeidentifier="merchantoutpost" multiplier="1.1" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" minavailable="2" />
+      <Price storeidentifier="merchantresearch" multiplier="1.2" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.2" />
+      <Price storeidentifier="merchantmine" multiplier="1.2" />
+    </Price>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas2.png" sourcerect="256,320,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="379,78,27,58" depth="0.6" origin="0.5,0.5" />
+    <Body width="25" height="55" density="12" />
+    <Fabricate suitablefabricators="fabricator" requiredtime="30" >
+      <RequiredSkill identifier="mechanical" level="20" />
+      <RequiredItem identifier="ethanol" />
+      <RequiredItem identifier="tin" />
+      <RequiredItem identifier="zinc" />
+    </Fabricate>
+    <Deconstruct time="10">
+      <Item identifier="ethanol" mincondition="0.9" />
+    </Deconstruct>
+    <Throwable characterusable="true" canBeCombined="true" slots="Any,RightHand,LeftHand" throwforce="3.5" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="OnImpact" target="This" Condition="0.0" setvalue="true">
+        <Explosion range="0.0" structuredamage="0" itemdamage="0" force="0.0" severlimbsprobability="0.0" decal="fruitsplatter_black" decalsize="1.0" />
+        <ParticleEmitter particle="whitegoosplash" anglemin="0" anglemax="360" particleamount="2" velocitymin="0" velocitymax="0" scalemin="1.5" scalemax="2" colormultiplier="20,20,20,255" />
+      </StatusEffect>
+      <StatusEffect type="OnFire" target="This" Condition="-50.0" interval="1" disabledeltatime="true" />
+      <StatusEffect type="OnBroken" target="This" Condition="-100.0">
+        <Remove />
+      </StatusEffect>
+    </Throwable>
+  </blackpaint>
+
+  <whitepaint name="" identifier="whitepaint" category="Misc" maxstacksize="8" cargocontaineridentifier="chemicalcrate" description="" Tags="smallitem,paint" spritecolor="128,128,128,255" InventoryIconColor="128,128,128,255" scale="0.5" impactsoundtag="impact_metal_light" impacttolerance="6">
+    <PreferredContainer secondary="storagecab" minamount="1" maxamount="2" spawnprobability="0.25" notcampaign="true" notpvp="true"/>
+    <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab,piratestoragecab" amount="1" spawnprobability="0.1" />
+    <Price baseprice="90" minleveldifficulty="5">
+      <Price storeidentifier="merchantoutpost" multiplier="1.1" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" minavailable="2" />
+      <Price storeidentifier="merchantresearch" multiplier="1.2" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.2" />
+      <Price storeidentifier="merchantmine" multiplier="1.2" />
+    </Price>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas2.png" sourcerect="256,320,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="379,78,27,58" depth="0.6" origin="0.5,0.5" />
+    <Body width="25" height="55" density="12" />
+    <Fabricate suitablefabricators="fabricator" requiredtime="30" >
+      <RequiredSkill identifier="mechanical" level="20" />
+      <RequiredItem identifier="ethanol" />
+      <RequiredItem identifier="tin" />
+      <RequiredItem identifier="zinc" />
+    </Fabricate>
+    <Deconstruct time="10">
+      <Item identifier="ethanol" mincondition="0.9" />
+    </Deconstruct>
+    <Throwable characterusable="true" canBeCombined="true" slots="Any,RightHand,LeftHand" throwforce="3.5" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="OnImpact" target="This" Condition="0.0" setvalue="true">
+        <Explosion range="0.0" structuredamage="0" itemdamage="0" force="0.0" severlimbsprobability="0.0" decal="fruitsplatter_white" decalsize="1.0" />
+        <ParticleEmitter particle="whitegoosplash" anglemin="0" anglemax="360" particleamount="2" velocitymin="0" velocitymax="0" scalemin="1.5" scalemax="2" />
+      </StatusEffect>
+      <StatusEffect type="OnFire" target="This" Condition="-50.0" interval="1" disabledeltatime="true" />
+      <StatusEffect type="OnBroken" target="This" Condition="-100.0">
+        <Remove />
+      </StatusEffect>
+    </Throwable>
+  </whitepaint>
+  
+  <Item name="" identifier="flamerunique" category="Equipment" Tags="smallitem,weapon,gun,mountableweapon" cargocontaineridentifier="metalcrate" Scale="0.5" impactsoundtag="impact_metal_light" hideinmenus="true" allowasextracargo="true">
+    <PreferredContainer primary="secarmcab" secondary="armcab" />
+    <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab,piratestoragecab" spawnprobability="0.02"/>
+    <PreferredContainer secondary="wreckarmcab" spawnprobability="0.05"/>
+    <Price baseprice="755" sold="false" canbespecial="false" />
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas2.png" sourcerect="384,256,62,64" />
+    <Sprite texture="Content/Items/Weapons/weapons_new.png" sourcerect="263,193,150,87" depth="0.55" origin="0.5,0.5" />
+    <Deconstruct time="10">
+      <Item identifier="steel" />
+      <Item identifier="plastic" />
+    </Deconstruct>
+    <Body width="150" height="77" density="25" />
+    <Holdable slots="Any,RightHand+LeftHand" controlpose="true" aimpos="50,0" handle1="-55,-20" handle2="-15,-10" msg="ItemMsgPickUpSelect" />
+    <RepairTool firedamage="20.0" structurefixamount="0.0" range="500" barrelpos="35,10" fireprobability="0.0" repairmultiple="true" repairthroughwalls="false" repairthroughholes="true" combatpriority="60" spread="25" unskilledspread="25">
+      <RequiredItems items="weldingtoolfuel,oxygensource" type="Contained" msg="ItemMsgWeldingFuelRequired" />
+      <RequiredSkill identifier="weapons" level="40" />
+      <ParticleEmitterHitCharacter particle="fleshsmoke" particlespersecond="3" anglemin="265" anglemax="275" velocitymin="0" velocitymax="50" />
+      <ParticleEmitter particle="steamspray" particlespersecond="80" anglemin="0" anglemax="0" velocitymin="1500" velocitymax="2000" highqualitycollisiondetection="true"/>
+      <ParticleEmitter particle="bubbles" particlespersecond="20" anglemin="-10" anglemax="10" scalemin="0.3" scalemax="0.7" velocitymin="5" velocitymax="100" copyentityangle="true"/>
+      <sound file="Content/Items/Weapons/FlameThrowerLoop.ogg" type="OnUse" range="750.0" loop="true" />
+      <StatusEffect type="OnFailure" target="UseTarget">
+        <ParticleEmitter particle="bubbles" particlespersecond="20" anglemin="-10" anglemax="10" scalemin="0.3" scalemax="0.7" velocitymin="5" velocitymax="100" copyentityangle="true"/>
+        <ParticleEmitter particle="fleshsmoke" particlespersecond="10" anglemin="-10" anglemax="10" scalemin="1" scalemax="1.5" velocitymin="5" velocitymax="200" copyentityangle="true"/>
+      </StatusEffect>
+      <!-- when using, the contained welding fuel tank will detoriate (= lose fuel) -->
+      <StatusEffect type="OnUse" targettype="Contained" targets="weldingfueltank" Condition="-10.0" />
+      <StatusEffect type="OnUse" targettype="Contained" targets="incendiumfueltank" Condition="-2.0" />
+      <!-- do burn damage to characters -->
+      <StatusEffect type="OnSuccess" target="UseTarget">
+        <Affliction identifier="burn" amount="1.5" />
+      </StatusEffect>
+      <StatusEffect type="OnUse" target="UseTarget">
+        <RequiredItem items="incendiumfueltank" type="Contained" />
+        <Affliction identifier="burn" amount="3.0" />
+        <Affliction identifier="stun" strength="1" probability="0.1" />
+      </StatusEffect>
+      <!-- explode if oxygen tanks are inserted -->
+      <StatusEffect type="OnUse" targettype="Contained" targets="oxygentank" delay="1.0" stackable="false" Condition="-100.0" disabledeltatime="true">
+        <sound file="Content/Items/Weapons/ExplosionSmall1.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionSmall2.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionSmall3.ogg" range="2000" />
+        <Explosion range="150.0" force="3" applyfireeffects="false" >
+          <Affliction identifier="burn" strength="25" />
+          <Affliction identifier="stun" strength="5" />
+        </Explosion>
+      </StatusEffect>
+      <StatusEffect type="OnUse" targettype="Contained" targets="oxygenitetank" delay="1.0" stackable="false" Condition="-100.0" disabledeltatime="true">
+        <sound file="Content/Items/Weapons/ExplosionSmall1.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionSmall2.ogg" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionSmall3.ogg" range="2000" />
+        <Explosion range="150.0" force="6" applyfireeffects="false" >
+          <Affliction identifier="burn" strength="50" />
+          <Affliction identifier="stun" strength="10" />
+        </Explosion>
+      </StatusEffect>
+      <!-- Self-damage on fail -->
+      <StatusEffect type="OnFailure" target="Character" targetlimbs="LeftHand,RightHand">
+        <Affliction identifier="burn" strength="7.5" probability="0.5"/>
+      </StatusEffect>
+      <StatusEffect type="OnFailure" target="Character" targetlimbs="LeftHand,RightHand">
+        <RequiredItem items="incendiumfueltank" type="Contained" />
+        <Affliction identifier="burn" strength="5.0" probability="0.5"/>
+      </StatusEffect>
+    </RepairTool>
+    <ItemContainer capacity="1" maxstacksize="1" hideitems="false" itempos="11,-15" containedspritedepth="0.56" containedstateindicatorstyle="tank">
+      <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="64,448,64,64" origin="0.5,0.5" />
+      <Containable items="weldingtoolfuel,oxygensource" />
+    </ItemContainer>
+    <aitarget sightrange="5000" soundrange="500" fadeouttime="5" />
+    <SkillRequirementHint identifier="weapons" level="40" />
+  </Item>
+
+  <Item name="" identifier="glowstick" category="Equipment" maxstacksize="32" maxstacksizecharacterinventory="8" cargocontaineridentifier="metalcrate" Scale="0.5" tags="smallitem,light,provocative" impactsoundtag="impact_soft" isshootable="true" damagedbymonsters="true" health="10">
+    <PreferredContainer primary="divingcab" minamount="3" maxamount="5" spawnprobability="1" notcampaign="true"/>
+    <PreferredContainer secondary="outpostcrewcabinet" amount="1" spawnprobability="0.1"/>
+    <Price baseprice="45" minavailable="6" displaynonempty="true">
+      <Price storeidentifier="merchantoutpost" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" minavailable="10" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.25" minavailable="8" />
+      <Price storeidentifier="merchantmine" minavailable="10" />
+      <Price storeidentifier="merchantarmory" multiplier="1.25" minavailable="8" />
+    </Price>
+    <Deconstruct time="5"/>
+    <Fabricate suitablefabricators="fabricator" requiredtime="10" amount="4">
+      <RequiredItem identifier="phosphorus" amount="2" />
+      <RequiredItem identifier="plastic" />
+    </Fabricate>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas2.png" sourcerect="128,384,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="278,157,50,9" depth="0.55" origin="0.5,0.5" />
+    <Body width="50" height="9" density="10" />
+    <Throwable slots="Any,RightHand,LeftHand" holdpos="0,0" handle1="0,0" holdangle="90" throwforce="2.0" aimpos="35,-10" msg="ItemMsgPickUpSelect" />
+    <LightComponent LightColor="50,255,50,255" Flicker="0.0" range="400" IsOn="false">
+      <sprite texture="Content/Items/Tools/tools.png" sourcerect="374,140,62,20" alpha="1.0" origin="0.5,0.5" />
+      <StatusEffect type="OnUse" targettype="This" IsOn="true" DontCleanUp="True">
+        <Conditional IsOn="eq False" targetitemcomponent="LightComponent" />
+        <sound file="Content/Items/Tools/FlareIgnite.ogg" range="800.0" />
+      </StatusEffect>
+      <StatusEffect type="OnActive" targettype="This" Condition="-0.00625" />
+      <StatusEffect type="OnActive" targettype="This">
+        <Conditional PhysicsBodyActive="eq true" />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" targettype="This" IsOn="false" />
+    </LightComponent>
+    <AiTarget sightrange="4000"/>
+    <Upgrade gameversion="0.10.0.0" scale="0.5" />
+  </Item>
+
+  <Item name="" identifier="ruinscanner" description="" category="Equipment" Tags="smallitem,scanner" Scale="0.5" cargocontaineridentifier="metalcrate" impactsoundtag="impact_metal_light" isshootable="true">
+    <PreferredContainer primary="divingcab"/>
+    <Sprite texture="Content/Items/Alien/AlienRuins_Items.png" depth="0.8" sourcerect="966,353,52,62" origin="0.5,0.5" />
+    <Body width="48" height="62" density="20" />
+    <Holdable selectkey="Action" pickkey="Select" slots="Any,RightHand,LeftHand" msg="itemmsgpickupselect" aimpos="35,-10" handle1="0,0" attachable="true" aimable="true">
+      <!--<RequiredItem items="wrench" type="Equipped" />-->
+    </Holdable>
+    <Scanner scanduration="30" scanradius="1000" alwaysdisplayprogressbar="false">
+      <StatusEffect type="OnActive" targettype="This">
+        <Conditional scantimer="gt 0"/>
+        <ParticleEmitter particle="scannerwavefx" anglemax="360" particlespersecond="0.5" />
+        <ParticleEmitter particle="scannerdot" particlespersecond="0.9"/>
+      </StatusEffect>
+    </Scanner>
+    <AITarget sightrange="50" soundrange="10000" staticsight="true" fadeouttime="5" />
+    <Sonar range="6000.0" powerconsumption="0" drawhudwhenequipped="true" detectsubmarinewalls="true" displaybordersize="-0.1" characterusable="false" hasmineralscanner="false" allowuioverlap="true">
+      <!--<StatusEffect type="OnUse" targettype="Contained" Condition="-1.0" disabledeltatime="true">
+        <RequiredItem items="batterycell" type="Contained" />
+      </StatusEffect>-->
+      <!--<StatusEffect type="OnUse" targettype="Contained" Condition="-0.5" disabledeltatime="true">
+        <RequiredItem items="fulguriumbatterycell" type="Contained" />
+      </StatusEffect>-->
+      <!--<StatusEffect type="OnUse" targettype="Contained" Condition="-1.0" disabledeltatime="true">
+        <RequiredItem excludedidentifiers="batterycell,fulguriumbatterycell" type="Contained" />
+      </StatusEffect>-->
+      <sound file="Content/Items/Command/SonarPing.ogg" type="OnUse" range="1000.0" />
+      <GuiFrame relativesize="0.4,0.4" anchor="CenterLeft" relativeoffset="0.006,-0.01"/>
+      <PingCircle texture="Content/Items/Command/pingCircle.png" origin="0.5,0.5" />
+      <DirectionalPingCircle texture="Content/Items/Command/directionalPingCircle.png" origin="0.0,0.5" />
+      <ScreenOverlay texture="Content/Items/Command/sonarOverlay.png" origin="0.5,0.5" />
+      <ScreenBackground texture="Content/Items/Command/sonarBackground.png" origin="0.5,0.5" />
+      <DirectionalPingBackground texture="Content/Items/Command/directionalPingBackground.png" origin="0.5,0.5" />
+      <DirectionalPingButton index="0" texture="Content/Items/Command/directionalPingButton.png" sourcerect="0,0,91,266" origin="-4.5275,0.5" />
+      <DirectionalPingButton index="1" texture="Content/Items/Command/directionalPingButton.png" sourcerect="133,0,91,266" origin="-4.5275,0.5" />
+      <DirectionalPingButton index="2" texture="Content/Items/Command/directionalPingButton.png" sourcerect="266,0,91,266" origin="-4.5275,0.5" />
+      <Blip texture="Content/Items/Command/sonarBlip.png" origin="0.5,0.5" />
+      <LineSprite texture="Content/Items/Command/NavUI.png" sourcerect="181,141,109,4" origin="0,0.5"/>
+      <icon identifier="outpost" texture="Content/UI/MainIconsAtlas.png" sourcerect="352,398,16,8" origin="0.5,0.5"/>
+      <icon identifier="submarine" texture="Content/UI/MainIconsAtlas.png" sourcerect="353,407,14,6" origin="0.5,0.5"/>
+      <icon identifier="shuttle" texture="Content/UI/MainIconsAtlas.png" sourcerect="336,407,8,6" origin="0.5,0.5"/>
+      <icon identifier="artifact" texture="Content/UI/MainIconsAtlas.png" sourcerect="336,414,8,8" origin="0.5,0.5"/>
+      <icon identifier="location" texture="Content/UI/MainIconsAtlas.png" sourcerect="349,435,11,11" origin="0.5,0.5"/>
+      <icon identifier="mineral" texture="Content/UI/MainIconsAtlas.png" sourcerect="336,434,7,12" origin="0.5,0.5"/>
+      <icon identifier="" texture="Content/UI/MainIconsAtlas.png" sourcerect="346,416,4,4" origin="0.5,0.5"/>
+    </Sonar>
+    
+  </Item>
+ </Items>

--- a/Reactorfix/tools.xml
+++ b/Reactorfix/tools.xml
@@ -1151,10 +1151,7 @@
     <Sprite texture="Content/Items/Tools/tools.png" depth="0.55" sourcerect="410,1,19,68" />
     <Body radius="6" height="55" density="20" />
     <Holdable handle1="0,0" slots="Any,RightHand,LeftHand" msg="ItemMsgPickUpSelect" >
-      <!--Status effect to cause radiation whenever handling fuel rods. Disabled for now because effect doesn't stop when no longer in contact with fuel rods.-->
-      <!--<StatusEffect type="Always" target="Character">
-        <Affliction identifier="radiationsickness" strength="0.25" />
-      </StatusEffect>-->
+      <StatusEffect type="OnContained" target="Parent" AvailableFuel="80.0" disabledeltatime="true" />
     </Holdable>
     <ItemContainer hideitems="true" capacity="1" itemrotation="90" drawinventory="false" canbeselected="false" SpawnWithId="nucleargunbolt" removecontaineditemsondeconstruct="true" showcontainedstateindicator="false">
       <Containable items="nucleargunbolt" />
@@ -1199,7 +1196,9 @@
     <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="640,64,64,64" origin="0.5,0.5" />
     <Sprite texture="Content/Items/Tools/tools.png" depth="0.55" sourcerect="431,1,19,68" />
     <Body radius="6" height="55" density="20" />
-    <Holdable handle1="0,0" slots="Any,RightHand,LeftHand" msg="ItemMsgPickUpSelect" />
+    <Holdable handle1="0,0" slots="Any,RightHand,LeftHand" msg="ItemMsgPickUpSelect" >
+      <StatusEffect type="OnContained" target="Parent" AvailableFuel="150.0" disabledeltatime="true" />
+    </Holdable>
     <ItemContainer hideitems="true" capacity="1" itemrotation="90" drawinventory="false" canbeselected="false" SpawnWithId="nucleargunbolt" removecontaineditemsondeconstruct="true" showcontainedstateindicator="false">
       <Containable items="nucleargunbolt" />
       <StatusEffect type="OnUse" target="This" condition="-12.5" disabledeltatime="true">
@@ -1243,11 +1242,8 @@
     <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="384,64,64,64" origin="0.5,0.5" />
     <Sprite texture="Content/Items/Tools/tools.png" depth="0.55" sourcerect="452,1,19,68" />
     <Body radius="6" width="21" height="71" density="20" />
-    <Holdable handle1="0,0" slots="Any,RightHand,LeftHand" msg="ItemMsgPickUpSelect">
-      <!--Status effect to cause radiation whenever handling fuel rods. Disabled for now because effect doesn't stop when no longer in contact with fuel rods.-->
-      <!--<StatusEffect type="Always" target="Character">
-        <Affliction identifier="radiationsickness" strength="0.5" />
-      </StatusEffect>-->
+    <Holdable handle1="0,0" slots="Any,RightHand,LeftHand" msg="ItemMsgPickUpSelect" >
+      <StatusEffect type="OnContained" target="Parent" AvailableFuel="100.0" disabledeltatime="true" />
     </Holdable>
     <ItemContainer hideitems="true" capacity="1" itemrotation="90" drawinventory="false" canbeselected="false" SpawnWithId="nucleargunbolt" removecontaineditemsondeconstruct="true" showcontainedstateindicator="false">
       <Containable items="nucleargunbolt" />

--- a/Reactorfix/traitor_items.xml
+++ b/Reactorfix/traitor_items.xml
@@ -46,7 +46,7 @@
     </Projectile>
   </Item>
 
-  <Item name="" identifier="huskfigurine" category="Misc" maxstacksize="2" Tags="smallitem,traitormissionitem" scale="0.5" health="10" cargocontaineridentifier="metalcrate" impactsoundtag="impact_metal_light" isshootable="true">
+  <Item name="" identifier="huskfigurine" category="Misc" maxstacksize="2" Tags="smallitem,traitormissionitem,reactoritem" scale="0.5" health="10" cargocontaineridentifier="metalcrate" impactsoundtag="impact_metal_light" isshootable="true">
     <Price baseprice="50" sold="false" canbespecial="false">
       <Price storeidentifier="merchantoutpost"/>
       <Price storeidentifier="merchantcity"/>

--- a/Reactorfix/traitor_items.xml
+++ b/Reactorfix/traitor_items.xml
@@ -1,0 +1,519 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Items>
+  <Item name="" identifier="deepdiverduck" category="Misc" Tags="smallitem,traitormissionitem" maxstacksize="1" impacttolerance="4" inventoryiconcolor="110,120,110,255" spritecolor="110,120,110" impactsoundtag="impact_metal_heavy">
+    <PreferredContainer primary="storagecab" />
+    <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab,piratestoragecab" spawnprobability="0" />
+    <Price baseprice="38" sold="false" canbespecial="false">
+      <Price storeidentifier="merchantoutpost" multiplier="1.3" />
+      <Price storeidentifier="merchantcity" multiplier="1.25" />
+      <Price storeidentifier="merchantresearch" />
+      <Price storeidentifier="merchantmilitary" multiplier="0.9" />
+      <Price storeidentifier="merchantmine" multiplier="0.9" />
+    </Price>
+    <Fabricate suitablefabricators="fabricator" hidefornontraitors="true" requiredtime="10">
+      <RequiredSkill identifier="helm" level="10" />
+      <RequiredItem identifier="rubber" />
+      <RequiredItem identifier="lead" />
+    </Fabricate>
+    <InventoryIcon texture="Content/Map/Outposts/Art/FactionItems.png" sourcerect="448,448,64,64" />
+    <Sprite texture="Content/Map/Outposts/Art/FactionItems.png" sourcerect="394,200,43,43" depth="0.55" origin="0.5,0.5" />
+    <Body width="3" radius="15" density="30" />
+    <ItemComponent>
+      <StatusEffect target="This" type="OnImpact">
+        <sound file="Content/Sounds/Damage/StructureBlunt1.ogg" range="500" frequencymultiplier="1.2" />
+        <Explosion range="50.0" showeffects="false" structuredamage="10" decal="" />
+      </StatusEffect>
+    </ItemComponent>
+    <Throwable slots="Any,RightHand,LeftHand" holdpos="0,0" handle1="0,0" throwforce="3.5" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="OnSecondaryUse" target="This" delay="0.1">
+        <Use />
+      </StatusEffect>
+    </Throwable>
+    <Projectile characterusable="false" launchimpulse="0.0" sticktocharacters="false">
+      <Attack structuredamage="5">
+        <Affliction identifier="blunttrauma" strength="5" />
+        <Affliction identifier="stun" strength="0.5" />
+        <StatusEffect type="OnUse" target="UseTarget">
+          <Conditional entitytype="eq Character"/>
+          <Sound file="Content/Items/Weapons/Smack1.ogg" selectionmode="random" range="500"/>
+          <Sound file="Content/Items/Weapons/Smack2.ogg" range="500" />
+        </StatusEffect>
+        <StatusEffect type="OnUse" target="Limb" targetLimbs="Head">
+          <Affliction identifier="concussion" strength="10" />
+          <Affliction identifier="stun" strength="5" />          
+        </StatusEffect>
+      </Attack>
+    </Projectile>
+  </Item>
+
+  <Item name="" identifier="huskfigurine" category="Misc" maxstacksize="2" Tags="smallitem,traitormissionitem" scale="0.5" health="10" cargocontaineridentifier="metalcrate" impactsoundtag="impact_metal_light" isshootable="true">
+    <Price baseprice="50" sold="false" canbespecial="false">
+      <Price storeidentifier="merchantoutpost"/>
+      <Price storeidentifier="merchantcity"/>
+      <Price storeidentifier="merchantresearch"/>
+      <Price storeidentifier="merchantmilitary"/>
+      <Price storeidentifier="merchantmine"/>
+    </Price>
+    <Fabricate suitablefabricators="fabricator" hidefornontraitors="true" requiredtime="10">
+      <RequiredItem identifier="aluminium" amount="2 "/>
+    </Fabricate>
+    <InventoryIcon texture="Content/Map/Outposts/Art/FactionItems.png" sourcerect="384,448,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Map/Outposts/Art/FactionItems.png" sourcerect="399,451,35,60" depth="0.55" origin="0.5,0.5" />
+    <Body width="30" height="55" density="15" />
+    <Holdable selectkey="Select" pickkey="Use" slots="Any,RightHand,LeftHand" msg="ItemMsgDetachWrench" PickingTime="3.0" aimpos="35,-10" handle1="0,0" attachable="true" attachedbydefault="false" aimable="true">
+      <RequiredItem items="wrench,deattachtool" excludeditems="multitool" type="Equipped" />
+      <StatusEffect type="OnNotContained" target="This" interval="25" >
+        <Conditional targetitemcomponent="Holdable" Attached="eq true" />
+        <particleemitter particle="shockwavesmall" particleamount="1" scalemin="0.5" scalemax="0.5" />
+        <Sound file="Content/Characters/Husk/Husk_Idle1.ogg" type="OnUse" range="300" selectionmode="Random" />
+        <Sound file="Content/Characters/Husk/Husk_Idle2.ogg" type="OnUse" range="300" />
+        <Sound file="Content/Characters/Husk/Husk_Idle3.ogg" type="OnUse" range="300" />
+        <Sound file="Content/Characters/Husk/Husk_Idle4.ogg" type="OnUse" range="300" />
+      </StatusEffect>
+    </Holdable>
+  </Item>
+  
+  <Item name="" identifier="faultycultistrobes" nameidentifier="cultistrobes" variantof="cultistrobes" hideinmenus="true">
+    <PreferredContainer primary="crewcab"/>
+    <Price baseprice="150" canbespecial="false" sold="false">
+      <Price sold="false" />
+    </Price>
+    <Deconstruct time="10">
+      <Item identifier="organicfiber" />
+    </Deconstruct>
+    <Wearable slots="Any,InnerClothes" variants="1" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="OnWearing" target="Character" interval="0.5" disabledeltatime="true">
+        <!-- Disable disguisedashusk - they're faulty!
+        <Affliction identifier="disguisedashusk" amount="0" /> -->
+        <Clear />
+      </StatusEffect>
+    </Wearable>
+  </Item>
+
+  <Item name="" identifier="huskcaller" hideinmenus="true" Tags="smallitem,instrument,traitormissionitem" cargocontaineridentifier="metalcrate" scale="0.5" description="" price="300" impactsoundtag="impact_metal_light" isshootable="true">
+    <Sprite texture="Content/Map/Outposts/Art/FactionItems.png" depth="0.55" sourcerect="235,252,79,46" origin="0.5,0.5" />
+    <InventoryIcon texture="Content/Map/Outposts/Art/FactionItems.png" sourcerect="235,252,79,46" origin="0.5,0.5" />
+    <Body width="5" radius="20" density="15" />
+    <PreferredContainer primary="crewcab" spawnprobability="0" notcampaign="true"/>
+    <PreferredContainer secondary="wreckcrewcab,abandonedcrewcab,piratecrewcab" spawnprobability="0"/>
+    <Price baseprice="50" sold="false" canbespecial="false" />
+    <Holdable slots="RightHand+LeftHand,Any" aimable="false" aimpos="35,15" handle1="-10,0" handle2="0,0" msg="ItemMsgPickUpSelect" />
+    <RangedWeapon reload="2">
+      <Sound file="Content/Items/Weapons/WEAPON_harpoonCoilRifleChargeUp.ogg" type="OnUse" range="500" frequencymultiplier="0.5" />
+    </RangedWeapon>
+  </Item>
+
+  <Item name="" identifier="traitorduffelbag" nameidentifier="duffelbag" variantof="duffelbag" hideinmenus="true" tags="mobilecontainer" fireproof="true" description="" impactsoundtag="impact_soft" scale="0.4">
+    <Holdable>
+      <!-- Disable deteriorating -->
+      <StatusEffect type="OnActive" targettype="This" Condition="0" />
+    </Holdable>
+  </Item>
+
+  <!-- Basic time bomb, can be dumped into water to get rid of -->
+  <Item name="" identifier="traitortimebomb" category="Weapon" hideinmenus="true" Tags="smallitem,explosive,traitorbomb,traitormissionitem" maxstacksize="1" Scale="0.5" health="120" cargocontaineridentifier="explosivecrate" impactsoundtag="impact_metal_light">
+    <Price baseprice="160" sold="false" canbespecial="false" />
+    <Sprite texture="Content/Map/Outposts/Art/FactionItems.png" depth="0.55" sourcerect="448,198,38,76" origin="0.5,0.5" />
+    <Body width="30" height="70" density="20" />
+    <Throwable characterusable="false" slots="Any,RightHand,LeftHand" canbecombined="true" removeoncombined="true" throwforce="3.5" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
+      <StatusEffect type="OnBroken" target="This">
+        <!-- Nuke -->
+        <sound file="Content/Items/Weapons/ExplosionLarge1.ogg" range="50000" />
+        <sound file="Content/Items/Weapons/ExplosionLarge2.ogg" range="50000" />
+        <Explosion range="500.0" ballastfloradamage="300" structuredamage="300" itemdamage="1000" force="20" severlimbsprobability="0.75" debris="true" decal="explosion" decalsize="0.75" penetration="0.5"
+                   camerashake="200" camerashakerange="10000"
+                   flashrange="1000" flashduration="2.0"
+                   screencolor="255,255,255,255" screencolorrange="5000" screencolorduration="3.0">
+          <Affliction identifier="explosiondamage" strength="200" />
+          <Affliction identifier="burn" strength="200" />
+          <Affliction identifier="bleeding" strength="40" probability="0.05" dividebylimbcount="false"/>
+          <Affliction identifier="stun" strength="10" />
+          <Affliction identifier="radiationsickness" strength="30" />
+        </Explosion>
+        <Remove />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="This">
+        <sound file="Content/Items/Weapons/ExplosionDebris1.ogg" range="6000" />
+        <sound file="Content/Items/Weapons/ExplosionDebris2.ogg" range="6000" />
+      </StatusEffect>
+    </Throwable>
+    <LightComponent LightColor="248,81,81,100" range="20" powerconsumption="0" IsOn="false" blinkfrequency="1.0" offset="0,16">
+      <sprite texture="Content/Map/Outposts/Art/FactionItems.png" sourcerect="492,218,17,7" origin="0.5,0.5"/>
+      <StatusEffect type="OnActive" target="This" interval="1" Condition="-1.0" disabledeltatime="true">
+        <sound file="Content/Items/Button/Switch1.ogg" range="200" frequencymultiplier="1.5" volume="0.75" />
+      </StatusEffect>
+    </LightComponent>
+  </Item>
+
+  <!-- Variant that cannot be dumped into the water to get rid of, it explodes and probably still nukes the ship -->
+  <Item name="" identifier="traitortimebomb2" category="Weapon" hideinmenus="true" Tags="smallitem,explosive,traitorbomb,traitormissionitem" maxstacksize="1" Scale="0.5" health="120" cargocontaineridentifier="explosivecrate" impactsoundtag="impact_metal_light">
+    <Price baseprice="160" sold="false" canbespecial="false" />
+    <Sprite texture="Content/Map/Outposts/Art/FactionItems.png" depth="0.55" sourcerect="448,198,38,76" origin="0.5,0.5" />
+    <Body width="30" height="70" density="20" />
+    <Throwable characterusable="false" slots="Any,RightHand,LeftHand" canbecombined="true" removeoncombined="true" throwforce="3.5" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
+      <StatusEffect type="OnBroken" target="This">
+        <!-- Nuke -->
+        <sound file="Content/Items/Weapons/ExplosionLarge1.ogg" range="50000" />
+        <sound file="Content/Items/Weapons/ExplosionLarge2.ogg" range="50000" />
+        <Explosion range="500.0" ballastfloradamage="300" structuredamage="300" itemdamage="1000" force="20" severlimbsprobability="0.75" debris="true" decal="explosion" decalsize="0.75" penetration="0.5"
+                   camerashake="200" camerashakerange="10000"
+                   flashrange="1000" flashduration="2.0"
+                   screencolor="255,255,255,255" screencolorrange="5000" screencolorduration="3.0">
+          <Affliction identifier="explosiondamage" strength="200" />
+          <Affliction identifier="burn" strength="200" />
+          <Affliction identifier="bleeding" strength="40" probability="0.05" dividebylimbcount="false"/>
+          <Affliction identifier="stun" strength="10" />
+          <Affliction identifier="radiationsickness" strength="30" />
+        </Explosion>
+        <Remove />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="This">
+        <sound file="Content/Items/Weapons/ExplosionDebris1.ogg" range="6000" />
+        <sound file="Content/Items/Weapons/ExplosionDebris2.ogg" range="6000" />
+      </StatusEffect>
+    </Throwable>
+    <LightComponent LightColor="248,81,81,100" range="20" powerconsumption="0" IsOn="false" blinkfrequency="1.0" offset="0,16">
+      <sprite texture="Content/Map/Outposts/Art/FactionItems.png" sourcerect="492,218,17,7" origin="0.5,0.5"/>
+      <StatusEffect type="OnActive" target="This" interval="1" Condition="-1.0" disabledeltatime="true">
+        <sound file="Content/Items/Button/Switch1.ogg" range="200" frequencymultiplier="1.5" volume="0.75" />
+      </StatusEffect>
+      <StatusEffect type="InWater" target="This">
+        <ParticleEmitter particle="weldspark" particlespersecond="5" anglemin="0" anglemax="360" velocitymin="100" velocitymax="500" scalemin="0.5" scalemax="1" />
+        <ParticleEmitter particle="swirlysmoke" particlespersecond="2" scalemin="0.5" scalemax="1" />
+        <ParticleEmitter particle="damagebubbles" particlespersecond="2" scalemin="0.5" scalemax="0.7" anglemin="0" anglemax="360" velocitymin="-10" velocitymax="10" />
+        <sound file="Content/Items/Electricity/Zap1.ogg" type="OnActive" range="500.0" loop="true" />
+      </StatusEffect>
+      <StatusEffect type="InWater" target="This" delay="5.0" setvalue="true" condition="0" stackable="false" checkconditionalalways="true">
+        <!-- check the item is still in water after the delay has run out-->
+        <Conditional InWater="true"/>
+      </StatusEffect>
+    </LightComponent>
+  </Item>
+
+  <!-- Variant that needs battery renewed, water = boom -->
+  <Item name="" identifier="traitortimebomb3" category="Weapon" hideinmenus="true" Tags="smallitem,explosive,traitorbomb,traitormissionitem" maxstacksize="1" Scale="0.5" health="120" cargocontaineridentifier="explosivecrate" impactsoundtag="impact_metal_light">
+    <Price baseprice="160" sold="false" canbespecial="false" />
+    <Sprite texture="Content/Map/Outposts/Art/FactionItems.png" depth="0.55" sourcerect="448,198,38,76" origin="0.5,0.5" />
+    <Body width="30" height="70" density="20" />
+    <Throwable characterusable="false" slots="Any,RightHand,LeftHand" canbecombined="true" removeoncombined="true" throwforce="3.5" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
+      <StatusEffect type="OnBroken" target="This">
+        <!-- Nuke -->
+        <sound file="Content/Items/Weapons/ExplosionLarge1.ogg" range="50000" />
+        <sound file="Content/Items/Weapons/ExplosionLarge2.ogg" range="50000" />
+        <Explosion range="500.0" ballastfloradamage="300" structuredamage="300" itemdamage="1000" force="20" severlimbsprobability="0.75" debris="true" decal="explosion" decalsize="0.75" penetration="0.5"
+                   camerashake="200" camerashakerange="10000"
+                   flashrange="1000" flashduration="2.0"
+                   screencolor="255,255,255,255" screencolorrange="5000" screencolorduration="3.0">
+          <Affliction identifier="explosiondamage" strength="200" />
+          <Affliction identifier="burn" strength="200" />
+          <Affliction identifier="bleeding" strength="40" probability="0.05" dividebylimbcount="false"/>
+          <Affliction identifier="stun" strength="10" />
+          <Affliction identifier="radiationsickness" strength="30" />
+        </Explosion>
+        <Remove />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="This">
+        <sound file="Content/Items/Weapons/ExplosionDebris1.ogg" range="6000" />
+        <sound file="Content/Items/Weapons/ExplosionDebris2.ogg" range="6000" />
+      </StatusEffect>
+    </Throwable>
+    <Powered PowerConsumption="1">
+      <StatusEffect type="InWater" target="This">
+        <ParticleEmitter particle="weldspark" particlespersecond="5" anglemin="0" anglemax="360" velocitymin="100" velocitymax="500" scalemin="0.5" scalemax="1" />
+        <ParticleEmitter particle="swirlysmoke" particlespersecond="2" scalemin="0.5" scalemax="1" />
+        <ParticleEmitter particle="damagebubbles" particlespersecond="2" scalemin="0.5" scalemax="0.7" anglemin="0" anglemax="360" velocitymin="-10" velocitymax="10" />
+        <sound file="Content/Items/Electricity/Zap1.ogg" type="OnActive" range="500.0" loop="true" />
+      </StatusEffect>
+      <StatusEffect type="InWater" target="This" delay="3.0" setvalue="true" condition="0" stackable="false" checkconditionalalways="true">
+        <!-- check the item is still in water after the delay has run out-->
+        <Conditional InWater="true"/>
+      </StatusEffect>
+    </Powered>
+    <LightComponent LightColor="248,81,81,100" range="20" powerconsumption="0" IsOn="false" blinkfrequency="1.0" offset="0,16">
+      <sprite texture="Content/Map/Outposts/Art/FactionItems.png" sourcerect="492,218,17,7" origin="0.5,0.5"/>
+      <StatusEffect type="OnActive" target="Contained" Condition="-0.1" interval="1" disabledeltatime="true">
+        <RequiredItem items="mobilebattery" type="Contained" />
+        <sound file="Content/Items/Button/Switch1.ogg" range="200" frequencymultiplier="1.5" volume="0.75" />
+      </StatusEffect>
+      <!-- explode in 5 seconds if voltage drops to 0 (if battery is removed) -->
+      <StatusEffect type="OnActive" target="This" delay="5.0" setvalue="true" condition="0" stackable="false" checkconditionalalways="true">
+        <Conditional Voltage="lte 0.5" />
+      </StatusEffect>
+      <!-- warning if battery is removed -->
+      <StatusEffect type="OnActive" target="This" setvalue="true" stackable="false" checkconditionalalways="true">
+        <Conditional Voltage="lte 0.5" />
+        <sound file="Content/Items/AlarmBuzzerLoop.ogg" range="1000.0" frequencymultiplier="2.0" />
+      </StatusEffect>
+    </LightComponent>
+    <ItemContainer capacity="1" maxstacksize="1" hideitems="true" containedstateindicatorstyle="battery">
+      <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="128,448,64,64" origin="0.5,0.5" />
+      <Containable items="mobilebattery">
+        <StatusEffect type="OnContaining" targettype="This" Voltage="1.0" setvalue="true" />
+      </Containable>
+    </ItemContainer>
+  </Item>
+
+  <Item name="" identifier="bloodsamplevial" hideinmenus="true" category="Medical" maxstacksize="8" maxstacksizecharacterinventory="1" cargocontaineridentifier="mediccrate" Tags="smallitem,traitormissionitem" description="" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light" RequireAimToUse="True">
+    <PreferredContainer primary="medcab" secondary="medcontainer"/>
+    <Deconstruct time="20">
+      <Item identifier="opium" />
+    </Deconstruct>
+    <InventoryIcon texture="Content/Map/Outposts/Art/FactionItems.png" sourcerect="320,448,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Map/Outposts/Art/FactionItems.png" sourcerect="419,268,16,46" depth="0.6" origin="0.5,0.5" />
+    <Body width="25" height="65" density="10.2" waterdragcoefficient="1" />
+    <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect" HitOnlyCharacters="true">
+      <!-- 1% condition because otherwise the item is "broken" and can't be swung-->
+      <StatusEffect type="OnSpawn" target="this" condition="1" setvalue="true" />
+      <StatusEffect type="OnSuccess" target="UseTarget" condition="10" AllowWhenBroken="true" disabledeltatime="true" comparison="And">
+        <Conditional bleeding="gt 0"/>
+        <Conditional hasstatustag="! bloodsampletaken"/>
+        <Conditional istraitor="false"/>
+        <EventTarget eventidentifier="bloodsamples" tag="sampletaken"/>
+      </StatusEffect>
+      <!-- increase condition ("fill the vial" when used on a bleeding target) -->
+      <StatusEffect type="OnSuccess" target="UseTarget,This" condition="10" AllowWhenBroken="true" disabledeltatime="true" comparison="Or">
+        <Conditional bleeding="gt 0"/>
+      </StatusEffect>
+    </MeleeWeapon>
+  </Item>
+
+  <Item name="" identifier="idcardfakesootman" Tags="smallitem,idcard" variantof="idcard" hideinmenus="true">
+    <PreferredContainer primary="crewcab"/>
+    <Price baseprice="10" sold="false" canbespecial="false">
+      <Price minavailable="0" />
+      <Price minavailable="0" />
+    </Price>
+    <IdCard slots="Card,Any" OwnerNameLocalized="charactername.Sootman" msg="ItemMsgPickUpSelect" />
+  </Item>
+
+  <Item name="" identifier="dirtybomb_showofstrength" variantof="dirtybomb" hideinmenus="true">
+    <!-- not purchaseable -->
+    <Price />
+    <!-- not fabricable -->
+    <Fabricate />
+    <ItemComponent>
+      <StatusEffect type="OnBroken" target="NearbyCharacters" range="1000">
+        <EventTarget eventidentifier="showofstrength" tag="explodedcharacter" />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="NearbyItems" targetidentifiers="primarynavterminal" range="1000">
+        <EventTarget eventidentifier="showofstrength" tag="explodednavterminal" />
+      </StatusEffect>
+    </ItemComponent>
+  </Item>
+
+  <Item name="" identifier="c4block_vipbombing" variantof="c4block" hideinmenus="true">
+    <PreferredContainer minamount="0" maxamount="0" spawnprobability="0" />
+    <PreferredContainer amount="0" spawnprobability="0" />
+    <PreferredContainer spawnprobability="0" />
+    <!-- not purchaseable -->
+    <Price />
+    <!-- not fabricable -->
+    <Fabricate />
+    <ItemComponent>
+      <StatusEffect type="OnBroken" target="NearbyCharacters" range="500">
+        <EventTarget eventidentifier="vipbombing" tag="explodedcharacter" />
+      </StatusEffect>
+    </ItemComponent>
+  </Item>
+
+  <Item name="" identifier="radiojammer" category="Equipment" Tags="smallitem" cargocontaineridentifier="metalcrate" Scale="0.5" impactsoundtag="impact_metal_light">
+    <PreferredContainer primary="engcab"/>
+    <Deconstruct time="15">
+      <Item identifier="copper" amount="2" />
+      <Item identifier="plastic" amount="2" />
+    </Deconstruct>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas2.png" sourcerect="128,960,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/Tools/tools.png" sourcerect="231,102,25,54" depth="0.55" origin="0.5,0.5" />    
+    <Body width="23" height="50" density="12" />
+    <Holdable slots="Any,RightHand,LeftHand" holdangle="30" handle1="0,-15" msg="ItemMsgPickUpSelect" />    
+    <LightComponent LightColor="0,255,0,255" range="25" powerconsumption="10" flicker="1" blinkfrequency="2" castshadows="false" IsOn="false" canbeselected="false">
+      <StatusEffect type="OnActive" targettype="Contained" Condition="-1.66" Interval="1" disabledeltatime="true">
+        <RequiredItem items="mobilebattery" type="Contained" />
+      </StatusEffect>
+      <StatusEffect type="OnActive" targettype="This" SoundRange="50000" setvalue="true">
+        <Conditional Voltage="gt 0.5" targetitemcomponent="LightComponent" />
+        <sound file="Content/Items/AlarmBuzzerLoop.ogg" range="150.0" frequencymultiplier="0.7" loop="true" volume="0.3" />
+      </StatusEffect>
+      <StatusEffect type="OnActive" target="NearbyItems" Interval="1" Range="1000" targetidentifiers="mobileradio" JamTimer="1.5" setvalue="true" />
+    </LightComponent>
+    <CustomInterface canbeselected="false" drawhudwhenequipped="true" allowuioverlap="true">
+      <GuiFrame relativesize="0.16,0.075" anchor="CenterLeft" pivot="BottomLeft" relativeoffset="0.006,-0.05" style="ItemUI" />
+      <TickBox text="radiojammer.transmit">
+        <StatusEffect type="OnUse" targettype="This" IsOn="true" />
+        <StatusEffect type="OnSecondaryUse" targettype="This" IsOn="false" />
+      </TickBox>
+    </CustomInterface>
+    <ItemContainer capacity="1" maxstacksize="1" hideitems="true" containedstateindicatorstyle="battery">
+      <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="128,448,64,64" origin="0.5,0.5" />
+      <Containable items="mobilebattery">
+        <StatusEffect type="OnContaining" targettype="This" Voltage="1.0" setvalue="true" />
+      </Containable>
+    </ItemContainer>
+  </Item>
+  
+  <Item name="" identifier="partybanner" hideinmenus="true" Tags="smallitem,traitormissionitem" cargocontaineridentifier="metalcrate" scale="0.5" description="" impactsoundtag="impact_soft" isshootable="true">
+    <ContainedSprite texture="Content/Map/Outposts/Art/ClownDistrict.png" usewhenattached="true" decorativespritebehavior="HideWhenNotVisible" depth="0.55" sourcerect="703,833,311,141" origin="0.5,0.5" />
+    <Sprite texture="Content/Map/Outposts/Art/ClownDistrict.png" depth="0.8" sourcerect="870,981,155,46" origin="0.5,0.5" canflipx="false" canflipy="false" />
+    <Body width="100" radius="15" density="15" />
+    <PreferredContainer primary="crewcab" spawnprobability="0"/>
+    <Holdable selectkey="Select" pickkey="Use" slots="Any,RightHand,LeftHand" msg="ItemMsgDetach" PickingTime="5.0" aimpos="65,-10" handle1="0,0" attachable="true" aimable="true" />
+  </Item>
+
+  <Item name="" identifier="divingknife_murdermystery" nameidentifier="murderweapon" variantof="divingknife" Tags="smallitem,weapon,gunsmith,mountableweapon,sharptool,murderweapon,traitormissionitem" hideinmenus="true">
+    <PreferredContainer spawnprobability="0"/>
+    <PreferredContainer spawnprobability="0"/>
+    <PreferredContainer spawnprobability="0"/>
+    <PreferredContainer spawnprobability="0"/>
+    <!-- not purchaseable -->
+    <Price sold="false" canbespecial="false" />
+    <!-- not fabricable -->
+    <Fabricate />
+    <MeleeWeapon>
+      <Attack>
+        <Affliction />
+        <Affliction />
+        <Affliction />
+        <Affliction identifier="mysteryaffliction" strength="20" />
+      </Attack>
+    </MeleeWeapon>
+  </Item>
+
+  <Item name="" identifier="screwdriver_murdermystery" nameidentifier="murderweapon" variantof="screwdriver" Tags="smallitem,simpletool,tool,electricalrepairtool,screwdriveritem,murderweapon,traitormissionitem" hideinmenus="true">
+    <PreferredContainer spawnprobability="0"/>
+    <PreferredContainer spawnprobability="0"/>
+    <PreferredContainer spawnprobability="0"/>
+    <PreferredContainer spawnprobability="0"/>
+    <PreferredContainer spawnprobability="0"/>
+    <PreferredContainer spawnprobability="0"/>
+    <PreferredContainer spawnprobability="0"/>
+    <!-- not purchaseable -->
+    <Price sold="false" canbespecial="false" />
+    <!-- not fabricable -->
+    <Fabricate />
+    <MeleeWeapon>
+      <Attack>
+        <Affliction identifier="lacerations" strength="10" />
+        <Affliction identifier="bleeding" strength="10" />
+        <Affliction identifier="stun" strength="0.2" />
+        <Affliction identifier="mysteryaffliction" strength="20" />
+      </Attack>
+    </MeleeWeapon>
+  </Item>
+
+  <Item name="" identifier="wrench_murdermystery" nameidentifier="murderweapon" variantof="wrench" Tags="smallitem,tool,simpletool,mechanicalrepairtool,wrenchitem,murderweapon,traitormissionitem" hideinmenus="true">
+    <PreferredContainer spawnprobability="0"/>
+    <PreferredContainer spawnprobability="0"/>
+    <PreferredContainer spawnprobability="0"/>
+    <PreferredContainer spawnprobability="0"/>
+    <PreferredContainer spawnprobability="0"/>
+    <PreferredContainer spawnprobability="0"/>
+    <!-- not purchaseable -->
+    <Price sold="false" canbespecial="false" />
+    <!-- not fabricable -->
+    <Fabricate />
+    <MeleeWeapon>
+      <Attack>
+        <Affliction identifier="blunttrauma" strength="10" />
+        <Affliction identifier="stun" strength="0.2" />
+        <Affliction identifier="mysteryaffliction" strength="20" />
+      </Attack>
+    </MeleeWeapon>
+  </Item>
+
+  <Item name="" identifier="coilgunammobox_blanks" nameidentifier="coilgunammobox" variantof="coilgunammobox" hideinmenus="true">
+    <PreferredContainer primary="coilgunammoloader" spawnprobability="0" />
+    <PreferredContainer spawnprobability="0" />
+    <PreferredContainer spawnprobability="0.01" /><!-- Tiny chance Thalamus/wrecks get the funny ammo -->
+    <PreferredContainer spawnprobability="0" />
+    <Price sold="false" />
+    <Deconstruct time="10">
+      <Item identifier="aluminium"/>
+    </Deconstruct>
+    <Fabricate />
+    <Fabricate />
+    <ItemContainer>
+      <StatusEffect type="OnUse" target="This" disabledeltatime="true">
+        <SpawnItem identifiers="coilgunbolt_blank" spawnposition="ThisInventory" />
+      </StatusEffect>
+      <StatusEffect type="OnUse" target="This" condition="-0.5" disabledeltatime="true">
+        <RequiredItem items="coilgunbolt_blank" type="Contained" />
+      </StatusEffect>
+      <StatusEffect type="OnUse" target="This">
+        <Conditional health="lte 90" />
+        <Sound file="Content/Items/Weapons/honk.ogg" type="OnUse" range="1000" />
+      </StatusEffect>
+      <Containable items="coilgunbolt_blank" />
+    </ItemContainer>
+  </Item>
+
+  <Item name="" identifier="coilgunbolt_blank" nameidentifier="coilgunbolt" variantof="coilgunbolt" hideinmenus="true" sonarsize="0">
+    <Sprite texture="weapons_new.png" sourcerect="0,0,1,1" depth="0.55" />
+    <Holdable />
+    <Projectile>
+      <Attack />
+      <StatusEffect />
+      <StatusEffect type="OnNotContained" target="This" stackable="false" delay="0.1">
+        <Remove />
+      </StatusEffect>
+      <StatusEffect />
+    </Projectile>
+  </Item>
+
+  <Item name="" identifier="huskeggs_huskroulette_harmless" nameidentifier="huskeggs" variantof="huskeggs" Tags="smallitem,syringe,huskroulette,traitormissionitem" hideinmenus="true" maxstacksize="1" maxstacksizecharacterinventory="1">
+    <PreferredContainer primary="toxcontainer" spawnprobability="0" notcampaign="true"/>
+    <PreferredContainer primary="wrecktoxcontainer" spawnprobability="0" />
+    <PreferredContainer secondary="medfabcab"/>
+    <Price baseprice="400" sold="false" />
+    <Fabricate />
+    <Deconstruct />
+    <MeleeWeapon>
+      <StatusEffect type="OnSuccess" target="This" Condition="-100.0" setvalue="true"/>
+      <StatusEffect>
+        <Conditional /><!-- Remove conditional -->
+        <Affliction identifier="huskroulette" amount="120" /><!-- Should override the huskinfection -->
+      </StatusEffect>
+    </MeleeWeapon>
+  </Item>
+
+  <Item name="" identifier="huskeggs_huskroulette_infect" nameidentifier="huskeggs" variantof="huskeggs" Tags="smallitem,syringe,huskroulette,traitormissionitem" hideinmenus="true" maxstacksize="1" maxstacksizecharacterinventory="1">
+    <PreferredContainer primary="toxcontainer" spawnprobability="0" notcampaign="true"/>
+    <PreferredContainer primary="wrecktoxcontainer" spawnprobability="0" />
+    <PreferredContainer secondary="medfabcab"/>
+    <Price baseprice="400" sold="false" />
+    <Fabricate />
+    <Deconstruct />
+    <MeleeWeapon>
+      <StatusEffect type="OnSuccess" />
+      <StatusEffect type="OnSuccess" target="UseTarget" duration="1">
+        <!-- HuskInfectionState must be less than 0.01 so you can't speed up the infection -->
+        <Conditional huskinfection="lt 0.01" />
+        <Affliction identifier="huskinfectionresistance" amount="-600" />
+        <Affliction identifier="huskinfection" amount="50" />
+        <Affliction identifier="huskroulette" amount="120" />
+      </StatusEffect>
+    </MeleeWeapon>
+  </Item>
+
+  <Item name="" identifier="dementonite_mindsunraveled" nameidentifier="dementonite" variantof="dementonite" HideInMenus="true">
+    <PreferredContainer />
+    <PreferredContainer spawnprobability="0" />
+    <PreferredContainer spawnprobability="0" />
+    <PreferredContainer spawnprobability="0" />
+    <PreferredContainer spawnprobability="0" />
+    <Price sold="false">
+      <Clear/>
+    </Price>
+    <Holdable />
+    <ItemComponent>
+      <StatusEffect type="Always" target="This,NearbyCharacters" range="300" Interval="5" Duration="2" stackable="false" checkconditionalalways="true">
+        <Affliction identifier="psychosis" strength="10" />
+        <ParticleEmitter particle="psychosisfx" anglemax="360" particlespersecond="8" />
+        <sound file="Content/Items/Alien/AlienArtifactLoop1.ogg" range="500.0" loop="true" volume="0.5"/>
+      </StatusEffect>
+    </ItemComponent>
+    <LevelResource />
+  </Item>
+</Items>


### PR DESCRIPTION
Reactors have hard restrictions on items they can hold, and the fuel value of the rods in defined in reactors, not the rods themselves. #15826

![430701713-fd521ebf-52ba-4a5f-a383-e541c0eb9c8d](https://github.com/user-attachments/assets/1393e125-78c9-439f-bc0b-1d1c467937ec)

This PR simply puts the fuel value in the rods and allows reactor to hold any time of item tagged as "reactorfuel" or "reactoritem", which allows modders to add new fuel/reactor items without overriding the reactor and causing conflicts. 


**Will this affect performance?**
Probably, I'm not sure to what extent: instead of having 5 statuseffects per reactor you have 1 per fuel rod. I spawned 100 fuel rods in a cabinet and it didnt kill the framerate. Adding an interval breaks the fuel rod. The average campaign will have 20 fuel rods at most, but I'll need more accurate profiling to know.

**Won't this break existing subs?**
I've tested sub editor and loaded existing campaigns, it seems just fine.
I'm not familiar with <Update /> at all, but the reactors and rods seem to have updated just fine, and the changes are quite simple as you can see

**Won't this break existing mods?**
Maybe, but most mods override reactors and fuel anyway partly due to this exact issue, and I'm in touch with modders who do reactor stuff, like M with Enhanced Reactors and Foxtrot with Hazardous Reactors which are the two big ones. I'll try notifying other modders as well.