### PR TITLE
Disallow using partial condition fpga for circuit box (in-game)

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Signal/CircuitBox.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Items/Components/Signal/CircuitBox.cs
@@ -275,6 +275,10 @@ namespace Barotrauma.Items.Components
                 if (IsInGame())
                 {
                     if (!GetApplicableResourcePlayerHas(prefab, Character.Controlled).TryUnwrap(out var r)) { return; }
+                    if (r.Condition < 100.0)
+                    {
+                        return;
+                    }
                     resource = r.Prefab;
                     RemoveItem(r);
                 }


### PR DESCRIPTION
This disallows players to use partial condition fpga circuit for adding components into a circuit box in-game. 
The goal of this is to remove a gameplay exploit where you could recover your fpga if it was damaged, without using any resource:

1. Damage your fpga circuit (enable a mod to do this, for example I was playing with NT Cybernetics Enhanced);
2. Use it to add a component in a circuit box;
3. Remove the component;
4. Obtain a full condition fpga circuit, without a cost.

Changes:
- Added full item condition check when adding a component into the circuit box in-game