### PR TITLE
Pirate Captain Hat Changes

### DIFF
--- a/Barotrauma/Content/Jobs.xml
+++ b/Barotrauma/Content/Jobs.xml
@@ -41,6 +41,24 @@
     </ItemSet>
     <ItemSet>
       <Item identifier="idcard" equip="true" showpreview="false"/>
+      <Item identifier="captainscap1" identifierteam2="piratecaptainhat2" equip="true"/>
+      <Item identifier="captainsuniform1" identifierteam2="captainseparatistsuniform1" equip="true" outfit="true"/>
+      <Item identifier="headset" equip="true" showpreview="false"/>
+      <Item identifier="captainspipe" GameMode="PvE" equip="false">
+        <Item identifier="pipetobacco" />
+      </Item>
+      <Item identifier="revolver" equip="false">
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+      </Item>
+      <Item identifier="divingknife" equip="false" GameMode="PvP"/>
+    </ItemSet>
+    <ItemSet>
+      <Item identifier="idcard" equip="true" showpreview="false"/>
       <Item identifier="captainscap2" identifierteam2="captainsseparatistcap1" equip="true"/>
       <Item identifier="captainsuniform2" identifierteam2="captainseparatistsuniform2" equip="true" outfit="true"/>
       <Item identifier="headset" equip="true" showpreview="false"/>

--- a/Barotrauma/Content/Jobs.xml
+++ b/Barotrauma/Content/Jobs.xml
@@ -1,0 +1,584 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Jobs>
+  <Job identifier="captain"
+       minnumber="0" maxnumber="1" minkarma="0" initialcount="1"
+       CampaignSetupUIOrder="0"
+       uicolor="0.65,0.73,0.84"
+       vitalitymodifier="0"
+       pricemultiplier="1.3"
+       idlebehavior="StayInHull">
+    <Jobicon>
+      <sprite texture="Content/UI/MainIconsAtlas.png" sourcerect="384,256,128,128" origin="0.5,0.5"/>
+    </Jobicon>
+    <JobiconSmall>
+      <sprite texture="Content/UI/CommandUIAtlas.png" sourcerect="612,669,28,28" origin="0.5,0.5"/>
+    </JobiconSmall>
+    <Skills>
+    <!-- Default pricemultiplier on skills is 15 mk per skillpoint. Primary skills cost more. -->
+      <Skill identifier="helm" level="40,50" primary="true" pvplevel="65" pricemultiplier="20"/>
+      <Skill identifier="weapons" level="25,35" pvplevel="55"/>
+      <Skill identifier="mechanical" level="15,25" pvplevel="50"/>
+      <Skill identifier="electrical" level="15,25" pvplevel="50"/>
+      <Skill identifier="medical" level="5,10" pvplevel="50" pricemultiplier="10"/>
+    </Skills>
+    <ItemSet>
+      <Item identifier="idcard" equip="true" showpreview="false"/>
+      <Item identifier="captainscap1" identifierteam2="piratecaptainhat" equip="true"/>
+      <Item identifier="captainsuniform1" identifierteam2="captainseparatistsuniform1" equip="true" outfit="true"/>
+      <Item identifier="headset" equip="true" showpreview="false"/>
+      <Item identifier="captainspipe" GameMode="PvE" equip="false">
+        <Item identifier="pipetobacco" />
+      </Item>
+      <Item identifier="revolver" equip="false">
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+      </Item>
+      <Item identifier="divingknife" equip="false" GameMode="PvP"/>
+    </ItemSet>
+    <ItemSet>
+      <Item identifier="idcard" equip="true" showpreview="false"/>
+      <Item identifier="captainscap2" identifierteam2="captainsseparatistcap1" equip="true"/>
+      <Item identifier="captainsuniform2" identifierteam2="captainseparatistsuniform2" equip="true" outfit="true"/>
+      <Item identifier="headset" equip="true" showpreview="false"/>
+      <Item identifier="captainspipe" GameMode="PvE" equip="false">
+        <Item identifier="pipetobacco" />
+      </Item>
+      <Item identifier="revolver" equip="false">
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+      </Item>
+      <Item identifier="divingknife" equip="false" GameMode="PvP"/>
+    </ItemSet>
+    <ItemSet>
+      <Item identifier="idcard" equip="true" showpreview="false"/>
+      <Item identifier="captainscap3" identifierteam2="captainsseparatistcap2" equip="true"/>
+      <Item identifier="captainsuniform3" identifierteam2="captainseparatistsuniform3" equip="true" outfit="true"/>
+      <Item identifier="headset" equip="true" showpreview="false"/>
+      <Item identifier="captainspipe" GameMode="PvE" equip="false">
+        <Item identifier="pipetobacco" />
+      </Item>
+      <Item identifier="revolver" equip="false">
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+      </Item>
+      <Item identifier="divingknife" equip="false" GameMode="PvP"/>
+    </ItemSet>
+    <AutonomousObjectives>
+      <Order identifier="fightintruders" prioritymodifier="1"/>
+      <Order identifier="extinguishfires" prioritymodifier ="1"/>
+      <Order identifier="rescue" prioritymodifier="1"/>
+      <Order identifier="steer" option="maintainposition" prioritymodifier="1"/>
+      <Order identifier="operatereactor" option="powerup" prioritymodifier="0.1"/>
+      <Order identifier="fixleaks" prioritymodifier="0.1"/>
+    </AutonomousObjectives>
+    <AppropriateOrders>
+      <Order identifier="steer"/>
+    </AppropriateOrders>
+  </Job>
+
+  <Job identifier="engineer"
+       minkarma="0" initialcount="1"
+       CampaignSetupUIOrder="1"
+       uicolor="0.88,0.72,0.43"
+       vitalitymodifier="0"
+       pricemultiplier="1"
+       idlebehavior="Active">
+    <Jobicon>
+      <sprite texture="Content/UI/MainIconsAtlas.png" sourcerect="768,256,128,128" origin="0.5,0.5"/>
+    </Jobicon>
+    <JobiconSmall>
+      <sprite texture="Content/UI/CommandUIAtlas.png" sourcerect="612,727,28,28" origin="0.5,0.5"/>
+    </JobiconSmall>
+    <Skills>
+      <Skill identifier="electrical" level="40,50" primary="true" pvplevel="70"  pricemultiplier="20"/>
+      <Skill identifier="mechanical" level="25,35" pvplevel="50"/>
+      <Skill identifier="weapons" level="15,25" pvplevel="50"/>
+      <Skill identifier="medical" level="15,25" pvplevel="50"/>
+      <Skill identifier="helm" level="5,10" pvplevel="50" pricemultiplier="10"/>
+    </Skills>
+    <ItemSet>
+      <Item identifier="idcard" equip="true" showpreview="false"/>
+      <Item identifier="orangejumpsuit1" identifierteam2="engineerseparatistsuniform1" equip="true" outfit="true"/>
+      <Item identifier="headset" equip="true" showpreview="false"/>
+      <Item identifier="toolbelt" equip="true" GameMode="PvE" />
+      <Item identifier="wrench" GameMode="PvE" />
+      <Item identifier="screwdriver" GameMode="PvE" />
+      <Item identifier="fuelrod" GameMode="PvE" />
+      <Item identifier="divingknife" equip="false" GameMode="PvP"/>
+      <Item identifier="revolver" GameMode="PvP" equip="false">
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+      </Item>
+    </ItemSet>
+    <ItemSet>
+      <Item identifier="idcard" equip="true" showpreview="false"/>
+      <Item identifier="orangejumpsuit2" identifierteam2="engineerseparatistsuniform2" equip="true" outfit="true"/>
+      <Item identifier="headset" equip="true" showpreview="false"/>
+      <Item identifier="toolbelt" equip="true" GameMode="PvE"/>
+      <Item identifier="wrench" GameMode="PvE"/>
+      <Item identifier="screwdriver" GameMode="PvE" />
+      <Item identifier="fuelrod" GameMode="PvE" />
+      <Item identifier="divingknife" equip="false" GameMode="PvP"/>
+      <Item identifier="revolver" GameMode="PvP" equip="false">
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+      </Item>
+    </ItemSet>
+    <AutonomousObjectives>
+      <Order identifier="extinguishfires" prioritymodifier ="1"/>
+      <Order identifier="repairelectrical" prioritymodifier="1"/>
+      <Order identifier="rescue" prioritymodifier="1"/>
+      <Order identifier="fixleaks" prioritymodifier="0.75"/>
+      <Order identifier="operatereactor" option="powerup" prioritymodifier="0.5"/>
+      <Order identifier="repairsystems" prioritymodifier="0.5"/>
+      <Order identifier="pumpwater" option="pumpout" prioritymodifier="0.1"/>
+    </AutonomousObjectives>
+    <AppropriateOrders>
+      <Order identifier="operatereactor"/>
+      <Order identifier="repairelectrical"/>
+      <Order identifier="chargebatteries"/>
+      <Order identifier="reportbrokendevices"/>
+    </AppropriateOrders>
+  </Job>
+
+  <Job identifier="mechanic"
+       minkarma="0" initialcount="1"
+       CampaignSetupUIOrder="2"
+       uicolor="0.5,0.86,0.9"
+       vitalitymodifier="0"
+       pricemultiplier="1"
+       idlebehavior="Active">
+    <Jobicon>
+      <sprite texture="Content/UI/MainIconsAtlas.png" sourcerect="896,256,128,128" origin="0.5,0.5"/>
+    </Jobicon>
+    <JobiconSmall>
+      <sprite texture="Content/UI/CommandUIAtlas.png" sourcerect="641,640,28,28" origin="0.5,0.5"/>
+    </JobiconSmall>
+    <Skills>
+      <Skill identifier="mechanical" level="40,50" primary="true" pvplevel="70" pricemultiplier="20"/>
+      <Skill identifier="electrical" level="25,35" pvplevel="50"/>
+      <Skill identifier="weapons" level="15,25" pvplevel="50"/>
+      <Skill identifier="medical" level="15,25" pvplevel="50"/>
+      <Skill identifier="helm" level="5,10" pvplevel="50" pricemultiplier="10"/>
+    </Skills>
+    <ItemSet>
+      <Item identifier="idcard" equip="true" showpreview="false"/>
+      <Item identifier="baseballcap" identifierteam2="piratebandana" equip="true" />
+      <Item identifier="bluejumpsuit1" identifierteam2="mechanicseparatistsuniform1" equip="true" outfit="true"/>
+      <Item identifier="headset" equip="true" showpreview="false"/>
+      <Item identifier="toolbelt" equip="true" GameMode="PvE"/>
+      <Item identifier="wrench" GameMode="PvE" />
+      <Item identifier="screwdriver" GameMode="PvE" />
+      <Item identifier="weldingtool" GameMode="PvE" >
+        <Item identifier="weldingfueltank" showpreview="false"/>
+      </Item>
+      <Item identifier="plasmacutter" GameMode="PvE">
+        <Item identifier="oxygentank" showpreview="false"/>
+      </Item>
+      <Item identifier="divingknife" equip="false" GameMode="PvP"/>
+      <Item identifier="revolver" GameMode="PvP" equip="false">
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+      </Item>
+    </ItemSet>
+    <ItemSet>
+      <Item identifier="idcard" equip="true" showpreview="false"/>
+      <Item identifier="baseballcap" identifierteam2="piratebandana" equip="true" />
+      <Item identifier="bluejumpsuit2" identifierteam2="mechanicseparatistsuniform2" equip="true" outfit="true"/>
+      <Item identifier="headset" equip="true" showpreview="false"/>
+      <Item identifier="toolbelt" equip="true" GameMode="PvE"/>
+      <Item identifier="wrench" GameMode="PvE"/>
+      <Item identifier="screwdriver" GameMode="PvE"/>
+      <Item identifier="weldingtool" GameMode="PvE">
+        <Item identifier="weldingfueltank" showpreview="false"/>
+      </Item>
+      <Item identifier="plasmacutter" GameMode="PvE">
+        <Item identifier="oxygentank" showpreview="false"/>
+      </Item>
+      <Item identifier="divingknife" equip="false" GameMode="PvP"/>
+      <Item identifier="revolver" GameMode="PvP" equip="false">
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+      </Item>
+    </ItemSet>
+    <AutonomousObjectives>
+      <Order identifier="fixleaks" prioritymodifier="1"/>
+      <Order identifier="repairmechanical" prioritymodifier="1"/>
+      <Order identifier="extinguishfires" prioritymodifier ="1"/>
+      <Order identifier="rescue" prioritymodifier="1"/>
+      <Order identifier="repairsystems" prioritymodifier="0.5"/>
+      <Order identifier="pumpwater" option="pumpout" prioritymodifier="0.5"/>
+      <Order identifier="operatereactor" option="powerup" prioritymodifier="0.3"/>
+    </AutonomousObjectives>
+    <AppropriateOrders>
+      <Order identifier="fixleaks"/>
+      <Order identifier="pumpwater"/>
+      <Order identifier="repairmechanical"/>
+      <Order identifier="reportbrokendevices"/>
+    </AppropriateOrders>
+  </Job>
+
+  <Job identifier="securityofficer"
+       minkarma="0"
+       uicolor="0.57,0.48,0.43"
+       vitalitymodifier="0"
+       pricemultiplier="1.15"
+       idlebehavior="Patrol">
+    <Jobicon>
+      <sprite texture="Content/UI/MainIconsAtlas.png" sourcerect="256,256,128,128" origin="0.5,0.5"/>
+    </Jobicon>
+    <JobiconSmall>
+      <sprite texture="Content/UI/CommandUIAtlas.png" sourcerect="612,640,28,28" origin="0.5,0.5"/>
+    </JobiconSmall>
+    <Skills>
+      <Skill identifier="weapons" level="40,50" primary="true" pvplevel="60" pricemultiplier="20" />
+      <Skill identifier="medical" level="25,35" pvplevel="50" />
+      <Skill identifier="mechanical" level="15,25" pvplevel="50" />
+      <Skill identifier="electrical" level="15,25" pvplevel="50" />
+      <Skill identifier="helm" level="5,10" pvplevel="50" pricemultiplier="10" />
+    </Skills>
+    <ItemSet>
+      <Item identifier="securityuniform1" identifierteam2="securityseparatistsuniform1" equip="true" outfit="true"/>
+      <Item identifier="idcard" equip="true" showpreview="false"/>
+      <Item identifier="headset" equip="true" showpreview="false"/>   
+      <Item identifier="divingknife" equip="false" />
+      <Item identifier="handcuffs" GameMode="PvE"/>
+      <Item identifier="stunbaton" GameMode="PvE">
+        <Item identifier="batterycell" showpreview="false"/>
+      </Item>
+      <Item identifier="revolver" GameMode="PvP" equip="false">
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+      </Item>
+    </ItemSet>
+    <ItemSet>
+      <Item identifier="securityuniform2" identifierteam2="securityseparatistsuniform2" equip="true" outfit="true"/>
+      <Item identifier="idcard" equip="true" showpreview="false"/>
+      <Item identifier="headset" equip="true" showpreview="false"/>
+      <Item identifier="divingknife" equip="false"/>
+      <Item identifier="handcuffs" GameMode="PvE"/>
+      <Item identifier="stunbaton" GameMode="PvE">
+        <Item identifier="batterycell" showpreview="false"/>
+      </Item>
+      <Item identifier="revolver" GameMode="PvP" equip="false">
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+      </Item>
+    </ItemSet>
+    <ItemSet>
+      <Item identifier="securityuniform3" identifierteam2="securityseparatistsuniform3" equip="true" outfit="true"/>
+      <Item identifier="idcard" equip="true" showpreview="false"/>
+      <Item identifier="headset" equip="true" showpreview="false"/>
+      <Item identifier="divingknife" equip="false" />
+      <Item identifier="handcuffs" GameMode="PvE"/>
+      <Item identifier="stunbaton" GameMode="PvE">
+        <Item identifier="batterycell" showpreview="false"/>
+      </Item>
+      <Item identifier="revolver" GameMode="PvP" equip="false">
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+      </Item>
+    </ItemSet>
+    <AutonomousObjectives>
+      <Order identifier="fightintruders" prioritymodifier="1"/>
+      <Order identifier="rescue" prioritymodifier="1"/>
+      <Order identifier="extinguishfires" prioritymodifier ="0.75"/>
+      <Order identifier="inspectnoises" prioritymodifier="0.5" />
+      <Order identifier="operatereactor" option="powerup" prioritymodifier="0.2"/>
+      <Order identifier="fixleaks" prioritymodifier="0.1"/>
+    </AutonomousObjectives>
+    <AppropriateOrders>
+      <Order identifier="operateweapons"/>
+      <Order identifier="fightintruders"/>
+    </AppropriateOrders>
+  </Job>
+
+  <Job identifier="medicaldoctor"
+       minkarma="0"
+       uicolor="0.81,0.31,0.19"
+       vitalitymodifier="0"
+       pricemultiplier="1.15"
+       idlebehavior="Active">
+    <Jobicon>
+      <sprite texture="Content/UI/MainIconsAtlas.png" sourcerect="512,256,128,128" origin="0.5,0.5"/>
+    </Jobicon>
+    <JobiconSmall>
+      <sprite texture="Content/UI/CommandUIAtlas.png" sourcerect="612,698,28,28" origin="0.5,0.5"/>
+    </JobiconSmall>
+    <Skills>
+      <Skill identifier="medical" level="40,50" primary="true" pvplevel="70" pricemultiplier="20"/>
+      <Skill identifier="weapons" level="15,25" pvplevel="50"/>
+      <Skill identifier="mechanical" level="15,25" pvplevel="50"/>
+      <Skill identifier="electrical" level="15,25" pvplevel="50"/>
+      <Skill identifier="helm" level="5,10" pvplevel="50" pricemultiplier="10"/>
+    </Skills>
+    <ItemSet>
+      <Item identifier="idcard" equip="true" showpreview="false"/>
+      <Item identifier="doctorsuniform1" identifierteam2="medicseparatistsuniform1" equip="true" outfit="true"/>
+      <Item identifier="headset" equip="true" showpreview="false"/>
+      <Item identifier="syringegun" GameMode="PvE"/>
+      <Item identifier="antibleeding1" GameMode="PvE" />
+      <Item identifier="antidama1" GameMode="PvE"/>
+      <Item identifier="divingknife" equip="false" GameMode="PvP"/>
+      <Item identifier="revolver" GameMode="PvP" equip="false">
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+      </Item>
+    </ItemSet>
+    <ItemSet>
+      <Item identifier="idcard" equip="true" showpreview="false"/>
+      <Item identifier="doctorsuniform2" identifierteam2="medicseparatistsuniform2" equip="true" outfit="true"/>
+      <Item identifier="headset" equip="true" showpreview="false"/>
+      <Item identifier="syringegun" GameMode="PvE"/>
+      <Item identifier="antibleeding1" GameMode="PvE"/>
+      <Item identifier="antidama1" GameMode="PvE"/>
+      <Item identifier="divingknife" equip="false" GameMode="PvP"/>
+      <Item identifier="revolver" GameMode="PvP" equip="false">
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+      </Item>
+    </ItemSet>
+    <AutonomousObjectives>
+      <Order identifier="rescue" prioritymodifier="1"/>
+      <Order identifier="extinguishfires" prioritymodifier ="0.5"/>
+      <Order identifier="operatereactor" option="powerup" prioritymodifier="0.2"/>
+      <Order identifier="fixleaks" prioritymodifier="0.1"/>
+    </AutonomousObjectives>
+    <AppropriateOrders>
+      <Order identifier="rescue"/>
+      <Order identifier="requestfirstaid"/>
+    </AppropriateOrders>
+  </Job>
+
+  <Job identifier="assistant"
+       allowalways="true" minkarma="0"
+       vitalitymodifier="0"
+       pricemultiplier="0.8"
+       idlebehavior="Active">
+    <Jobicon>
+      <sprite texture="Content/UI/MainIconsAtlas.png" sourcerect="640,256,128,128" origin="0.5,0.5"/>
+    </Jobicon>
+    <JobiconSmall>
+      <sprite texture="Content/UI/CommandUIAtlas.png" sourcerect="641,669,28,28" origin="0.5,0.5"/>
+    </JobiconSmall>
+    <Skills>
+      <Skill identifier="weapons" level="20,30" pvplevel="55" />
+      <Skill identifier="mechanical" level="20,30" pvplevel="55" />
+      <Skill identifier="electrical" level="20,30" pvplevel="55"/>
+      <Skill identifier="medical" level="20,30" pvplevel="55" />
+      <Skill identifier="helm" level="17.5,20" pvplevel="55"/>
+    </Skills>
+    <ItemSet>
+      <Item identifier="idcard" equip="true" showpreview="false"/>
+      <Item identifier="assistantclothes" identifierteam2="separatistcommoner1" equip="true" outfit="true"/>
+      <Item identifier="wrench" GameMode="PvE"/>
+      <Item identifier="screwdriver" GameMode="PvE"/>
+      <Item identifier="headset" equip="true" showpreview="false"/>
+      <Item identifier="divingknife" equip="false" GameMode="PvP"/>
+      <Item identifier="revolver" GameMode="PvP" equip="false">
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+        <Item identifier="revolverround" />
+      </Item>
+    </ItemSet>
+    <AutonomousObjectives>
+      <Order identifier="extinguishfires" prioritymodifier ="1"/>
+      <Order identifier="pumpwater" option="pumpout" prioritymodifier="1"/>
+      <Order identifier="rescue" prioritymodifier="1"/>
+      <Order identifier="repairsystems" prioritymodifier="0.5"/>
+      <Order identifier="fixleaks" prioritymodifier="0.5"/>
+      <Order identifier="operatereactor" option="powerup" prioritymodifier="0.4"/>
+    </AutonomousObjectives>
+  </Job>
+  
+  <!--NPC only jobs-->
+  <!-- items and behaviors defined through itemsets-->
+
+  <Job identifier="watchman"
+       onlyjobspecificdialog="false"
+       minnumber="0" maxnumber="0" initialcount="0" hiddenjob="true">
+    <ItemSet>
+      <Item identifier="watchmanclothes" equip="true"/>
+      <Item identifier="idcard" equip="true" showpreview="false"/>
+      <Item identifier="revolver" equip="false">
+        <Item identifier="revolverround"/>
+        <Item identifier="revolverround"/>
+        <Item identifier="revolverround"/>
+        <Item identifier="revolverround"/>
+        <Item identifier="revolverround"/>
+        <Item identifier="revolverround"/>
+      </Item>
+    </ItemSet>
+  </Job>
+
+  <Job identifier="commoner" onlyjobspecificdialog="true" minnumber="0" maxnumber="0" initialcount="0" hiddenjob="true"/>
+  <Job identifier="prisoner" onlyjobspecificdialog="true" minnumber="0" maxnumber="0" initialcount="0" hiddenjob="true">
+    <AutonomousObjectives>
+      <Order identifier="escapehandcuffs" prioritymodifier="1" />
+      <Order identifier="fightintruders" />
+    </AutonomousObjectives>
+  </Job>
+  <Job identifier="vip" onlyjobspecificdialog="true" minnumber="0" maxnumber="0" initialcount="0" hiddenjob="true">
+    <Skills>
+      <Skill identifier="medical" level="80,90" primary="true" />
+      <Skill identifier="weapons" level="15,25" />
+      <Skill identifier="mechanical" level="15,25" />
+      <Skill identifier="electrical" level="15,25" />
+      <Skill identifier="helm" level="5,10" />
+    </Skills>
+    <ItemSet />
+    <AutonomousObjectives>
+      <Order identifier="rescue" prioritymodifier="1" />
+    </AutonomousObjectives>
+  </Job>
+  <Job identifier="vipsecurityofficer" onlyjobspecificdialog="true" minnumber="0" maxnumber="0" initialcount="0" hiddenjob="true">
+    <Skills>
+      <Skill identifier="weapons" level="40,50" primary="true" />
+      <Skill identifier="medical" level="25,35" />
+      <Skill identifier="mechanical" level="15,25" />
+      <Skill identifier="electrical" level="15,25" />
+      <Skill identifier="helm" level="5,10" />
+    </Skills>
+    <AutonomousObjectives>
+      <Order identifier="fightintruders" prioritymodifier="1" />
+      <Order identifier="rescue" prioritymodifier="1" />
+      <Order identifier="inspectnoises" prioritymodifier="0.5" />
+      <Order identifier="extinguishfires" prioritymodifier="0.75" />
+    </AutonomousObjectives>
+  </Job>
+
+  <Job identifier="outpostsecurityofficer" vitalitymodifier="10" minnumber="0" maxnumber="0" initialcount="0" idlebehavior="Patrol" hiddenjob="true">
+    <Skills>
+      <Skill identifier="weapons" level="40,50" primary="true"/>
+      <Skill identifier="medical" level="25,35"/>
+      <Skill identifier="mechanical" level="15,25"/>
+      <Skill identifier="electrical" level="15,25"/>
+      <Skill identifier="helm" level="5,10"/>
+    </Skills>
+    <AutonomousObjectives>
+      <Order identifier="fightintruders" prioritymodifier="1"/>
+      <Order identifier="findthieves" prioritymodifier="1" IgnoreAtNonOutpost="true"/>
+      <Order identifier="rescue" prioritymodifier="1"/>
+      <Order identifier="inspectnoises" prioritymodifier="0.5" />
+      <Order identifier="extinguishfires" prioritymodifier ="0.75"/>
+      <Order identifier="operatereactor" option="powerup" prioritymodifier="0.2"/>
+      <Order identifier="fixleaks" prioritymodifier="0.1"/>
+    </AutonomousObjectives>
+  </Job>
+
+  <Job identifier="outpostmanager" vitalitymodifier="0" idlebehavior="StayInHull" hiddenjob="true">
+    <Skills>
+      <Skill identifier="helm" level="40,50" primary="true"/>
+      <Skill identifier="weapons" level="25,35"/>
+      <Skill identifier="mechanical" level="15,25"/>
+      <Skill identifier="electrical" level="15,25"/>
+      <Skill identifier="medical" level="5,10"/>
+    </Skills>
+    <AutonomousObjectives>
+      <Order identifier="fightintruders" prioritymodifier="1"/>
+      <Order identifier="extinguishfires" prioritymodifier ="1"/>
+      <Order identifier="rescue" prioritymodifier="1"/>
+      <Order identifier="fixleaks" prioritymodifier="0.1"/>
+    </AutonomousObjectives>
+  </Job>
+
+  <!-- Used for hostile NPCs -->
+  <Job identifier="killer" onlyjobspecificdialog="false" minnumber="0" maxnumber="0" initialcount="0" hiddenjob="true" idlebehavior="Patrol">
+    <Skills>
+      <Skill identifier="weapons" level="60,70" primary="true" />
+      <Skill identifier="medical" level="25,35" />
+      <Skill identifier="mechanical" level="15,25" />
+      <Skill identifier="electrical" level="15,25" />
+      <Skill identifier="helm" level="5,10" />
+    </Skills>
+    <AutonomousObjectives>
+      <Order identifier="fightintruders" prioritymodifier="1" />
+      <Order identifier="inspectnoises" prioritymodifier="0.5" />
+      <Order identifier="extinguishfires" prioritymodifier="0.75" />
+    </AutonomousObjectives>
+  </Job>
+  <Job identifier="structuredefender" onlyjobspecificdialog="false" minnumber="0" maxnumber="0" initialcount="0" hiddenjob="true" idlebehavior="Patrol">
+    <Skills>
+      <Skill identifier="weapons" level="60,70" primary="true" />
+      <Skill identifier="medical" level="25,35" />
+      <Skill identifier="mechanical" level="15,25" />
+      <Skill identifier="electrical" level="15,25" />
+      <Skill identifier="helm" level="5,10" />
+    </Skills>
+    <AutonomousObjectives>
+      <Order identifier="fightintruders" prioritymodifier="1"/>
+      <Order identifier="rescue" prioritymodifier="1"/>
+      <Order identifier="extinguishfires" prioritymodifier ="0.75"/>
+      <Order identifier="operatereactor" option="powerup" prioritymodifier="0.5"/>
+      <Order identifier="operateweapons" prioritymodifier="0.3"/>
+      <Order identifier="fixleaks" prioritymodifier="0.2"/>
+      <Order identifier="repairsystems" prioritymodifier="0.2"/>
+      <Order identifier="cleanupitems" prioritymodifier="0.1"/>
+    </AutonomousObjectives>
+  </Job>
+
+  <ItemRepairPriorities>
+    <Item tag="reactor" priority="5.0"/>
+    <Item tag="navterminal" priority="5.0"/>
+    <Item tag="engine" priority="4.0"/>
+    <Item tag="pump" priority="3.0"/>
+    <Item tag="junctionbox" priority="3.0"/>
+    <Item tag="oxygengenerator" priority="2.0"/>
+    <Item tag="supercapacitor" priority="2.0"/>
+    <Item tag="door" priority="0.5"/>
+    <Item tag="fabricator" priority="0.5"/>
+    <Item tag="medicalfabricator" priority="0.5"/>
+  </ItemRepairPriorities>
+
+</Jobs>

--- a/Barotrauma/Content/Map/Pirates/PirateItems.xml
+++ b/Barotrauma/Content/Map/Pirates/PirateItems.xml
@@ -1,0 +1,442 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Items>
+  <piratedecor name="" nameidentifier="piratesubdeco" noninteractable="true" identifier="piratesubdeco1" scale="0.7" category="Decorative" subcategory="separatistassets">
+    <sprite texture="Content/Map/Pirates/PirateShipAssets2.png" sourcerect="1230,737,393,482" depth="0.8" origin="0.5,0.5" />
+  </piratedecor>
+  <piratedecor name="" nameidentifier="piratesubdeco" noninteractable="true" identifier="piratesubdeco2" scale="0.7" category="Decorative" subcategory="separatistassets">
+    <sprite texture="Content/Map/Pirates/PirateShipAssets2.png" sourcerect="1121,1252,600,360" depth="0.8" origin="0.5,0.5" />
+  </piratedecor>
+  <piratedecor name="" nameidentifier="piratesubdeco" noninteractable="true" identifier="piratesubdeco3" scale="0.7" category="Decorative" subcategory="separatistassets">
+    <sprite texture="Content/Map/Pirates/PirateShipAssets2.png" sourcerect="1065,1646,756,397" depth="0.8" origin="0.5,0.5" />
+  </piratedecor>
+  <piratedecor name="" nameidentifier="op_sepbarbedwire" noninteractable="true" identifier="barbedwire" scale="0.7" category="Decorative, Wrecked" subcategory="banditseparatist">
+    <sprite texture="Content/Map/Pirates/PirateShipAssets2.png" sourcerect="0,1981,920,59" depth="0.8" origin="0.5,0.5" />
+  </piratedecor>
+  <piratedecor name="" nameidentifier="graffiti1" noninteractable="true" identifier="piratedecal1" scale="0.7" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Pirates/PirateShipAssets2.png" sourcerect="39,1264,380,431" depth="0.8" origin="0.5,0.5" />
+  </piratedecor>
+  <piratedecor name="" nameidentifier="graffiti1" noninteractable="true" identifier="piratedecal2" scale="0.7" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Pirates/PirateShipAssets2.png" sourcerect="556,1263,262,437" depth="0.8" origin="0.5,0.5" />
+  </piratedecor>
+  <piratedecor name="" nameidentifier="graffiti1" noninteractable="true" identifier="piratedecal3" scale="0.7" category="Decorative" subcategory="generic">
+    <sprite texture="Content/Map/Pirates/PirateShipAssets2.png" sourcerect="71,1707,714,252" depth="0.8" origin="0.5,0.5" />
+  </piratedecor>
+  <Item name="" identifier="separatistcommoner1" nameidentifier="pirateclothes" aliases="pirateclothes" category="Equipment" cargocontaineridentifier="metalcrate" tags="smallitem,clothing,separatists" scale="0.5" impactsoundtag="impact_soft">
+    <Price baseprice="225" sold="false">
+      <Price storeidentifier="merchantoutpost" minavailable="1" maxavailable="2" sold="true">
+        <Reputation faction="separatists" min="30"/>
+      </Price>
+      <Price storeidentifier="merchantcity" multiplier="1.2" minavailable="2" maxavailable="5" sold="true">
+        <Reputation faction="separatists" min="30"/>
+      </Price>
+      <Price storeidentifier="merchantresearch" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.3" />
+      <Price storeidentifier="merchantmine" multiplier="0.9" />
+    </Price>
+    <Deconstruct time="10">
+      <Item identifier="organicfiber" />
+    </Deconstruct>
+    <Sprite name="pirate" texture="Content/Items/Jobgear/MiscJobGear.png" sourcerect="767,233,122,58" depth="0.6" origin="0.5,0.5" />
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas2.png" sheetindex="1,10" sheetelementsize="64,64" />
+    <Body width="100" height="50" density="15" friction="0.8" restitution="0.01" />
+    <Wearable slots="Any,InnerClothes" msg="ItemMsgPickUpSelect">
+      <sprite name="Pirate Uniform 2 Torso" texture="pirate_2.png" limb="Torso" hidelimb="false" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 2 Right Hand" texture="pirate_2.png" limb="RightHand" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 2 Left Hand" texture="pirate_2.png" limb="LeftHand" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 2 Right Lower Arm" texture="pirate_2.png" limb="RightArm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 2 Left Lower Arm" texture="pirate_2.png" limb="LeftArm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 2 Right Upper Arm" texture="pirate_2.png" limb="RightForearm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 2 Left Upper Arm" texture="pirate_2.png" limb="LeftForearm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 2 Waist" texture="pirate_2.png" limb="Waist" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 2 Right Thigh" texture="pirate_2.png" limb="RightThigh" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 2 Left Thigh" texture="pirate_2.png" limb="LeftThigh" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 2 Right Leg" texture="pirate_2.png" limb="RightLeg" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 2 Left Leg" texture="pirate_2.png" limb="LeftLeg" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 2 Left Shoe" texture="pirate_2.png" limb="LeftFoot" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 2 Right Shoe" texture="pirate_2.png" limb="RightFoot" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <damagemodifier armorsector="0.0,360.0" afflictionidentifiers="lacerations,gunshotwound" damagemultiplier="0.9" />
+    </Wearable>
+  </Item>
+  <Item name="" identifier="piratecaptainhat" category="Equipment" tags="smallitem,clothing,separatists" impactsoundtag="impact_metal_heavy" scale="0.4" cargocontaineridentifier="metalcrate">
+    <Price baseprice="175" sold="false">
+      <Price storeidentifier="merchantoutpost" minavailable="1" maxavailable="2" sold="true">
+        <Reputation faction="separatists" min="30"/>
+      </Price>
+      <Price storeidentifier="merchantcity" minavailable="2" maxavailable="5" sold="true">
+        <Reputation faction="separatists" min="30"/>
+      </Price>
+      <Price storeidentifier="merchantresearch" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.3" />
+      <Price storeidentifier="merchantmine" />
+    </Price>
+    <Deconstruct time="10" />
+    <Sprite texture="Content/Items/Jobgear/headgears.png" sourcerect="203,418,89,46" depth="0.6" origin="0.5,0.5" />
+    <Body radius="30" density="15" />
+    <Wearable slots="Any,Head" armorvalue="20.0" msg="ItemMsgPickUpSelect">
+      <damagemodifier afflictionidentifiers="blunttrauma,lacerations,bitewounds" armorsector="0.0,360.0" damagemultiplier="0.9" />
+      <sprite texture="Content/Items/Jobgear/headgears.png" limb="Head" hidewearablesoftype="Hair" inheritlimbdepth="true" inheritscale="true" ignorelimbscale="true" scale="0.8" sourcerect="203,418,89,90" origin="0.55,0.6" />
+      <SkillModifier skillidentifier="helm" skillvalue="12" />
+      <StatusEffect type="OnWearing" target="Character" HideFace="true" duration="0.1" stackable="false" />
+    </Wearable>
+  </Item>
+  <Item name="" identifier="piratebandana" category="Equipment" cargocontaineridentifier="metalcrate" tags="smallitem,separatists" description="" scale="0.5" impactsoundtag="impact_soft">
+    <Price baseprice="15" sold="false" canbespecial="false">
+      <Price storeidentifier="merchantoutpost" minavailable="1" maxavailable="2" sold="true">
+        <Reputation faction="separatists" min="30"/>
+      </Price>
+      <Price storeidentifier="merchantcity" multiplier="1.2" minavailable="3" maxavailable="5" sold="true">
+        <Reputation faction="separatists" min="30"/>
+      </Price>
+    </Price>
+    <Deconstruct time="10" />
+    <Sprite texture="Content/Items/Jobgear/headgears.png" depth="0.6" sourcerect="336,455,60,42" origin="0.5,0.5" scale="0.5" />
+    <Body width="20" radius="15" density="12" />
+    <Wearable limbtype="Head" slots="Any,Head" msg="ItemMsgPickUpSelect">
+      <sprite texture="Content/Items/Jobgear/headgears.png" limb="Head" inheritlimbdepth="true" inheritscale="true" ignorelimbscale="true" scale="0.8" sourcerect="313,407,100,95" origin="0.55,0.6" />
+      <damagemodifier afflictionidentifiers="blunttrauma,lacerations,gunshotwound,bitewounds" armorsector="0.0,360.0" damagemultiplier="0.8" />
+      <StatusEffect type="OnWearing" target="Character" HideFace="true" duration="0.1" stackable="false" />
+    </Wearable>
+  </Item>
+  <Item name="" identifier="turban" category="Equipment" cargocontaineridentifier="metalcrate" tags="smallitem,clothing" description="" scale="0.5" impactsoundtag="impact_soft">
+    <Price baseprice="15" sold="false" canbespecial="false" />
+    <Deconstruct time="10" />
+    <Sprite texture="Content/Items/Jobgear/headgears.png" depth="0.6" sourcerect="336,455,60,42" origin="0.5,0.5" scale="0.8" />
+    <Body width="10" radius="10" density="12" />
+    <Wearable limbtype="Head" slots="Any,Head" msg="ItemMsgPickUpSelect">
+      <sprite texture="Content/Items/Jobgear/headgears.png" limb="Head" inheritlimbdepth="true" inheritscale="true" ignorelimbscale="true" scale="1.2" rotation="45" sourcerect="313,407,100,95" origin="0.55,0.9" />
+    </Wearable>
+  </Item>
+  <Item name="" fallbacknameidentifier="bodyarmor" identifier="piratebodyarmor" category="Equipment" tags="smallitem,clothing,separatists" scale="0.35" cargocontaineridentifier="metalcrate" description="" impactsoundtag="impact_soft">
+    <Price baseprice="480" sold="false">
+      <Price storeidentifier="merchantoutpost" minavailable="0" maxavailable="2" sold="true">
+        <Reputation faction="separatists" min="30"/>
+      </Price>
+      <Price storeidentifier="merchantcity" multiplier="1.2" minavailable="2" maxavailable="5" sold="true">
+        <Reputation faction="separatists" min="30"/>
+      </Price>
+      <Price storeidentifier="merchantmilitary" multiplier="1.3" minavailable="4" maxavailable="6" sold="true">
+        <Reputation faction="separatists" min="50"/>
+      </Price>
+      <Price storeidentifier="merchantresearch" />
+      <Price storeidentifier="merchantmine" multiplier="0.9" />
+    </Price>
+    <Deconstruct time="40">
+      <Item identifier="ballisticfiber" />
+      <Item identifier="ballisticfiber" />
+    </Deconstruct>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas2.png" sourcerect="320,640,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Map/Pirates/PirateEquip.png" sourcerect="14,45,103,158" depth="0.6" origin="0.5,0.4" />
+    <Body radius="45" height="35" density="30" />
+    <Wearable slots="Any,OuterClothes" msg="ItemMsgPickUpSelect">
+      <damagemodifier afflictiontypes="burn" armorsector="0.0,360.0" damagemultiplier="0.9" />
+      <damagemodifier afflictionidentifiers="blunttrauma,lacerations,gunshotwound,bitewounds" armorsector="0.0,360.0" damagemultiplier="0.3" damagesound="LimbArmor" deflectprojectiles="true" />
+      <damagemodifier afflictionidentifiers="explosiondamage" armorsector="0.0,360.0" damagemultiplier="0.5" damagesound="LimbArmor" deflectprojectiles="true" />
+      <damagemodifier afflictiontypes="bleeding" armorsector="0.0,360.0" damagemultiplier="0.15" damagesound="LimbArmor" deflectprojectiles="true" />
+      <SkillModifier skillidentifier="weapons" skillvalue="5" />
+      <sprite name="Pirate Armor Wearable" texture="Content/Map/Pirates/PirateEquip.png" limb="Torso" hidelimb="false" inherittexturescale="true" inheritorigin="true" ignorelimbscale="true" scale="0.7" inheritsourcerect="false" sourcerect="14,45,103,158" />
+    </Wearable>
+  </Item>
+  <Item name="" fallbacknameidentifier="ballistichelmet1" identifier="piratehelmet" aliases="ballistichelmet" category="Equipment" tags="smallitem,separatists" cargocontaineridentifier="metalcrate" description="" impactsoundtag="impact_metal_heavy" scale="0.4">
+    <Price baseprice="225" sold="false">
+      <Price storeidentifier="merchantoutpost" minavailable="1" maxavailable="2" sold="true">
+        <Reputation faction="separatists" min="30"/>
+      </Price>
+      <Price storeidentifier="merchantcity" multiplier="1.2" minavailable="1" maxavailable="2" sold="true">
+        <Reputation faction="separatists" min="30"/>
+      </Price>
+      <Price storeidentifier="merchantmilitary" multiplier="1.3" minavailable="1" maxavailable="2" sold="true">
+        <Reputation faction="separatists" min="30"/>
+      </Price>
+      <Price storeidentifier="merchantresearch" />
+      <Price storeidentifier="merchantmine" multiplier="0.9" />
+    </Price>
+    <Deconstruct time="10">
+      <Item identifier="ballisticfiber" />
+    </Deconstruct>
+    <Sprite name="Pirate Helmet" texture="Content/Items/Jobgear/headgears.png" sourcerect="424,206,88,95" depth="0.6" origin="0.5,0.5" />
+    <Body radius="30" density="30" />
+    <Wearable slots="Any,Head" armorvalue="20.0" msg="ItemMsgPickUpSelect">
+      <damagemodifier afflictionidentifiers="lacerations,gunshotwound" armorsector="0.0,360.0" damagemultiplier="0.2" damagesound="LimbArmor" deflectprojectiles="true" />
+      <damagemodifier afflictionidentifiers="bitewounds, blunttrauma" armorsector="0.0,360.0" damagemultiplier="0.3" damagesound="LimbArmor" deflectprojectiles="true" />
+      <damagemodifier afflictiontypes="bleeding" armorsector="0.0,360.0" damagemultiplier="0.1" damagesound="LimbArmor" deflectprojectiles="true" />
+      <damagemodifier afflictionidentifiers="concussion" armorsector="0.0,360.0" damagemultiplier="0.0" damagesound="" deflectprojectiles="true" />
+      <SkillModifier skillidentifier="weapons" skillvalue="5" />
+      <sprite name="Pirate Helmet 1 Wearable" texture="Content/Items/Jobgear/headgears.png" limb="Head" inheritlimbdepth="true" inheritscale="true" ignorelimbscale="true" scale="0.7" hidewearablesoftype="Hair" sourcerect="322,207,93,99" origin="0.6,0.5" />
+    </Wearable>
+  </Item>
+  <Item name="" nameidentifier="pirateclothes" identifier="separatistcommoner2" aliases="pirateclothesnovice" category="Equipment" cargocontaineridentifier="metalcrate" tags="smallitem,clothing,separatists" scale="0.5" impactsoundtag="impact_soft">
+    <Price baseprice="150" sold="false">
+      <Price storeidentifier="merchantoutpost" minavailable="1" maxavailable="2" sold="true">
+        <Reputation faction="separatists" min="30"/>
+      </Price>
+      <Price storeidentifier="merchantcity" multiplier="1.2" minavailable="1" maxavailable="2" sold="true">
+        <Reputation faction="separatists" min="30"/>
+      </Price>
+      <Price storeidentifier="merchantresearch" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.3" />
+      <Price storeidentifier="merchantmine" multiplier="0.9" />
+    </Price>
+    <Deconstruct time="10">
+      <Item identifier="organicfiber" />
+    </Deconstruct>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas2.png" sheetindex="2,10" sheetelementsize="64,64" />
+    <Sprite name="pirate" texture="Content/Items/Jobgear/MiscJobGear.png" sourcerect="898,222,120,66" depth="0.6" origin="0.5,0.5" />
+    <Body width="100" height="50" density="15" friction="0.8" restitution="0.01" />
+    <Wearable slots="Any,InnerClothes" msg="ItemMsgPickUpSelect">
+      <sprite name="Pirate Uniform 1 Torso" texture="pirate_1.png" limb="Torso" hidelimb="false" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 1 Right Hand" texture="pirate_1.png" limb="RightHand" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 1 Left Hand" texture="pirate_1.png" limb="LeftHand" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 1 Right Lower Arm" texture="pirate_1.png" limb="RightArm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 1 Left Lower Arm" texture="pirate_1.png" limb="LeftArm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 1 Right Upper Arm" texture="pirate_1.png" limb="RightForearm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 1 Left Upper Arm" texture="pirate_1.png" limb="LeftForearm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 1 Waist" texture="pirate_1.png" limb="Waist" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 1 Right Thigh" texture="pirate_1.png" limb="RightThigh" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 1 Left Thigh" texture="pirate_1.png" limb="LeftThigh" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 1 Right Leg" texture="pirate_1.png" limb="RightLeg" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 1 Left Leg" texture="pirate_1.png" limb="LeftLeg" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 1 Left Shoe" texture="pirate_1.png" limb="LeftFoot" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 1 Right Shoe" texture="pirate_1.png" limb="RightFoot" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <damagemodifier armorsector="0.0,360.0" afflictionidentifiers="lacerations,gunshotwound" damagemultiplier="0.95" />
+    </Wearable>
+  </Item>
+  <Item name="" identifier="separatistcommoner3" aliases="pirateclotheshard" category="Equipment" cargocontaineridentifier="metalcrate" tags="smallitem,clothing,separatists" scale="0.5" impactsoundtag="impact_soft">
+    <Price baseprice="300" sold="false">
+      <Price storeidentifier="merchantoutpost" minavailable="1" maxavailable="2" sold="true">
+        <Reputation faction="separatists" min="30"/>
+      </Price>
+      <Price storeidentifier="merchantcity" multiplier="1.2" minavailable="1" maxavailable="2" sold="true">
+        <Reputation faction="separatists" min="30"/>
+      </Price>
+      <Price storeidentifier="merchantresearch" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.3" />
+      <Price storeidentifier="merchantmine" multiplier="0.9" />
+    </Price>
+    <Deconstruct time="10">
+      <Item identifier="organicfiber" />
+    </Deconstruct>
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas2.png" sheetindex="0,10" sheetelementsize="64,64" />
+    <Sprite name="pirate" texture="Content/Items/Jobgear/MiscJobGear.png" sourcerect="904,294,118,59" depth="0.6" origin="0.5,0.5" />
+    <Body width="100" height="50" density="15" friction="0.8" restitution="0.01" />
+    <Wearable slots="Any,InnerClothes" msg="ItemMsgPickUpSelect">
+      <sprite name="Pirate Uniform 3 Torso" texture="pirate_3.png" limb="Torso" hidelimb="false" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 3 Right Hand" texture="pirate_3.png" limb="RightHand" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 3 Left Hand" texture="pirate_3.png" limb="LeftHand" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 3 Right Lower Arm" texture="pirate_3.png" limb="RightArm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 3 Left Lower Arm" texture="pirate_3.png" limb="LeftArm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 3 Right Upper Arm" texture="pirate_3.png" limb="RightForearm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 3 Left Upper Arm" texture="pirate_3.png" limb="LeftForearm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 3 Waist" texture="pirate_3.png" limb="Waist" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 3 Right Thigh" texture="pirate_3.png" limb="RightThigh" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 3 Left Thigh" texture="pirate_3.png" limb="LeftThigh" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 3 Right Leg" texture="pirate_3.png" limb="RightLeg" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 3 Left Leg" texture="pirate_3.png" limb="LeftLeg" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 3 Left Shoe" texture="pirate_3.png" limb="LeftFoot" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <sprite name="Pirate Uniform 3 Right Shoe" texture="pirate_3.png" limb="RightFoot" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+      <damagemodifier armorsector="0.0,360.0" afflictionidentifiers="blunttrauma" damagemultiplier="0.95" />
+      <damagemodifier armorsector="0.0,360.0" afflictionidentifiers="gunshotwound,lacerations" damagemultiplier="0.85" />
+    </Wearable>
+  </Item>
+
+
+  <Item name="" identifier="40mmnuke" category="Weapon" maxstacksize="8" interactthroughwalls="true" cargocontaineridentifier="metalcrate" tags="smallitem,grenade,separatists" Scale="0.5" impactsoundtag="impact_metal_light">
+    <PreferredContainer primary="grenadelauncher" amount="1" spawnprobability="0"/>
+    <PreferredContainer secondary="wreckarmcab,abandonedarmcab,piratearmcab" spawnprobability="0"/>
+    <PreferredContainer primary="secarmcab" secondary="armcab"/>
+    <Price baseprice="400" sold="false">
+      <Price storeidentifier="merchantoutpost" minavailable="0" maxavailable="1" sold="true">
+        <Reputation faction="separatists" min="70"/>
+      </Price>
+      <Price storeidentifier="merchantcity" minavailable="1" maxavailable="2" sold="true">
+        <Reputation faction="separatists" min="70"/>
+      </Price>
+      <Price storeidentifier="merchantmilitary" minavailable="2" maxavailable="5" sold="true">
+        <Reputation faction="separatists" min="70"/>
+      </Price>
+    </Price>
+    <Deconstruct time="5">
+      <Item identifier="iron" />
+      <Item identifier="sodium" />
+    </Deconstruct>    
+    <InventoryIcon texture="Content/Map/Outposts/Art/FactionItems.png" sourcerect="114,110,51,51" origin="0.5,0.5" />
+    <Sprite texture="Content/Map/Outposts/Art/FactionItems.png" sourcerect="2,144,39,17" depth="0.55" origin="0.5,0.5" />
+    <Body width="38" height="15" density="30" />
+    <Pickable slots="Any" msg="ItemMsgPickUpSelect"/>
+    <Projectile characterusable="false" launchimpulse="20.0" sticktocharacters="false">     
+      <Attack structuredamage="40" penetration="1" severlimbsprobability="5" >
+        <!-- Extra damage on larger creatures (smaller will die anyway) -->
+        <Affliction identifier="explosiondamage" strength="100" />
+        <Affliction identifier="burn" strength="100" />
+        <Affliction identifier="bleeding" strength="50" />
+        <Affliction identifier="stun" strength="5" />
+      </Attack>
+      <StatusEffect type="OnImpact" target="This" Condition="-100.0" disabledeltatime="true">
+        <SteamTimeLineEvent title="Nuke detonated" description="A 40mm Mini Nuke detonated!" icon="steam_explosion"/>
+        <sound file="Content/Items/Weapons/ExplosionLarge1.ogg" volume="1" range="20000" />
+        <sound file="Content/Items/Weapons/ExplosionLarge2.ogg" volume="1" range="20000" />
+        <Explosion range="500.0" ballastfloradamage="300" structuredamage="300" itemdamage="1000" force="20" severlimbsprobability="0.75" debris="true" decal="explosion" decalsize="0.75" penetration="0.5"
+                   camerashake="200" camerashakerange="10000"
+                   flashrange="1000" flashduration="2.0"
+                   screencolor="255,255,255,255" screencolorrange="5000" screencolorduration="3.0">
+          <Affliction identifier="explosiondamage" strength="200" />
+          <Affliction identifier="burn" strength="200" />
+          <Affliction identifier="bleeding" strength="40" probability="0.05" dividebylimbcount="false"/>
+          <Affliction identifier="stun" strength="10" />
+          <Affliction identifier="radiationsickness" strength="30" />
+        </Explosion>
+        <Explosion range="1000" force="0.0" smoke="false" sparks="false" empstrength="1" applyfireeffects="false" ignorecover="true">
+          <Affliction identifier="emp" strength="20" multiplybymaxvitality="true" />
+        </Explosion>
+        <ParticleEmitter particle="underwaterexplosion" anglemin="0" anglemax="360" particleamount="3" velocitymin="0" velocitymax="0" scalemin="5" scalemax="6" />
+      </StatusEffect>
+      <StatusEffect type="OnActive" target="This">
+        <ParticleEmitter particle="bubbles" anglemin="0" anglemax="360" particleamount="5" velocitymin="0" velocitymax="50" scalemin="0.5" scalemax="1" />
+      </StatusEffect>
+      <StatusEffect type="OnImpact" target="This">
+        <sound file="Content/Items/Weapons/ExplosionDebris4.ogg" range="3000" />
+        <sound file="Content/Items/Weapons/ExplosionDebris5.ogg" range="3000" />
+      </StatusEffect>
+      <StatusEffect type="OnImpact" target="Contained" allowwhenbroken="true">
+        <Use />
+      </StatusEffect>
+      <!-- Remove the item after exploding -->
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
+    </Projectile>
+  </Item>
+
+  <Item name="" identifier="molotovcoctail" category="Equipment" maxstacksize="12" cargocontaineridentifier="metalcrate" impacttolerance="5" Scale="0.5" tags="smallitem,light,provocative,separatists" impactsoundtag="impact_metal_light" isshootable="true">
+    <PreferredContainer primary="secarmcab" secondary="armcab"/>
+    <PreferredContainer secondary="wreckarmcab,abandonedarmcab,piratearmcab" spawnprobability="0"/>
+    <Price baseprice="90" minavailable="6" sold="false">
+      <Price storeidentifier="merchantoutpost" minavailable="2" maxavailable="4" sold="true">
+        <Reputation faction="separatists" min="50"/>
+      </Price>
+      <Price storeidentifier="merchantcity" minavailable="3" maxavailable="6" sold="true">
+        <Reputation faction="separatists" min="50"/>
+      </Price>
+      <Price storeidentifier="merchantmilitary" minavailable="5" maxavailable="10" sold="true">
+        <Reputation faction="separatists" min="50"/>
+      </Price>
+    </Price>
+    <InventoryIcon texture="Content/Map/Outposts/Art/FactionItems.png" sourcerect="271,2,65,68" origin="0.5,0.5" />
+    <sprite texture="Content/Map/Outposts/Art/FactionItems.png" sourcerect="308,165,40,64" depth="0.55" origin="0.5,0.5" />
+    <Body width="40" height="60" density="12" />
+    <Throwable slots="Any,RightHand,LeftHand" holdpos="0,0" handle1="0,0" throwforce="4.0" aimpos="35,-10" msg="ItemMsgPickUpSelect" />
+    <LightComponent LightColor="255,100,50,255" Flicker="0.5" range="600" IsOn="false">
+      <StatusEffect type="OnUse" targettype="This" IsOn="true">
+        <Conditional IsOn="eq False" targetitemcomponent="LightComponent" />
+        <sound file="Content/Items/Tools/FlareIgnite.ogg" range="800.0" />
+      </StatusEffect>
+      <StatusEffect type="OnActive" targettype="This" Condition="-0.25">
+        <Conditional Condition="gt 1" />
+      </StatusEffect>
+      <StatusEffect type="OnActive" targettype="This" conditionalcomparison="And">
+        <Conditional PhysicsBodyActive="eq true" />
+        <Conditional Condition="gt 1" />
+        <ParticleEmitter particle="flame" particlespersecond="15" velocitymin="0" scalemin="0.2" scalemax="0.3" anglemin="0" anglemax="360" lifetimemultiplier="0.5" />
+      </StatusEffect>
+      <StatusEffect type="InWater" targettype="This" IsOn="false" />
+      <StatusEffect type="OnBroken" targettype="This" IsOn="false" />
+      <StatusEffect type="OnImpact" target="This">
+        <sound file="Content/Sounds/Damage/GlassImpact2.ogg" selectionmode="All" range="2000" />
+        <ParticleEmitter particle="iceshards" anglemin="0" anglemax="360" particleamount="30" velocitymin="0" velocitymax="500" scalemin="0.5" scalemax="1" />
+        <Remove />
+      </StatusEffect>
+      <StatusEffect type="OnImpact" target="This" Condition="-100.0" conditionalcomparison="And">
+        <Conditional IsOn="eq True"/>
+        <Conditional Condition="gt 1" />
+        <sound file="Content/Sounds/Damage/GlassImpact2.ogg" selectionmode="All" range="2000" />
+        <sound file="Content/Items/Weapons/ExplosionDebris3.ogg" selectionmode="All" range="2000" />
+        <ParticleEmitter particle="iceshards" anglemin="0" anglemax="360" particleamount="20" velocitymin="500" velocitymax="800" scalemin="0.5" scalemax="0.5" />
+        <Explosion range="500.0" ballastfloradamage="200" structuredamage="0" itemdamage="100" force="2.0" severlimbsprobability="0" debris="true" underwaterbubble="false">
+          <Affliction identifier="burn" strength="50" />
+          <Affliction identifier="stun" strength="0.5" />
+        </Explosion>
+        <Fire size="400" />
+        <Remove />
+      </StatusEffect>
+    </LightComponent>
+  </Item>
+
+  <Item name="" identifier="dirtybomb" category="Weapon" Tags="smallitem,explosive,separatists" allowasextracargo="true" maxstacksize="8" Scale="0.5" impactsoundtag="impact_soft">
+    <PreferredContainer primary="secarmcab" secondary="armcab"/>
+    <Price baseprice="240" sold="false">
+      <Price storeidentifier="merchantoutpost" multiplier="1.25" minavailable="0" maxavailable="2" sold="true">
+        <Reputation faction="separatists" min="50"/>
+      </Price>
+      <Price storeidentifier="merchantcity" multiplier="1.25" minavailable="1" maxavailable="4" sold="true">
+        <Reputation faction="separatists" min="50"/>
+      </Price>
+      <Price storeidentifier="merchantmilitary" multiplier="0.9" minavailable="4" maxavailable="8" sold="true">
+        <Reputation faction="separatists" min="50"/>
+      </Price>
+      <Price storeidentifier="merchantresearch" multiplier="1.25" />
+      <Price storeidentifier="merchantmine" />
+    </Price>
+    <!-- fabrication recipe disabled for now because there's no way to get the recipe -->
+    <!--
+    <Fabricate suitablefabricators="fabricator" requiredtime="20" requiresrecipe="true">
+      <RequiredSkill identifier="weapons" level="30" />
+      <RequiredItem identifier="uex" />
+      <RequiredItem identifier="uranium" />
+      <RequiredItem identifier="depletedfuel" />
+    </Fabricate>    
+    -->
+    <InventoryIcon texture="Content/Items/InventoryIconAtlas2.png" sourcerect="448,640,64,64" origin="0.5,0.5" />
+    <Sprite texture="Content/Items/JobGear/TalentGear.png" depth="0.8" sourcerect="202,1,47,32" origin="0.5,0.5" />
+    <Body width="45" height="30" density="20" />
+    <Throwable characterusable="false" slots="Any,RightHand,LeftHand" canbecombined="true" removeoncombined="true" throwforce="3.5" aimpos="35,-10" msg="ItemMsgPickUpSelect">
+      <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true" />
+      <StatusEffect type="OnBroken" target="This">
+        <sound file="Content/Items/Weapons/ExplosionMedium1.ogg" range="5000" />
+        <sound file="Content/Items/Weapons/ExplosionMedium2.ogg" range="5000" />
+        <sound file="Content/Items/Weapons/ExplosionMedium3.ogg" range="5000" />
+        <ParticleEmitter particle="fixfoam" anglemax="360" velocitymin="4000" velocitymax="4000" particlespersecond="64" colormultiplier="50,150,50" />
+        <Explosion range="250.0" ballastfloradamage="50" structuredamage="90" itemdamage="250" force="5" severlimbsprobability="0.25" debris="true" decal="explosion" decalsize="0.25">
+          <Affliction identifier="explosiondamage" strength="50" />
+          <Affliction identifier="burn" strength="5" probability="0.2" dividebylimbcount="false"/>
+          <Affliction identifier="bleeding" strength="20" probability="0.05" dividebylimbcount="false"/>
+          <Affliction identifier="stun" strength="3" />
+        </Explosion>
+        <Explosion range="1500" force="0.0" smoke="false" sparks="false" empstrength="2.5" applyfireeffects="false" ignorecover="true">
+          <Affliction identifier="emp" strength="25" multiplybymaxvitality="true" />
+        </Explosion>
+        <SpawnItem identifier="dirtybombafteremitter" spawnposition="This" />
+        <Remove />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="This">
+        <sound file="Content/Items/Weapons/ExplosionDebris5.ogg" range="3500" />
+      </StatusEffect>
+    </Throwable>
+  </Item>
+  <Item name="dirtybombafteremitter" identifier="dirtybombafteremitter" Scale="0.5" tags="" sonarsize="20" hideinmenus="true">
+    <AiTarget sightrange="1000.0" soundrange="1000" sonardisruption="10" static="True" />
+    <Sprite texture="Content/Items/JobGear/TalentGear.png" sourcerect="0,0,2,2" depth="0.55" origin="0.5,0.5" />
+    <ItemComponent>
+      <StatusEffect type="Always" target="This" condition="-25" />
+      <StatusEffect type="Always" target="NearbyCharacters" range="1600" interval="1" disabledeltatime="true">
+        <Affliction identifier="radiationsickness" strength="12" />
+      </StatusEffect>
+      <StatusEffect type="Always" target="NearbyCharacters" range="1200" interval="1" disabledeltatime="true">
+        <Affliction identifier="radiationsickness" strength="32" />
+      </StatusEffect>
+      <StatusEffect type="Always" target="NearbyCharacters" range="800" interval="1" disabledeltatime="true">
+        <Affliction identifier="radiationsickness" strength="48" />
+      </StatusEffect>
+      <StatusEffect type="OnBroken" target="This">
+        <Remove />
+      </StatusEffect>
+    </ItemComponent>
+  </Item>
+
+  <Item name="" identifier="tormsdalereport" category="Misc" hideinmenus="true" Tags="smallitem" cargocontaineridentifier="metalcrate" scale="0.5" impactsoundtag="impact_soft">
+    <PreferredContainer primary="crewcab" secondary="locker"/>
+    <InventoryIcon texture="Content/Map/Outposts/Art/FactionItems.png" sourcerect="409,51,62,61" origin="0.5,0.5" />
+    <sprite texture="Content/Map/Outposts/Art/FactionItems.png" sourcerect="401,120,49,68" depth="0.8" origin="0.5,0.5" />
+    <Body width="45" height="65" density="8" />
+    <Holdable slots="Any,RightHand,LeftHand" holdangle="30" handle1="-10,0" msg="ItemMsgPickUpSelect" />
+  </Item>
+  
+</Items>

--- a/Barotrauma/Content/Map/Pirates/PirateItems.xml
+++ b/Barotrauma/Content/Map/Pirates/PirateItems.xml
@@ -74,7 +74,7 @@
     <Body radius="30" density="15" />
     <Wearable slots="Any,Head" armorvalue="20.0" msg="ItemMsgPickUpSelect">
       <damagemodifier afflictionidentifiers="blunttrauma,lacerations,bitewounds" armorsector="0.0,360.0" damagemultiplier="0.9" />
-      <sprite texture="Content/Items/Jobgear/headgears.png" limb="Head" hidewearablesoftype="Hair" inheritlimbdepth="true" inheritscale="true" ignorelimbscale="true" scale="0.8" sourcerect="203,418,89,46" origin="0.55,0.6" />
+      <sprite texture="Content/Items/Jobgear/headgears.png" limb="Head" hidewearablesoftype="Hair" inheritlimbdepth="true" inheritscale="true" ignorelimbscale="true" scale="0.8" sourcerect="203,418,89,46" origin="0.55,1.15" />
       <SkillModifier skillidentifier="helm" skillvalue="12" />
       <StatusEffect type="OnWearing" target="Character" HideFace="true" duration="0.1" stackable="false" />
     </Wearable>

--- a/Barotrauma/Content/Map/Pirates/PirateItems.xml
+++ b/Barotrauma/Content/Map/Pirates/PirateItems.xml
@@ -57,8 +57,8 @@
       <damagemodifier armorsector="0.0,360.0" afflictionidentifiers="lacerations,gunshotwound" damagemultiplier="0.9" />
     </Wearable>
   </Item>
-  <Item name="" identifier="piratecaptainhat" category="Equipment" tags="smallitem,clothing,separatists" impactsoundtag="impact_metal_heavy" scale="0.4" cargocontaineridentifier="metalcrate">
-    <Price baseprice="175" sold="false">
+  <Item nameidentifier="piratecaptainhat" identifier="piratecaptainhat2" category="Equipment" tags="smallitem,clothing,separatists" impactsoundtag="impact_metal_heavy" scale="0.4" cargocontaineridentifier="metalcrate">
+    <Price baseprice="160" sold="false">
       <Price storeidentifier="merchantoutpost" minavailable="1" maxavailable="2" sold="true">
         <Reputation faction="separatists" min="30"/>
       </Price>
@@ -71,6 +71,28 @@
     </Price>
     <Deconstruct time="10" />
     <Sprite texture="Content/Items/Jobgear/headgears.png" sourcerect="203,418,89,46" depth="0.6" origin="0.5,0.5" />
+    <Body radius="30" density="15" />
+    <Wearable slots="Any,Head" armorvalue="20.0" msg="ItemMsgPickUpSelect">
+      <damagemodifier afflictionidentifiers="blunttrauma,lacerations,bitewounds" armorsector="0.0,360.0" damagemultiplier="0.9" />
+      <sprite texture="Content/Items/Jobgear/headgears.png" limb="Head" hidewearablesoftype="Hair" inheritlimbdepth="true" inheritscale="true" ignorelimbscale="true" scale="0.8" sourcerect="203,418,89,46" origin="0.55,0.6" />
+      <SkillModifier skillidentifier="helm" skillvalue="12" />
+      <StatusEffect type="OnWearing" target="Character" HideFace="true" duration="0.1" stackable="false" />
+    </Wearable>
+  </Item>
+  <Item name="" identifier="piratecaptainhat" category="Equipment" tags="smallitem,clothing,separatists" impactsoundtag="impact_metal_heavy" scale="0.4" cargocontaineridentifier="metalcrate">
+    <Price baseprice="175" sold="false">
+      <Price storeidentifier="merchantoutpost" minavailable="1" maxavailable="1" sold="true">
+        <Reputation faction="separatists" min="30"/>
+      </Price>
+      <Price storeidentifier="merchantcity" minavailable="1" maxavailable="3" sold="true">
+        <Reputation faction="separatists" min="30"/>
+      </Price>
+      <Price storeidentifier="merchantresearch" />
+      <Price storeidentifier="merchantmilitary" multiplier="1.3" />
+      <Price storeidentifier="merchantmine" />
+    </Price>
+    <Deconstruct time="10" />
+    <Sprite texture="Content/Items/Jobgear/headgears.png" sourcerect="203,418,89,90" depth="0.6" origin="0.5,0.5" />
     <Body radius="30" density="15" />
     <Wearable slots="Any,Head" armorvalue="20.0" msg="ItemMsgPickUpSelect">
       <damagemodifier afflictionidentifiers="blunttrauma,lacerations,bitewounds" armorsector="0.0,360.0" damagemultiplier="0.9" />

--- a/Barotrauma/Content/NPCPrefabs/EscortMissionNpcs.xml
+++ b/Barotrauma/Content/NPCPrefabs/EscortMissionNpcs.xml
@@ -1,0 +1,213 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<npcsets>
+
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+  <!--                          Escort Mission NPCs                              -->
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+  
+  <npcset identifier="escortnpcs1">
+    <npc identifier="prisoner" job="prisoner" moduleflags="none" behavior="Patrol">
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="prisonerclothes" equip="true" />
+        <Item identifier="handcuffs" equip="true" />
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="prisonerclothes" equip="true" />
+        <Item identifier="handcuffs" equip="true" />
+        <Item identifier="divingknife" equip="false" />
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="prisonerclothes" equip="true" />
+        <Item identifier="handcuffs" equip="true" />
+        <Item identifier="ethanol" equip="false" />
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="prisonerclothes" equip="true" />
+        <Item identifier="handcuffs" equip="true" />
+        <Item identifier="antidama1" equip="false" />
+      </ItemSet>
+    </npc>
+    <npc identifier="commoner" job="commoner" behavior="Patrol">
+      <ItemSet>
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="commonerclothes1" equip="true" />
+        <Item identifier="screwdriver" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet>
+        <Item identifier="commonerclothes1" equip="true" />
+        <Item identifier="baseballcap" equip="true" />
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="wrench" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet>
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="commonerclothes2" equip="true" />
+        <Item identifier="crowbar" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="commonerclothes2" equip="true" />
+        <Item identifier="divingknife" equip="false" />
+        <Item identifier="wrench" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet>
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="commonerclothes3" equip="true" />
+        <Item identifier="crowbar" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet>
+        <Item identifier="commonerclothes3" equip="true" />
+        <Item identifier="baseballcap" equip="true" />
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="screwdriver" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet>
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="commonerclothes4" equip="true" />
+        <Item identifier="divingknife" equip="false" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+    <npc identifier="commonerseparatist" job="commoner" behavior="Patrol">
+      <ItemSet>
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="separatistcommoner2" equip="true" />
+        <Item identifier="piratebandana" equip="true" />
+        <Item identifier="screwdriver" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet>
+        <Item identifier="separatistcommoner1" equip="true" />
+        <Item identifier="piratebandana" equip="true" />
+        <Item identifier="baseballcap" equip="true" />
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="wrench" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet>
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="separatistcommoner3" equip="true" outfit="true" />
+        <Item identifier="crowbar" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="piratecaptainhat" equip="true" />
+        <Item identifier="separatistcommoner1" equip="true" />
+        <Item identifier="divingknife" equip="false" />
+        <Item identifier="wrench" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet>
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="piratebodyarmor" equip="true" />
+        <Item identifier="separatistcommoner1" equip="true" />
+        <Item identifier="piratebandana" equip="true" />
+        <Item identifier="crowbar" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+    <npc identifier="vip" moduleflags="none" job="vip" behavior="StayInHull">
+      <ItemSet>
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="vipclothes1" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet>
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="vipclothes2" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet>
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="vipclothes3" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+    <npc identifier="securitynpc" job="vipsecurityofficer" spawnpointtags="security" healthmultiplier="1" behavior="StayInHull">
+      <ItemSet>
+        <Item identifier="securitypatrolclothes" equip="true" />
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="stunbaton">
+          <Item identifier="batterycell" />
+        </Item>
+        <Item identifier="handcuffs" />
+        <Item identifier="smg">
+          <Item identifier="smgmagazine" />
+        </Item>
+        <Item identifier="smgmagazine" />
+        <Item identifier="smgmagazine" />
+        <Item identifier="divingknife" />
+        <Item identifier="bodyarmor" equip="true" />
+        <Item identifier="ballistichelmet1" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet>
+        <Item identifier="securitypatrolclothes" equip="true" />
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="stunbaton">
+          <Item identifier="batterycell" />
+        </Item>
+        <Item identifier="handcuffs" />
+        <Item identifier="revolver" equip="false">
+          <Item identifier="revolverround" />
+          <Item identifier="revolverround" />
+          <Item identifier="revolverround" />
+          <Item identifier="revolverround" />
+          <Item identifier="revolverround" />
+          <Item identifier="revolverround" />
+        </Item>
+        <Item identifier="divingknife" />
+        <Item identifier="antibleeding1" />
+        <Item identifier="bodyarmor" equip="true" />
+        <Item identifier="ballistichelmet2" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+  </npcset>
+
+</npcsets>

--- a/Barotrauma/Content/NPCPrefabs/EscortMissionNpcs.xml
+++ b/Barotrauma/Content/NPCPrefabs/EscortMissionNpcs.xml
@@ -130,6 +130,16 @@
           <Item identifier="oxygentank" />
         </Item>
       </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="piratecaptainhat2" equip="true" />
+        <Item identifier="separatistcommoner1" equip="true" />
+        <Item identifier="divingknife" equip="false" />
+        <Item identifier="wrench" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
       <ItemSet>
         <Item identifier="idcard" equip="true" />
         <Item identifier="piratebodyarmor" equip="true" />

--- a/Barotrauma/Content/NPCPrefabs/OutpostNpcs.xml
+++ b/Barotrauma/Content/NPCPrefabs/OutpostNpcs.xml
@@ -1,0 +1,1552 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<npcsets>
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+  <!--                               Outpost NPCs                                -->
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+  <npcset identifier="outpostnpcs1">
+    <npc identifier="captain" job="captain" commonness="1" spawnpointtags="admin" behavior="Passive" preferredoutpostmoduletypes="admin,adminmodule">
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true" tags="id_outpostsecurity"/>
+        <Item identifier="captainscap1" equip="true"/>
+        <Item identifier="captainsuniform1" equip="true"/>
+        <Item identifier="revolver" equip="false">
+          <Item identifier="revolverround" amount="3"/>
+        </Item>
+        <Item identifier="captainspipe" equip="false"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="captainscap2" equip="true"/>
+        <Item identifier="captainsuniform2" equip="true"/>
+        <Item identifier="revolver" equip="false">
+          <Item identifier="revolverround"/>
+        </Item>
+        <Item identifier="steroids"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <!--<ItemSet commonness="0.3">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="clownmask" equip="true"/>
+        <Item identifier="clowncostume" equip="true"/>
+        <Item identifier="revolver" equip="false">
+          <Item identifier="revolverround"/>
+        </Item>
+        <Item identifier="huskeggs"/>
+      </ItemSet>-->
+    </npc>
+
+    <npc identifier="outpostmanagercoalition" job="outpostmanager" tags="outpostmanager" spawnpointtags="admin" behavior="StayInHull" preferredoutpostmoduletypes="admin,adminmodule">
+      <ItemSet commonness="1">
+        <Item identifier="administratorclothes" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="revolver" equip="false">
+          <Item identifier="revolverround" amount="6"/>
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="outpostmanagerseparatists" job="outpostmanager" tags="outpostmanager" spawnpointtags="admin" behavior="StayInHull" preferredoutpostmoduletypes="admin,adminmodule">
+      <ItemSet commonness="1">
+        <Item identifier="piratecaptainhat" equip="true" />
+        <Item identifier="separatistcommoner3" equip="true" outfit="true" />
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="revolver" equip="false">
+          <Item identifier="revolverround" amount="6"/>
+        </Item>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <!-- for backwards compatibility (some mods that override location types still use this - if it doesn't exist, you can't get any missions)
+          not used by the vanilla game -->
+    <npc identifier="outpostmanager" job="outpostmanager" tags="outpostmanager" spawnpointtags="admin" behavior="Passive" preferredoutpostmoduletypes="admin,adminmodule">
+      <ItemSet commonness="1">
+        <Item identifier="administratorclothes" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="revolver" equip="false">
+          <Item identifier="revolverround" amount="6"/>
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="hrmanager" job="watchman" spawnpointtags="hr" healthmultiplier="1.1" campaigninteractiontype="Crew" behavior="StayInHull">
+      <ItemSet commonness="1">
+        <Item identifier="quartermasterclothes" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="wrench"/>
+        <Item identifier="screwdriver"/>
+        <Item identifier="revolver" equip="false">
+          <Item identifier="revolverround" amount="6"/>
+        </Item>
+        <Item identifier="weldingtool" equip="false">
+          <Item identifier="weldingfueltank" />
+        </Item>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="reactoroperator" job="engineer" commonness="1" spawnpointtags="engineering" healthmultiplier="1.1" behavior="Passive" preferredoutpostmoduletypes="engineeringmodule">
+      <ItemSet commonness="1">
+        <Item identifier="orangejumpsuit2" equip="true"/>
+        <Item identifier="baseballcap" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="wrench"/>
+        <Item identifier="screwdriver"/>
+        <Item identifier="crowbar"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="subupgradenpc" job="mechanic" commonness="1" spawnpointtags="engineering" healthmultiplier="1.1" campaigninteractiontype="Upgrade" behavior="StayInHull">
+      <ItemSet commonness="1">
+        <Item identifier="toolbelt" equip="true">
+          <Item identifier="weldingfueltank"/>
+          <Item identifier="aluminium"/>
+          <Item identifier="weldingtool">
+            <Item identifier="weldingfueltank" />
+          </Item>
+        </Item>
+        <Item identifier="commonerclothes5" equip="true" />
+        <Item identifier="headset" equip="true" />
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="wrench"/>
+        <Item identifier="screwdriver"/>
+        <Item identifier="revolver" equip="false">
+          <Item identifier="revolverround" amount="6"/>
+        </Item>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="subsalesnpc" job="mechanic" commonness="1" spawnpointtags="engineering" healthmultiplier="1.1" campaigninteractiontype="PurchaseSub" behavior="StayInHull">
+      <ItemSet commonness="1">
+        <Item identifier="toolbelt" equip="true">
+          <Item identifier="weldingfueltank"/>
+          <Item identifier="aluminium"/>
+          <Item identifier="weldingtool">
+            <Item identifier="weldingfueltank" />
+          </Item>
+        </Item>
+        <Item identifier="wrench"/>
+        <Item identifier="screwdriver"/>
+        <Item identifier="bluejumpsuit1" equip="true" />
+        <Item identifier="headset" equip="true" />
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="merchantoutpost" job="watchman" spawnpointtags="shop" healthmultiplier="1.1" campaigninteractiontype="Store" behavior="StayInHull">
+      <ItemSet commonness="1">
+        <Item identifier="baseballcap" equip="true"/>
+        <Item identifier="crewchiefclothes" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="wrench"/>
+        <Item identifier="screwdriver"/>
+        <Item identifier="revolver">
+          <Item identifier="revolverround" amount="6"/>
+        </Item>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="merchantcity" job="watchman" spawnpointtags="shop" healthmultiplier="1.1" campaigninteractiontype="Store" behavior="StayInHull">
+      <ItemSet commonness="1">
+        <Item identifier="baseballcap" equip="true"/>
+        <Item identifier="crewchiefclothes" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="wrench"/>
+        <Item identifier="screwdriver"/>
+        <Item identifier="revolver">
+          <Item identifier="revolverround" amount="6"/>
+        </Item>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="merchantmine" job="watchman" spawnpointtags="shop" healthmultiplier="1.1" campaigninteractiontype="Store" behavior="StayInHull">
+      <ItemSet commonness="1">
+        <Item identifier="baseballcap" equip="true"/>
+        <Item identifier="crewchiefclothes" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="wrench"/>
+        <Item identifier="screwdriver"/>
+        <Item identifier="revolver">
+          <Item identifier="revolverround" amount="6"/>
+        </Item>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="merchantresearch" job="watchman" spawnpointtags="shop" healthmultiplier="1.1" campaigninteractiontype="Store" behavior="StayInHull">
+      <ItemSet commonness="1">
+        <Item identifier="baseballcap" equip="true"/>
+        <Item identifier="crewchiefclothes" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="wrench"/>
+        <Item identifier="screwdriver"/>
+        <Item identifier="revolver">
+          <Item identifier="revolverround" amount="6"/>
+        </Item>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="merchantmilitary" job="watchman" spawnpointtags="shop" healthmultiplier="1.1" campaigninteractiontype="Store" behavior="StayInHull">
+      <ItemSet commonness="1">
+        <Item identifier="baseballcap" equip="true"/>
+        <Item identifier="crewchiefclothes" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="wrench"/>
+        <Item identifier="screwdriver"/>
+        <Item identifier="revolver">
+          <Item identifier="revolverround" amount="6"/>
+        </Item>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="merchantarmory" job="watchman" spawnpointtags="armory" healthmultiplier="1.1" campaigninteractiontype="Store" behavior="StayInHull">
+      <ItemSet commonness="1">
+        <Item identifier="baseballcap" equip="true"/>
+        <Item identifier="crewchiefclothes" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="revolver">
+          <Item identifier="revolverround" amount="6"/>
+        </Item>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="merchantmedical" job="watchman" spawnpointtags="medical" healthmultiplier="1.1" campaigninteractiontype="Store" behavior="StayInHull">
+      <ItemSet commonness="1">
+        <Item identifier="medicalofficerclothes" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="antibloodloss1"/>
+        <Item identifier="antibloodloss1"/>
+        <Item identifier="antidama1"/>
+        <Item identifier="antidama1"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="merchantengineering" job="watchman" spawnpointtags="engineering" healthmultiplier="1.1" campaigninteractiontype="Store" behavior="StayInHull">
+      <ItemSet commonness="1">
+        <Item identifier="orangejumpsuit1" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="wrench"/>
+        <Item identifier="screwdriver"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+    
+    <npc identifier="merchantnightclub" spawnpointtags="nightclubcounter" RequireSpawnPointTag="true" campaigninteractiontype="Store" behavior="StayInHull">
+      <ItemSet commonness="1">
+        <Item identifier="vipclothes1" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="shotgun">
+          <Item identifier="shotgunshell" amount="6"/>
+        </Item>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+    
+    <npc identifier="securitynpccoalition" job="outpostsecurityofficer" tags="securitynpc" spawnpointtags="security" healthmultiplier="1.2" behavior="Patrol">
+      <ItemSet>
+        <Item identifier="securitypatrolclothes" equip="true" />
+        <Item identifier="idcard" equip="true" tags="id_outpostsecurity"/>
+        <Item identifier="stunbaton">
+          <Item identifier="batterycell" infinite="true"/>
+        </Item>
+        <Item identifier="handcuffs"/>
+        <Item identifier="smg">
+          <Item identifier="smgmagazine" infinite="true"/>
+        </Item>
+        <Item identifier="divingknife" />
+        <Item identifier="bodyarmor" equip="true"/>
+        <Item identifier="ballistichelmet1" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item> 
+      </ItemSet>
+      <ItemSet>
+        <Item identifier="securitypatrolclothes" equip="true"/>
+        <Item identifier="idcard" equip="true" tags="id_outpostsecurity"/>
+        <Item identifier="stungun">
+          <Item identifier="stungundart" infinite="true"/>
+        </Item>
+        <Item identifier="stunbaton">
+          <Item identifier="batterycell" infinite="true"/>
+        </Item>
+        <Item identifier="divingknife" />
+        <Item identifier="handcuffs"/>
+        <Item identifier="antibleeding1"/>
+        <Item identifier="bodyarmor" equip="true"/>
+        <Item identifier="ballistichelmet3" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item> 
+      </ItemSet>
+      <ItemSet>
+        <Item identifier="securitypatrolclothes" equip="true"/>
+        <Item identifier="idcard" equip="true" tags="id_outpostsecurity"/>
+        <Item identifier="stunbaton">
+          <Item identifier="batterycell" infinite="true"/>
+        </Item>
+        <Item identifier="handcuffs"/>
+        <Item identifier="revolver" equip="false">
+          <Item identifier="revolverround" amount="6" infinite="true"/>
+        </Item>
+        <Item identifier="divingknife" />
+        <Item identifier="antibleeding1"/>
+        <Item identifier="bodyarmor" equip="true"/>
+        <Item identifier="ballistichelmet2" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="armsdealer" job="watchman" spawnpointtags="shop" healthmultiplier="1.1" campaigninteractiontype="Store" behavior="StayInHull">
+      <ItemSet commonness="1">
+        <Item identifier="baseballcap" equip="true"/>
+        <Item identifier="crewchiefclothes" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="wrench"/>
+        <Item identifier="screwdriver"/>
+        <Item identifier="revolver">
+          <Item identifier="revolverround" amount="6"/>
+        </Item>
+        <Item identifier="divingknife" />
+        <Item identifier="antibleeding1"/>
+        <Item identifier="bodyarmor" equip="true"/>
+        <Item identifier="ballistichelmet2" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item> 
+      </ItemSet>
+    </npc>
+
+    <npc identifier="securitynpcseparatists" job="outpostsecurityofficer" tags="securitynpc" spawnpointtags="security" healthmultiplier="1.2" behavior="Patrol">
+      <ItemSet>
+        <Item identifier="securityseparatistsuniform1" equip="true" />
+        <Item identifier="piratebodyarmor" equip="true" />
+        <Item identifier="idcard" equip="true" tags="id_outpostsecurity"/>
+        <Item identifier="stunbaton">
+          <Item identifier="batterycell" infinite="true"/>
+        </Item>
+        <Item identifier="handcuffs"/>
+        <Item identifier="smg">
+          <Item identifier="smgmagazine" infinite="true"/>
+        </Item>
+        <Item identifier="divingknife" />
+        <Item identifier="ballistichelmet1" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet>
+        <Item identifier="securityseparatistsuniform2" equip="true"/>
+        <Item identifier="piratebodyarmor" equip="true" />
+        <Item identifier="idcard" equip="true" tags="id_outpostsecurity"/>
+        <Item identifier="stungun">
+          <Item identifier="stungundart" infinite="true"/>
+        </Item>
+        <Item identifier="stunbaton">
+          <Item identifier="batterycell" infinite="true"/>
+        </Item>
+        <Item identifier="divingknife" />
+        <Item identifier="handcuffs"/>
+        <Item identifier="antibleeding1"/>
+        <Item identifier="piratebandana" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet>
+        <Item identifier="securityseparatistsuniform3" equip="true"/>
+        <Item identifier="piratebodyarmor" equip="true" />
+        <Item identifier="idcard" equip="true" tags="id_outpostsecurity"/>
+        <Item identifier="stunbaton">
+          <Item identifier="batterycell" infinite="true"/>
+        </Item>
+        <Item identifier="handcuffs"/>
+        <Item identifier="revolver" equip="false">
+          <Item identifier="revolverround" amount="6" infinite="true"/>
+        </Item>
+        <Item identifier="divingknife" />
+        <Item identifier="antibleeding1"/>
+        <Item identifier="ballistichelmet2" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="cargomissiongiver" job="mechanic" moduleflags="none" behavior="Passive">
+      <ItemSet>
+        <Item identifier="commonerclothes1" equip="true"/>
+        <Item identifier="ballistichelmet1" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet>
+        <Item identifier="commonerclothes2" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet>
+        <Item identifier="commonerclothes3" equip="true"/>
+        <Item identifier="ballistichelmet1" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet>
+        <Item identifier="commonerclothes3" equip="true"/>
+        <Item identifier="baseballcap" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="salvagemissiongiver" job="medicaldoctor" moduleflags="none" behavior="Passive">
+      <ItemSet commonness="1">
+        <Item identifier="doctorsuniform1" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="doctorsuniform2" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="outpostdoctor" job="medicaldoctor" campaigninteractiontype="MedicalClinic" moduleflags="MedicalModule" behavior="Passive">
+      <ItemSet commonness="1">
+        <Item identifier="medicalofficerclothes" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="antibloodloss1"/>
+        <Item identifier="antibloodloss1"/>
+        <Item identifier="antidama1"/>
+        <Item identifier="antidama1"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="watchman" job="watchman" spawnpointtags="unlockpath" healthmultiplier="1.1" behavior="StayInHull">
+      <ItemSet commonness="1">
+        <Item identifier="watchmanclothes" equip="true"/>
+        <Item identifier="captainscap1" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="revolver" equip="false">
+          <Item identifier="revolverround"/>
+          <Item identifier="revolverround"/>
+          <Item identifier="revolverround"/>
+          <Item identifier="revolverround"/>
+          <Item identifier="revolverround"/>
+          <Item identifier="revolverround"/>
+        </Item>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="watchmanseparatist" job="watchman" spawnpointtags="unlockpath" healthmultiplier="1.1" behavior="StayInHull">
+      <ItemSet commonness="1">
+        <Item identifier="watchmanclothes" equip="true"/>
+        <Item identifier="piratecaptainhat" equip="true" />
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="revolver" equip="false">
+          <Item identifier="revolverround"/>
+          <Item identifier="revolverround"/>
+          <Item identifier="revolverround"/>
+          <Item identifier="revolverround"/>
+          <Item identifier="revolverround"/>
+          <Item identifier="revolverround"/>
+        </Item>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+    
+    <npc identifier="commoner" commonness="0" moduleflags="none" job="mechanic" behavior="Passive" healthmultiplier="0.75" preferredoutpostmoduletypes="crewmodule,seccrewmodule">
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="commonerclothes1" equip="true"/>
+        <Item identifier="screwdriver"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="commonerclothes1" equip="true"/>
+        <Item identifier="baseballcap" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="wrench"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="commonerclothes2" equip="true"/>
+        <Item identifier="crowbar"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="commonerclothes2" equip="true"/>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="wrench"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="commonerclothes3" equip="true"/>
+        <Item identifier="crowbar"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="commonerclothes3" equip="true"/>
+        <Item identifier="baseballcap" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="screwdriver"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="commonerclothes4" equip="true"/>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="researcher" commonness="0" moduleflags="none" job="medicaldoctor" tags="researchernpc" behavior="Passive" healthmultiplier="0.75" ModuleFlags="ResearchModule" preferredoutpostmoduletypes="researchmodule,crewmodule">
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="researcherclothes" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="miner" commonness="0" moduleflags="none" job="mechanic" behavior="Passive" healthmultiplier="0.75" preferredoutpostmoduletypes="crewmodule">
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="minerclothes" equip="true"/>
+        <Item identifier="screwdriver"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="minerclothes" equip="true"/>
+        <Item identifier="baseballcap" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="wrench"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="minerclothes" equip="true"/>
+        <Item identifier="crowbar"/>        
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="hardhatman" commonness="0" moduleflags="none" job="mechanic" behavior="Passive" preferredoutpostmoduletypes="crewmodule">
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="ballistichelmet2" equip="true"/>
+        <Item identifier="minerclothes" equip="true"/>
+        <Item identifier="crowbar"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="clown" commonness="0" faction="clowns" moduleflags="clownmodule" job="assistant" behavior="Passive" preferredoutpostmoduletypes="clownmodule" spawnpointtags="clown">
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="clownmask" equip="true"/>
+        <Item identifier="clowncostume" equip="true"/>
+        <Item identifier="bikehorn" equip="false"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="clownmask" equip="true"/>
+        <Item identifier="commonerclothes2" equip="true"/>
+        <Item identifier="bikehorn" equip="false"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="clownmask" equip="true"/>
+        <Item identifier="commonerclothes3" equip="true"/>
+        <Item identifier="bikehorn" equip="false"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="baseballcap" equip="true"/>
+        <Item identifier="clowncostume" equip="true"/>
+        <Item identifier="bikehorn" equip="false"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="clownmask" equip="true"/>
+        <Item identifier="vipclothes1" equip="true"/>
+        <Item identifier="toyhammer" equip="false"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="merchantclown" commonness="0" faction="clowns" moduleflags="clownmodule" job="assistant" behavior="Passive" preferredoutpostmoduletypes="clownmodule" campaigninteractiontype="Store" spawnpointtags="clown">
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="clownmask" equip="true"/>
+        <Item identifier="vipclothes1" equip="true"/>
+        <Item identifier="toyhammer" equip="false"/>
+      </ItemSet>
+    </npc>
+    
+    <npc identifier="huskcultist" tags="huskcultist" faction="huskcult" commonness="0" moduleflags="huskmodule" job="assistant" behavior="Passive" healthmultiplier="0.5" preferredoutpostmoduletypes="huskmodule" spawnpointtags="husk">
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="cultistrobes" equip="true"/>
+        <Item identifier="divingknife" equip="false"/>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="cultistrobes" equip="true"/>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="piratebandana" equip="true" />
+      </ItemSet>
+    </npc>
+
+    <npc identifier="huskcultecclesiast" faction="huskcult" tags="" commonness="0" moduleflags="huskmodule" job="assistant" behavior="Passive" healthmultiplier="2.0" preferredoutpostmoduletypes="huskmodule" spawnpointtags="husk">
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="zealotrobes" equip="true"/>
+        <Item identifier="divingknifeunique" equip="false"/>
+      </ItemSet>
+    </npc>
+    
+    <npc identifier="merchanthusk" faction="huskcult" commonness="0" moduleflags="huskmodule" job="assistant" behavior="Passive" preferredoutpostmoduletypes="huskmodule" campaigninteractiontype="Store" spawnpointtags="clown">
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="cultistrobes" equip="true"/>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="piratebandana" equip="true" />
+      </ItemSet>
+    </npc>
+
+
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!--                                  Hireable                                 -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <npc identifier="hireablecoalitionsecurityofficer" job="securityofficer" tags="securitynpc" skillmultiplier="1.5" experiencepoints="2850" BaseSalary="500" SkillSalaryMultiplier="0.75">
+      <ItemSet>
+        <Item identifier="securitypatrolclothes" equip="true"/>
+        <Item identifier="headset" equip="true" />
+        <Item identifier="idcard" equip="true" tags="id_outpostsecurity"/>
+        <Item identifier="stunbaton">
+          <Item identifier="batterycell" />
+        </Item>
+        <Item identifier="batterycell" />
+        <Item identifier="handcuffs"/>
+        <Item identifier="revolver" equip="false">
+          <Item identifier="revolverround" amount="6"/>
+        </Item>
+        <Item identifier="divingknife" />
+        <Item identifier="antibleeding1"/>
+        <Item identifier="bodyarmor" equip="true"/>
+        <Item identifier="ballistichelmet2" equip="true"/>
+      </ItemSet>
+    </npc>
+    <npc identifier="hireablecoalitionsecurityofficerveteran" job="securityofficer" tags="securitynpc" skillmultiplier="2.0" experiencepoints="7000" BaseSalary="500" SkillSalaryMultiplier="0.75">
+      <ItemSet>
+        <Item identifier="securitypatrolclothes" equip="true"/>
+        <Item identifier="headset" equip="true" />
+        <Item identifier="idcard" equip="true" tags="id_outpostsecurity"/>
+        <Item identifier="stunbaton">
+          <Item identifier="batterycell" />
+        </Item>
+        <Item identifier="batterycell" />
+        <Item identifier="handcuffs"/>
+        <Item identifier="assaultrifle" equip="false">
+          <Item identifier="assaultriflemagazine"/>
+          <Item identifier="revolverround"/>
+        </Item>
+        <Item identifier="divingknife" />
+        <Item identifier="antibleeding1"/>
+        <Item identifier="bandolier" equip="true"/>
+        <Item identifier="ballistichelmet2" equip="true"/>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="hireablecoalitionengineer" job="engineer" skillmultiplier="1.5" experiencepoints="2850" BaseSalary="500" SkillSalaryMultiplier="0.75">
+      <ItemSet>
+        <Item identifier="orangejumpsuit2" equip="true" />
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="headset" equip="true" showpreview="false"/>
+        <Item identifier="wrench" />
+        <Item identifier="screwdriver" />
+        <Item identifier="crowbar" />
+        <Item identifier="toolbelt" equip="true"/>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+      </ItemSet>
+    </npc>
+    <npc identifier="hireablecoalitionengineerveteran" job="engineer" skillmultiplier="2.0" experiencepoints="7000" BaseSalary="500" SkillSalaryMultiplier="0.75">
+      <ItemSet>
+        <Item identifier="orangejumpsuit2" equip="true" />
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="headset" equip="true" showpreview="false"/>
+        <Item identifier="wrench" />
+        <Item identifier="screwdriver" />
+        <Item identifier="crowbar" />
+        <Item identifier="toolbelt" equip="true"/>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+      </ItemSet>
+    </npc>
+    <npc identifier="hireablecoalitionmechanic" job="mechanic"  skillmultiplier="1.5" experiencepoints="2850" BaseSalary="500" SkillSalaryMultiplier="0.75">
+      <ItemSet>
+        <Item identifier="bluejumpsuit2" equip="true" />
+        <Item identifier="headset" equip="true" showpreview="false"/>
+        <Item identifier="baseballcap" equip="true" />
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="wrench" />
+        <Item identifier="screwdriver" />
+        <Item identifier="toolbelt" equip="true"/>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+      </ItemSet>
+    </npc>
+    <npc identifier="hireablecoalitionmechanicveteran" job="mechanic"  skillmultiplier="2.0" experiencepoints="7000" BaseSalary="500" SkillSalaryMultiplier="0.75">
+      <ItemSet>
+        <Item identifier="bluejumpsuit2" equip="true" />
+        <Item identifier="headset" equip="true" showpreview="false"/>
+        <Item identifier="baseballcap" equip="true" />
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="wrench" />
+        <Item identifier="screwdriver" />
+        <Item identifier="toolbelt" equip="true"/>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+      </ItemSet>
+    </npc>
+    <npc identifier="hireablecoalitionmedic" job="medicaldoctor" skillmultiplier="1.5" experiencepoints="2850" BaseSalary="500" SkillSalaryMultiplier="0.75">
+      <ItemSet>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="doctorsuniform1" equip="true"/>
+        <Item identifier="healthscanner"/>
+        <Item identifier="headset" equip="true"/>
+        <Item identifier="syringegun"/>
+        <Item identifier="antibleeding1"/>
+        <Item identifier="antidama1"/>
+      </ItemSet>
+    </npc>
+    <npc identifier="hireablecoalitionmedicveteran" job="medicaldoctor" skillmultiplier="2.0" experiencepoints="7000" BaseSalary="500" SkillSalaryMultiplier="0.75">
+      <ItemSet>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="doctorsuniform2" equip="true"/>
+        <Item identifier="healthscanner"/>
+        <Item identifier="autoinjectorheadset" equip="true"/>
+        <Item identifier="syringegun"/>
+        <Item identifier="antibleeding1"/>
+        <Item identifier="antidama1"/>
+        <Item identifier="pressurestabilizer"/>
+        <Item identifier="genesplicer"/>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="hireableseparatistsecurityofficer" job="securityofficer" skillmultiplier="1.5" experiencepoints="2850" BaseSalary="500" SkillSalaryMultiplier="0.75">
+      <ItemSet>
+        <Item identifier="securityseparatistsuniform1" equip="true" />
+        <Item identifier="headset" equip="true" />
+        <Item identifier="piratebodyarmor" equip="true" />
+        <Item identifier="idcard" equip="true" tags="id_outpostsecurity"/>
+        <Item identifier="stunbaton">
+          <Item identifier="batterycell" />
+        </Item>
+        <Item identifier="batterycell" />
+        <Item identifier="handcuffs"/>
+        <Item identifier="smg">
+          <Item identifier="smgmagazine" />
+        </Item>
+        <Item identifier="smgmagazine" />
+        <Item identifier="smgmagazine" />
+        <Item identifier="divingknife" />
+        <Item identifier="ballistichelmet1" equip="true"/>
+      </ItemSet>
+    </npc>
+    <npc identifier="hireableseparatistsecurityofficerveteran" job="securityofficer" skillmultiplier="2.0" experiencepoints="7000" BaseSalary="500" SkillSalaryMultiplier="0.75">
+      <ItemSet>
+        <Item identifier="securityseparatistsuniform2" equip="true" />
+        <Item identifier="headset" equip="true" />
+        <Item identifier="bandolier" equip="true" />
+        <Item identifier="idcard" equip="true" tags="id_outpostsecurity"/>
+        <Item identifier="stunbaton">
+          <Item identifier="batterycell" />
+        </Item>
+        <Item identifier="batterycell" />
+        <Item identifier="handcuffs"/>
+        <Item identifier="autoshotgun">
+          <Item identifier="shotgunshell" />
+          <Item identifier="shotgunshell" />
+          <Item identifier="shotgunshell" />
+          <Item identifier="shotgunshell" />
+        </Item>
+        <Item identifier="divingknife" />
+        <Item identifier="ballistichelmet1" equip="true"/>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="hireableseparatistengineer" job="engineer" skillmultiplier="1.5" experiencepoints="2850" BaseSalary="500" SkillSalaryMultiplier="0.75">
+      <ItemSet>
+        <Item identifier="engineerseparatistsuniform1" equip="true" />
+        <Item identifier="piratebandana" equip="true" />
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="headset" equip="true" showpreview="false"/>
+        <Item identifier="wrench" />
+        <Item identifier="screwdriver" />
+        <Item identifier="crowbar" />
+        <Item identifier="toolbelt" equip="true"/>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+      </ItemSet>
+    </npc>
+    <npc identifier="hireableseparatistengineerveteran" job="engineer" skillmultiplier="2.0" experiencepoints="7000" BaseSalary="500" SkillSalaryMultiplier="0.75">
+      <ItemSet>
+        <Item identifier="engineerseparatistsuniform2" equip="true" />
+        <Item identifier="piratebandana" equip="true" />
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="headset" equip="true" showpreview="false"/>
+        <Item identifier="wrench" />
+        <Item identifier="screwdriver" />
+        <Item identifier="crowbar" />
+        <Item identifier="toolbelt" equip="true"/>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+      </ItemSet>
+    </npc>
+    <npc identifier="hireableseparatistmechanic" job="mechanic" skillmultiplier="1.5" experiencepoints="2850" BaseSalary="500" SkillSalaryMultiplier="0.75">
+      <ItemSet>
+        <Item identifier="mechanicseparatistsuniform1" equip="true" />
+        <Item identifier="baseballcap" equip="true"/>
+        <Item identifier="headset" equip="true" showpreview="false"/>
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="wrench" />
+        <Item identifier="screwdriver" />
+        <Item identifier="toolbelt" equip="true"/>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+      </ItemSet>
+    </npc>
+    <npc identifier="hireableseparatistmechanicveteran" job="mechanic" skillmultiplier="2.0" experiencepoints="7000" BaseSalary="500" SkillSalaryMultiplier="0.75">
+      <ItemSet>
+        <Item identifier="mechanicseparatistsuniform2" equip="true" />
+        <Item identifier="baseballcap" equip="true"/>
+        <Item identifier="headset" equip="true" showpreview="false"/>
+        <Item identifier="idcard" equip="true" />
+        <Item identifier="wrench" />
+        <Item identifier="screwdriver" />
+        <Item identifier="toolbelt" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+      </ItemSet>
+    </npc>
+    <npc identifier="hireableseparatistmedic" job="medicaldoctor" skillmultiplier="1.5" experiencepoints="2850" BaseSalary="500" SkillSalaryMultiplier="0.75">
+      <ItemSet>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="medicseparatistsuniform1" equip="true"/>
+        <Item identifier="piratebandana" equip="true" />
+        <Item identifier="healthscanner"/>
+        <Item identifier="headset" equip="true"/>
+        <Item identifier="syringegun"/>
+        <Item identifier="antibleeding1"/>
+        <Item identifier="antidama1"/>
+      </ItemSet>
+    </npc>
+    <npc identifier="hireableseparatistmedicveteran" job="medicaldoctor" skillmultiplier="2.0" experiencepoints="7000" BaseSalary="500" SkillSalaryMultiplier="0.75">
+      <ItemSet>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="medicseparatistsuniform2" equip="true"/>
+        <Item identifier="piratebandana" equip="true" />
+        <Item identifier="healthscanner"/>
+        <Item identifier="autoinjectorheadset" equip="true"/>
+        <Item identifier="syringegun"/>
+        <Item identifier="antibleeding1"/>
+        <Item identifier="antidama1"/>
+        <Item identifier="combatstimulantsyringe"/>
+        <Item identifier="genesplicer"/>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="hireablehuskcultist" job="assistant" skillmultiplier="1.5" experiencepoints="2850" BaseSalary="500" SkillSalaryMultiplier="0.75">
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="cultistrobes" equip="true"/>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="headset" equip="true"/>
+        <Item identifier="wrench"/>
+        <Item identifier="screwdriver"/>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="cultistrobes" equip="true"/>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="piratebandana" equip="true" />
+        <Item identifier="headset" equip="true"/>
+        <Item identifier="wrench"/>
+        <Item identifier="screwdriver"/>
+      </ItemSet>
+    </npc>
+    <npc identifier="hireablehuskcultistveteran" skillmultiplier="2.0" experiencepoints="7000" BaseSalary="500" SkillSalaryMultiplier="0.75">
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="zealotrobes" equip="true"/>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="rituallantern" equip="true"/>
+        <Item identifier="syringegun" equip="false">
+          <Item identifier="huskeggs" amount="2" />
+        </Item>
+        <Item identifier="headset" equip="true"/>
+        <Item identifier="wrench"/>
+        <Item identifier="screwdriver"/>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="zealotrobes" equip="true"/>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="piratebandana" equip="true" />
+        <Item identifier="headset" equip="true"/>
+        <Item identifier="huskstinger" equip="true"/>
+        <Item identifier="syringegun" equip="false">
+          <Item identifier="huskeggs" amount="2" />
+        </Item>
+        <Item identifier="wrench"/>
+        <Item identifier="screwdriver"/>
+      </ItemSet>
+    </npc>
+    <npc identifier="hireableclown" job="assistant" skillmultiplier="1.5" experiencepoints="2850" BaseSalary="500" SkillSalaryMultiplier="0.75">
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="clownmask" equip="true"/>
+        <Item identifier="clowncostume" equip="true"/>
+        <Item identifier="bikehorn" equip="false"/>
+        <Item identifier="headset" equip="true"/>
+        <Item identifier="wrench"/>
+        <Item identifier="screwdriver"/>
+      </ItemSet>
+    </npc>
+    <npc identifier="hireableclownveteran" job="assistant" skillmultiplier="2.0" experiencepoints="7000" BaseSalary="500" SkillSalaryMultiplier="0.75">
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="clownmask" equip="true"/>
+        <Item identifier="clowncostume" equip="true"/>
+        <Item identifier="cymbals" equip="false"/>
+        <Item identifier="headset" equip="true"/>
+        <Item identifier="bananapeel" amount="8" />
+        <Item identifier="toyhammer"/>
+        <Item identifier="honkmotherianscriptures1"/>
+      </ItemSet>
+    </npc>
+
+    <npc identifier="prisonerseparatists" tags="hostage,prisoner" job="assistant" moduleflags="none" faction="separatists" behavior="Passive" AllowDraggingIndefinitely="true">
+      <ItemSet>
+        <Item identifier="prisonerclothes" equip="true" />
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+    <npc identifier="prisonercoalition" tags="hostage,prisoner" job="assistant" moduleflags="none" faction="coalition" behavior="Passive" AllowDraggingIndefinitely="true">
+      <ItemSet>
+        <Item identifier="prisonerclothes" equip="true" />
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+
+  </npcset>
+
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+  <!--                          Abandoned Outpost NPCs                           -->
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+  <npcset identifier="abandonedoutpostnpcs">
+    <npc identifier="bandit" commonness="0" tags="bandit" moduleflags="crewmodule,engineeringmodule" job="structuredefender" behavior="Passive" healthmultiplier="0.75" aimspeed="0.8" aimaccuracy="0.25" reportrange="500" hearing="1.0" findweaponsrange="1000">
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="banditclothes1" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+        <Item identifier="wrench"/>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="toolbelt" equip="true"/>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="banditclothes1" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="toolbelt" equip="true"/>
+        <Item identifier="revolver">
+          <Item identifier="revolverround" amount="6"/>
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="banditclothes2" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+        <Item identifier="baseballcap" equip="true"/>
+        <Item identifier="crowbar" equip="false"/>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="banditclothes2" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+        <Item identifier="crowbar"/>
+        <Item identifier="toolbelt" equip="true"/>
+        <Item identifier="revolver">
+          <Item identifier="revolverround" amount="6"/>
+        </Item>
+      </ItemSet>
+    </npc>
+    <npc identifier="bandit_heavy" commonness="0" tags="bandit" moduleflags="crewmodule,engineeringmodule" job="structuredefender" behavior="Passive" healthmultiplier="0.8" aimspeed="0.85" aimaccuracy="0.45" reportrange="550" hearing="1.0" findweaponsrange="1000">
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="piratehelmet" equip="true" />
+        <Item identifier="banditclothes1" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="machinepistol" equip="true">
+          <Item identifier="smgmagazine"/>
+        </Item>
+        <Item identifier="toolbelt" equip="true"/>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="piratehelmet" equip="true" />
+        <Item identifier="banditclothes1" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="toolbelt" equip="true"/>
+        <Item identifier="revolver">
+          <Item identifier="revolverround" amount="6"/>
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="piratehelmet" equip="true" />
+        <Item identifier="banditclothes2" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+        <Item identifier="baseballcap" equip="true"/>
+        <Item identifier="crowbar" equip="false"/>
+        <Item identifier="shotgun">
+          <Item identifier="shotgunshell" amount="6"/>
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="banditclothes2" equip="true"/>
+        <Item identifier="piratebodyarmor" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="toolbelt" equip="true"/>
+        <Item identifier="revolver" equip="true">
+          <Item identifier="revolverround" amount="6"/>
+        </Item>
+      </ItemSet>
+    </npc>
+    <npc identifier="bandit_elite" commonness="0" tags="bandit" moduleflags="crewmodule,engineeringmodule" job="structuredefender" behavior="Passive" aimspeed="0.9" aimaccuracy="0.65" reportrange="600" hearing="1.0" findweaponsrange="1000">
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="banditclothes1" equip="true"/>
+        <Item identifier="piratebodyarmor" equip="true" />
+        <Item identifier="piratehelmet" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="smgmagazine" amount="2" />
+        <Item identifier="machinepistol" equip="true">
+          <Item identifier="smgmagazine"/>
+        </Item>
+        <Item identifier="machinepistol" equip="true">
+          <Item identifier="smgmagazine"/>
+        </Item>
+        <Item identifier="toolbelt" equip="true"/>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="banditclothes1" equip="true"/>
+        <Item identifier="piratebodyarmor" equip="true" />
+        <Item identifier="piratehelmet" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="toolbelt" equip="true"/>
+        <Item identifier="revolverround" amount="6"/>
+        <Item identifier="revolver" equip="true">
+          <Item identifier="revolverround" amount="6"/>
+        </Item>
+        <Item identifier="revolver" equip="true">
+          <Item identifier="revolverround" amount="6"/>
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="banditclothes2" equip="true"/>
+        <Item identifier="piratebodyarmor" equip="true" />
+        <Item identifier="piratehelmet" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+        <Item identifier="baseballcap" equip="true"/>
+        <Item identifier="crowbar" equip="false"/>
+        <Item identifier="shotgunshell" amount="6"/>
+        <Item identifier="shotgun">
+          <Item identifier="shotgunshell" amount="6"/>
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="banditclothes2" equip="true"/>
+        <Item identifier="piratebodyarmor" equip="true" />
+        <Item identifier="piratehelmet" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="toolbelt" equip="true"/>
+        <Item identifier="rifle" equip="true">
+          <Item identifier="riflebullet" amount="6"/>
+        </Item>
+      </ItemSet>
+    </npc>
+    <npc identifier="banditleader" commonness="0" tags="bandit" moduleflags="adminmodule,securitymodule" spawnpointtags="banditleader" job="structuredefender" behavior="Passive" aimspeed="0.8" aimaccuracy="0.75" reportrange="750" hearing="1.0" findweaponsrange="1000">
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="captainscap2" equip="true"/>
+        <Item identifier="captainsuniform2" equip="true"/>
+        <Item identifier="bodyarmor" equip="true"/>
+        <Item identifier="steroids"/>
+        <Item identifier="steroids"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+        <Item identifier="shotgun">
+          <Item identifier="shotgunshell" amount="6"/>
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="0.5">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="wrench"/>
+        <Item identifier="captainscap2" equip="true"/>
+        <Item identifier="captainsuniform2" equip="true"/>
+        <Item identifier="bodyarmor" equip="true"/>
+        <Item identifier="steroids"/>
+        <Item identifier="steroids"/>
+        <Item identifier="toolbelt" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+        <Item identifier="smg">
+          <Item identifier="smgmagazine"/>
+        </Item>
+      </ItemSet>
+    </npc>
+    <npc identifier="banditleader_heavy" commonness="0" tags="bandit" moduleflags="adminmodule,securitymodule" spawnpointtags="banditleader" job="structuredefender" behavior="Passive" aimspeed="0.85" aimaccuracy="0.75" reportrange="750" hearing="1.0" findweaponsrange="1000">
+      <ItemSet commonness="0.8">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="captainsuniform3" equip="true"/>
+        <Item identifier="bodyarmor" equip="true"/>
+        <Item identifier="steroids"/>
+        <Item identifier="steroids"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+        <Item identifier="shotgun">
+          <Item identifier="shotgunshell" amount="6"/>
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="0.5">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="wrench"/>
+        <Item identifier="captainsuniform3" equip="true"/>
+        <Item identifier="bodyarmor" equip="true"/>
+        <Item identifier="steroids"/>
+        <Item identifier="steroids"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+        <Item identifier="smg">
+          <Item identifier="smgmagazine"/>
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="0.2">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="captainsuniform3" equip="true"/>
+        <Item identifier="bodyarmor" equip="true"/>
+        <Item identifier="steroids"/>
+        <Item identifier="steroids"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+        <Item identifier="shotgununique">
+          <Item identifier="shotgunshell"/>
+          <Item identifier="shotgunshell"/>
+        </Item>
+        <Item identifier="shotgunshell" amount="4"/>
+      </ItemSet>
+      <ItemSet commonness="0.2">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="captainsuniform3" equip="true"/>
+        <Item identifier="bodyarmor" equip="true"/>
+        <Item identifier="steroids"/>
+        <Item identifier="steroids"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="weldingtool">
+          <Item identifier="weldingfueltank" />
+        </Item>
+        <Item identifier="smgunique">
+          <Item identifier="smgmagazine"/>
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="0.2">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingknife" equip="false"/>
+        <Item identifier="captainsuniform3" equip="true"/>
+        <Item identifier="bodyarmor" equip="true"/>
+        <Item identifier="steroids"/>
+        <Item identifier="steroids"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="flamer">
+          <Item identifier="weldingfueltank"/>
+        </Item>
+      </ItemSet>
+    </npc>
+    <npc identifier="hostage" tags="hostage,prisoner" job="assistant" moduleflags="none" behavior="Passive" AllowDraggingIndefinitely="true">
+      <ItemSet>
+        <Item identifier="commonerclothes1" equip="true"/>
+        <Item identifier="handcuffs" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet>
+        <Item identifier="commonerclothes2" equip="true"/>
+        <Item identifier="handcuffs" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet>
+        <Item identifier="commonerclothes3" equip="true"/>
+        <Item identifier="handcuffs" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingmask" >
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+    <npc identifier="hostageseparatists" tags="hostage,prisoner" job="assistant" moduleflags="none" faction="separatists" behavior="Passive" AllowDraggingIndefinitely="true">
+      <ItemSet>
+        <Item identifier="separatistcommoner2" equip="true" />
+        <Item identifier="handcuffs" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet>
+        <Item identifier="separatistcommoner1" equip="true" />
+        <Item identifier="handcuffs" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+    <npc identifier="hostagecoalition" tags="hostage,prisoner" job="assistant" moduleflags="none" faction="coalition" behavior="Passive" AllowDraggingIndefinitely="true">
+      <ItemSet>
+        <Item identifier="bluejumpsuit2" equip="true" />
+        <Item identifier="handcuffs" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet>
+        <Item identifier="orangejumpsuit2" equip="true" />
+        <Item identifier="handcuffs" equip="true"/>
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+    <npc identifier="psychoclown" commonness="0" moduleflags="none" job="killer" behavior="Passive" healthmultiplier="1.5" healthmultiplierinmultiplayer="3" aimspeed="1" aimaccuracy="1" reportrange="500" findweaponsrange="0">
+      <ItemSet commonness="99">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="clowncostume" equip="true"/>
+        <Item identifier="clownmask" equip="true"/>
+        <Item identifier="clowndivingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="oxygentank" />
+        <Item identifier="pressurestabilizer" />
+        <Item identifier="divingknife" equip="true"/>
+        <Item identifier="bikehorn" equip="true"/>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="clownsuitunique" equip="true"/>
+        <Item identifier="clownmaskunique" equip="true"/>
+        <Item identifier="clowndivingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+        <Item identifier="oxygentank" />
+        <Item identifier="pressurestabilizer" />
+        <Item identifier="divingknifeunique" equip="true"/>
+        <Item identifier="bikehorn" equip="true"/>
+      </ItemSet>
+    </npc>
+    <npc identifier="huskextremist" commonness="0" tags="huskcultist" group="husk" moduleflags="crewmodule,researchmodule" job="killer" behavior="Passive" healthmultiplier="0.5" healthmultiplierinmultiplayer="1.5" aimspeed="0.8" aimaccuracy="0.25" reportrange="500" findweaponsrange="0">
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="cultistrobes" equip="true"/>
+        <Item identifier="huskstinger" equip="false"/>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="cultistrobes" equip="true"/>
+        <Item identifier="huskstinger" equip="false"/>
+        <Item identifier="piratebandana" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="0.5">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="cultistrobes" equip="true"/>
+        <Item identifier="huskstinger" equip="false"/>
+        <Item identifier="piratebandana" equip="true" />
+        <Item identifier="huskeggs" equip="true" />
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+    <npc identifier="huskextremist_leader" tags="huskcultist" group="husk" commonness="0" moduleflags="crewmodule,researchmodule" job="medicaldoctor" behavior="Passive" healthmultiplier="1" healthmultiplierinmultiplayer="1.3" aimspeed="0.8" aimaccuracy="0.75" reportrange="750" findweaponsrange="0">
+      <ItemSet commonness="10">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="zealotrobes" equip="true"/>
+        <Item identifier="huskstinger" equip="true"/>
+        <Item identifier="syringegun" equip="false">
+          <Item identifier="huskeggs" amount="2" />
+        </Item>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="zealotrobes" equip="true"/>
+        <Item identifier="divingknifeunique" equip="false"/>
+        <Item identifier="syringegun" equip="false">
+          <Item identifier="huskeggs" amount="2" />
+        </Item>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+    </npc>
+  </npcset>
+</npcsets>

--- a/Barotrauma/Content/NPCPrefabs/OutpostNpcs.xml
+++ b/Barotrauma/Content/NPCPrefabs/OutpostNpcs.xml
@@ -66,6 +66,17 @@
           <Item identifier="oxygentank" />
         </Item>
       </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="piratecaptainhat2" equip="true" />
+        <Item identifier="separatistcommoner3" equip="true" outfit="true" />
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="revolver" equip="false">
+          <Item identifier="revolverround" amount="6"/>
+        </Item>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
     </npc>
 
     <!-- for backwards compatibility (some mods that override location types still use this - if it doesn't exist, you can't get any missions)
@@ -511,6 +522,22 @@
       <ItemSet commonness="1">
         <Item identifier="watchmanclothes" equip="true"/>
         <Item identifier="piratecaptainhat" equip="true" />
+        <Item identifier="idcard" equip="true"/>
+        <Item identifier="revolver" equip="false">
+          <Item identifier="revolverround"/>
+          <Item identifier="revolverround"/>
+          <Item identifier="revolverround"/>
+          <Item identifier="revolverround"/>
+          <Item identifier="revolverround"/>
+          <Item identifier="revolverround"/>
+        </Item>
+        <Item identifier="divingmask">
+          <Item identifier="oxygentank" />
+        </Item>
+      </ItemSet>
+      <ItemSet commonness="1">
+        <Item identifier="watchmanclothes" equip="true"/>
+        <Item identifier="piratecaptainhat2" equip="true" />
         <Item identifier="idcard" equip="true"/>
         <Item identifier="revolver" equip="false">
           <Item identifier="revolverround"/>


### PR DESCRIPTION
This adds a bandanaless version of the Separatist Captain Hat as I feel it should be included in the base game, also to add a lil bit more variety and flavour cuz I LOVE FLAVOUR.
It costs 15 marks less because the bandana costs 15 marks, decreased the normal Sep Captain Hat's min-maxavailables as an attempt to make it have sense, since idk about going up to a dirty merchant and them selling you a bandana, a hat, and a hat with a bandana all being separate options
I tried to integrate it into NPCs' prefabs and etc, wanting it to be like 50% chance for each, but I don't really know if I did that, you're gonna have to check if it works correctly
Also made the normal Sep Captain Hat's inventory sprite appear with the bandana as well, to help differentiate them a lil bit
<img width="472" height="475" alt="image" src="https://github.com/user-attachments/assets/bf38e07a-65df-44d0-96e6-0645abd84107" />
<img width="140" height="277" alt="image" src="https://github.com/user-attachments/assets/ef0b4ec0-8437-409a-8196-2dfabd91a82f" />