### PR TITLE
Added current arguments as context for validargs

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/DebugConsole.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/DebugConsole.cs
@@ -46,7 +46,7 @@ namespace Barotrauma
             
             public Action<string[]> OnExecute;
 
-            public Func<string[][]> GetValidArgs;
+            public Func<string[], string[][]> GetValidArgs;
 
             /// <summary>
             /// Using a command that's considered a cheat disables achievements
@@ -63,7 +63,7 @@ namespace Barotrauma
 
                 this.OnExecute = onExecute;
                 
-                this.GetValidArgs = getValidArgs;
+                this.GetValidArgs = args => getValidArgs();
                 this.IsCheat = isCheat;
             }
 
@@ -84,6 +84,14 @@ namespace Barotrauma
                 }
 
                 OnExecute(args);
+            }
+
+            // Used to chain method calls when initializing commands.
+            // Overloading the constructor in a tidy way was not possible without running into ambiguity or partial backwards incompatibility.
+            public Command SetGetValidArgs(Func<string[], string[][]> getValidArgs)
+            {
+                this.GetValidArgs = getValidArgs;
+                return this;
             }
 
             public override int GetHashCode()
@@ -2377,7 +2385,7 @@ namespace Barotrauma
                 int autoCompletedArgIndex = args.Length > 0 && command.Last() != ' ' ? args.Length - 1 : args.Length;
 
                 //get all valid arguments for the given command
-                string[][] allArgs = matchingCommand.GetValidArgs();
+                string[][] allArgs = matchingCommand.GetValidArgs(args);
                 if (allArgs == null || allArgs.GetLength(0) < autoCompletedArgIndex + 1) { return command; }
 
                 if (string.IsNullOrEmpty(currentAutoCompletedCommand))


### PR DESCRIPTION
Changed Command class and AutoComplete method in DebugConsole.cs so GetValidArgs has access to the current argument list. This allows the list of valid arguments to be able to contextualize itself off the current list of arguments. The AutoComplete method already had a string[] of the arguments computed but it just didn't pass it on to GetValidArgs to potentially benefit from.

I attempted to achieve this in the simplest and most backwards compatible way possible so as to not require any changes from in-memory or per-compiled C# mods. Constructor overloading would look nicer but had the potential to break some mods and would require every instance of "commands.Add" to be slightly altered to avoid ambiguity.

Ahead are some examples of ways this could be used:
1. Make the "prefab" options depend on the "category" for the "maxupgrades" command.
2. "giveaffliction" could skip the "limp type" argument (and still autocomplete correctly) if the affliction isn't limb specific.
3. If there was a command to set a config consisting of key-value pairs where the values are typed, the autocomplete could give different options depending on the type of the value associated with the key. E.g.: "setconfig color" autocompleting to the available colors whilst "setconfig direction" autocompletes to left, right, up and down.