### PR TITLE
[fix] Use filepath instead of XDocument for md5hash (submarine)

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Map/SubmarineInfo.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Map/SubmarineInfo.cs
@@ -160,8 +160,7 @@ namespace Barotrauma
                 {
                     if (hashTask == null)
                     {
-                        XDocument doc = OpenFile(FilePath);
-                        StartHashDocTask(doc);
+                        StartHashDocTask();
                     }
                     hashTask.Wait();
                     hashTask = null;
@@ -381,7 +380,7 @@ namespace Barotrauma
             }
             if (hash == null)
             {
-                StartHashDocTask(doc);
+                StartHashDocTask();
             }
             SubmarineElement = doc.Root;
         }
@@ -528,14 +527,14 @@ namespace Barotrauma
             return false;
         }
 
-        public void StartHashDocTask(XDocument doc)
+        public void StartHashDocTask()
         {
             if (hash != null) { return; }
             if (hashTask != null) { return; }
 
             hashTask = new Task(() =>
             {
-                hash = Md5Hash.CalculateForString(doc.ToString(), Md5Hash.StringHashOptions.IgnoreWhitespace);
+                hash = Md5Hash.CalculateForFile(FilePath, Md5Hash.StringHashOptions.IgnoreWhitespace);
             });
             hashTask.Start();
         }


### PR DESCRIPTION
Prior to this commit, it would load an XML file (ignoring white spaces, deserializing overhead etc), write the new XDocument into a string (Loading the game would peak at 150MB just for this function alone). It would then try to strip whitespaces again (which allocates another 50-70mb as it constructs a string builder with half the current string size) and finally hash it.

Instead, read the FilePath, strip whitespaces and hash. Very small load times test showed a reduction of roughly 3 seconds, most likely wont be as big in release mode. But at very least, it will make GC more happy :)

This was tested on Linux with .NET 6