### PR TITLE
[fix] AI Select target crash

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/EnemyAIController.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/EnemyAIController.cs
@@ -501,6 +501,9 @@ namespace Barotrauma
 
         public void SelectTarget(AITarget target, float priority)
         {
+            if (target == null)
+                return;
+
             SelectedAiTarget = target;
             currentTargetMemory = GetTargetMemory(target, addIfNotFound: true);
             currentTargetMemory.Priority = priority;
@@ -4400,7 +4403,9 @@ namespace Barotrauma
                     {
                         if (SelectedAiTarget != door.Item.AiTarget || State != AIState.Attack)
                         {
-                            SelectTarget(door.Item.AiTarget, CurrentTargetMemory.Priority);
+                            if (door.Item.AiTarget != null)
+                                SelectTarget(door.Item.AiTarget, CurrentTargetMemory.Priority);
+
                             State = AIState.Attack;
                             return false;
                         }


### PR DESCRIPTION
Had this error twice now in a play through:

```
   05/03/2025 22:15:28 - [05/03/2025 22:15:28]
  SwagLag placed Chemical Crate in the inventory of Crate Shelf (ID: 301)
   05/03/2025 22:15:28 - [05/03/2025 22:15:28]
  Charon opened Custom Door
A crash report("servercrashreport.log") was saved in the root folder of the game. The error was not sent to the developers because user statistics have been disabled, but if you'd like to help fix this bug, you may post it on Barotrauma's GitHub issue tracker: https://github.com/Regalis11/Barotrauma/issues/Unhandled exception. System.ArgumentNullException: Value cannot be null. (Parameter 'key')
   at System.Collections.Generic.Dictionary`2.FindValue(TKey key)
   at System.Collections.Generic.Dictionary`2.TryGetValue(TKey key, TValue& value)
   at Barotrauma.EnemyAIController.SelectTarget(AITarget target, Single priority) in /home/runner/work/LuaCsForBarotrauma/LuaCsForBarotrauma/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/EnemyAIController.cs:
line 508
   at Barotrauma.EnemyAIController.Escape(Single deltaTime)
   at Barotrauma.EnemyAIController.Update(Single deltaTime) in /home/runner/work/LuaCsForBarotrauma/LuaCsForBarotrauma/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/EnemyAIController.cs:line 532
   at Barotrauma.Character.UpdateAll(Single deltaTime, Camera cam) in /home/runner/work/LuaCsForBarotrauma/LuaCsForBarotrauma/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs:line 3363
   at Barotrauma.GameScreen.Update(Double deltaTime) in /home/runner/work/LuaCsForBarotrauma/LuaCsForBarotrauma/Barotrauma/BarotraumaShared/SharedSource/Screens/GameScreen.cs:line 196
   at Barotrauma.GameMain.Run() in /home/runner/work/LuaCsForBarotrauma/LuaCsForBarotrauma/Barotrauma/BarotraumaServer/ServerSource/GameMain.cs:line 356
   at Barotrauma.Program.Main(String[] args) in /home/runner/work/LuaCsForBarotrauma/LuaCsForBarotrauma/Barotrauma/BarotraumaServer/ServerSource/Program.cs:line 89
fish: Job 1, './DedicatedServer' terminated by signal SIGABRT (Abort)
```

This PR should fix that, `SelectTarget` now does a null check internally and the call that would cause the crash also does a null check to be more inline with the other `SelectTarget` calls.

Not sure if there should be a console warning or some sort of info dump if null is passed in? Not entirely sure if its useful.