### PR TITLE
Small improvement to stutters with the server list

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/ServerListScreen/ServerListScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/ServerListScreen/ServerListScreen.cs
@@ -1327,20 +1327,26 @@ namespace Barotrauma
 
             int similarServerCount = 0;
             string serverInfoStr = getServerInfoStr(serverInfo);
-            foreach (var serverElement in serverList.Content.Children)
+            Parallel.ForEach(serverList.Content.Children, serverElement =>
             {
-                if (!serverElement.Visible) { continue; }
-                if (serverElement.UserData is not ServerInfo otherServer || otherServer == serverInfo) { continue; }
-                if (ToolBox.LevenshteinDistance(serverInfoStr, getServerInfoStr(otherServer)) < serverInfoStr.Length * (1.0f - MinSimilarityPercentage))
+                if (!serverElement.Visible)
+                    return;
+
+                if (serverElement.UserData is not ServerInfo otherServer || otherServer == serverInfo)
+                    return;
+
+                if (ToolBox.LevenshteinDistance(serverInfoStr, getServerInfoStr(otherServer)) <
+                    serverInfoStr.Length * (1.0f - MinSimilarityPercentage))
                 {
                     similarServerCount++;
-                    if (similarServerCount > MaxAllowedSimilarServers) 
-                    {  
-                        DebugConsole.Log($"Server {serverInfo.ServerName} seems to be almost identical to {otherServer.ServerName}. Hiding as a potential spam server.");
-                        break;
+                    if (similarServerCount > MaxAllowedSimilarServers)
+                    {
+                        DebugConsole.Log(
+                            $"Server {serverInfo.ServerName} seems to be almost identical to {otherServer.ServerName}. Hiding as a potential spam server.");
                     }
                 }
-            }
+            });
+            
             if (similarServerCount > MaxAllowedSimilarServers) { return; }
 
             static string getServerInfoStr(ServerInfo serverInfo)


### PR DESCRIPTION
Replaced `foreach` with `Parallel.ForEach` as `LevenshteinDistance` is pretty cpu intensive. This at least makes the server browser more usable, it does not eliminate the stutters but it definitely helps. In my use case, I just want to click on `favourites` but I have to wait 10 seconds :sweat_smile: 

It seems like most of the lag spike now comes from bulk adding UI elements, not really sure how that can be improved as `spriteBatch` or adding a new gui frame can't be called from another thread without breaking horribly.

Small video of before & after
https://github.com/user-attachments/assets/b9456c1f-374c-42a9-b68c-3b0b67a0f979

