### PR TITLE
Remove OSX if else statement for save path.

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/Utils/SaveUtil.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Utils/SaveUtil.cs
@@ -65,23 +65,13 @@ namespace Barotrauma
         private static readonly string LegacySaveFolder = Path.Combine("Data", "Saves");
         private static readonly string LegacyMultiplayerSaveFolder = Path.Combine(LegacySaveFolder, "Multiplayer");
 
-#if OSX
         //"/*user*/Library/Application Support/Daedalic Entertainment GmbH/" on Mac
-        public static readonly string DefaultSaveFolder = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.Personal), 
-            "Library",
-            "Application Support",
-            "Daedalic Entertainment GmbH",
-            "Barotrauma");
-#else
         //"C:/Users/*user*/AppData/Local/Daedalic Entertainment GmbH/" on Windows
         //"/home/*user*/.local/share/Daedalic Entertainment GmbH/" on Linux
         public static readonly string DefaultSaveFolder = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "Daedalic Entertainment GmbH",
             "Barotrauma");
-#endif
-
         public static string DefaultMultiplayerSaveFolder = Path.Combine(DefaultSaveFolder, "Multiplayer");
 
         public static readonly string SubmarineDownloadFolder = Path.Combine("Submarines", "Downloaded");


### PR DESCRIPTION
Fix for bug report  #16268. An if-else statement in the saveutil breaks the file pathing for macOS. Previously, save files were stored under `~/Library/Application Support/`, but after installing the latest update, they're now found under `~/Documents/Library/Application Support/`. I'm guessing the project was updated from .NET 7 to .NET 8 or higher in the latest release, which changed `Environment.SpecialFolder.Personal` from `$HOME` to `$HOME/Documents`. 

The obvious fix is to remove the if-else statement altogether and use `SpecialFolder.LocalApplicationData` for all operating systems.

https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/getfolderpath-unix

```
Console.WriteLine("Home: " + Environment.GetEnvironmentVariable("HOME"));
Console.WriteLine("Personal: " + Environment.GetFolderPath(Environment.SpecialFolder.Personal));
Console.WriteLine("ApplicationData: " + Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));
Console.WriteLine("LocalApplicationData: " + Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData));
Console.WriteLine(".NET Version: " + Environment.Version);
Console.WriteLine("macOS Version: " + Environment.OSVersion);
```
```
Home: /Users/cubea01
Personal: /Users/cubea01/Documents
ApplicationData: /Users/cubea01/Library/Application Support
LocalApplicationData: /Users/cubea01/Library/Application Support
.NET Version: 9.0.6
macOS Version: Unix 15.5.0
```
