### PR TITLE
Fixed #16142 - Allows to open circuit boxes with E (sub editor)

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/SubEditorScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/SubEditorScreen.cs
@@ -5685,7 +5685,8 @@ namespace Barotrauma
                                     if (entity is Item item && item.Components.Any(ic => ic is not ConnectionPanel && ic is not Repairable && ic.GuiFrame != null))
                                     {
                                         var container = item.GetComponents<ItemContainer>().ToList();
-                                        if (!container.Any() || container.Any(ic => ic?.DrawInventory ?? false))
+                                        if (!container.Any() || container.Any(ic => ic?.DrawInventory ?? false) ||
+                                            item.Components.Any(ic => ic is CircuitBox))
                                         {
                                             OpenItem(item);
                                             break;


### PR DESCRIPTION
Closes #16142 - Not being able to open circuit boxes using "E" in submarine editor

Changes:
- Added a `CircuitBox` component exception check before the `OpenItem()` call in `SubEditorScreen`