### PR TITLE
Add AITarget to Submaries that is used with sonar machines

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Characters/AI/AITarget.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Characters/AI/AITarget.cs
@@ -57,6 +57,10 @@ namespace Barotrauma
                     }
                     color = Color.CadetBlue;
                 }
+                else if (Entity is Submarine)
+                {
+                    color = Color.WhiteSmoke;
+                }
                 else
                 {
                     //color = Color.WhiteSmoke;

--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/GameScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/GameScreen.cs
@@ -511,6 +511,7 @@ namespace Barotrauma
             {
                 MapEntity.MapEntityList.ForEach(me => me.AiTarget?.Draw(spriteBatch));
                 Character.CharacterList.ForEach(c => c.AiTarget?.Draw(spriteBatch));
+                Submarine.MainSub?.AiTarget.Draw(spriteBatch);
                 if (GameMain.GameSession?.EventManager != null)
                 {
                     GameMain.GameSession.EventManager.DebugDraw(spriteBatch);

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/EnemyAIController.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/EnemyAIController.cs
@@ -486,6 +486,10 @@ namespace Barotrauma
                     }
                 }
             }
+            else if (aiTarget.Entity is Submarine)
+            {
+                _targetingTags.Add(Tags.Sonar);
+            }
             else if (aiTarget.Entity is Structure)
             {
                 _targetingTags.Add(Tags.Wall);
@@ -3412,7 +3416,7 @@ namespace Barotrauma
                     }
                 }
 
-                if (Character.Submarine == null && aiTarget.Entity?.Submarine != null && targetCharacter == null)
+                if (Character.Submarine == null && aiTarget.Entity is Submarine || aiTarget.Entity?.Submarine != null && targetCharacter == null)
                 {
                     if (matchingTargetParams.PrioritizeSubCenter || matchingTargetParams.AttackPattern is AttackPattern.Circle or AttackPattern.Sweep)
                     {

--- a/Barotrauma/BarotraumaShared/SharedSource/Map/Submarine.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Map/Submarine.cs
@@ -1243,6 +1243,11 @@ namespace Barotrauma
         {
             RefreshConnectedSubs();
 
+            if (aiTarget != null && aiTarget.NeedsUpdate)
+            {
+                aiTarget.Update(deltaTime);
+            }
+
             if (Info.IsWreck)
             {
                 WreckAI?.Update(deltaTime);
@@ -1618,6 +1623,8 @@ namespace Barotrauma
             {
                 this
             };
+
+            aiTarget = new AITarget(this);
 
             upgradeEventIdentifier = new Identifier($"Submarine{ID}");
             Loading = true;


### PR DESCRIPTION
### What
Sonar machines use the AITarget provided by the Entity part of Submarines instead of the machine itself.
### Why
Fixes the misalignment between the display and AITarget that I talk about in #10225 and #11350
### Draft
I made this PR a draft to indicate that I've not looked too much into edge cases yet.