### PR TITLE
feat(mem): added buffer pooling for networking code to reduce load on GC

### DIFF
--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/GameClient.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/GameClient.cs
@@ -2185,7 +2185,7 @@ namespace Barotrauma.Networking
                             UInt16 updateID = inc.ReadUInt16();
 
                             UInt16 settingsLen = inc.ReadUInt16();
-                            byte[] settingsData = inc.ReadBytes(settingsLen);
+                            PooledBuffer settingsData = inc.ReadBytes(settingsLen);
 
                             bool isInitialUpdate = inc.ReadBoolean();
                             DebugConsole.Log($"Received {(isInitialUpdate ? "initial" : string.Empty)} lobby update ID: {updateID}, last ID: {GameMain.NetLobbyScreen.LastUpdateID}.");

--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/Primitives/P2PSocket/EosP2PSocket.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/Primitives/P2PSocket/EosP2PSocket.cs
@@ -40,7 +40,7 @@ sealed class EosP2PSocket : P2PSocket
         foreach (var msg in eosSocket.GetMessageBatch())
         {
             EosP2PEndpoint endpoint = new EosP2PEndpoint(msg.Sender);
-            callbacks.OnData(endpoint, new ReadWriteMessage(msg.Buffer, 0, msg.ByteLength * 8, false));
+            callbacks.OnData(endpoint, new ReadWriteMessage(new PooledBuffer(msg.Buffer), 0, msg.ByteLength * 8, false));
 
             if (Type is OwnerOrClient.Owner)
             {

--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/Primitives/P2PSocket/SteamConnectSocket.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/Primitives/P2PSocket/SteamConnectSocket.cs
@@ -17,10 +17,7 @@ sealed class SteamConnectSocket : P2PSocket
 
         public override void OnMessage(IntPtr data, int size, long messageNum, long recvTime, int channel)
         {
-            var dataArray = new byte[size];
-            Marshal.Copy(source: data, destination: dataArray, startIndex: 0, length: size);
-
-            callbacks.OnData(endpoint, new ReadWriteMessage(dataArray, bitPos: 0, lBits: size * 8, copyBuf: false));
+            callbacks.OnData(endpoint, new ReadWriteMessage(new PooledBuffer(data,size), bitPos: 0, lBits: size * 8, copyBuf: false));
         }
 
         public override void OnDisconnected(Steamworks.Data.ConnectionInfo info)

--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/Primitives/P2PSocket/SteamListenSocket.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/Primitives/P2PSocket/SteamListenSocket.cs
@@ -73,10 +73,9 @@ sealed class SteamListenSocket : P2PSocket
             if (!identity.IsSteamId || data == IntPtr.Zero) { return; }
             var endpoint = new SteamP2PEndpoint(new SteamId((Steamworks.SteamId)identity));
 
-            var dataArray = new byte[size];
-            Marshal.Copy(source: data, destination: dataArray, startIndex: 0, length: size);
+            
 
-            callbacks.OnData(endpoint, new ReadWriteMessage(dataArray, bitPos: 0, lBits: size * 8, copyBuf: false));
+            callbacks.OnData(endpoint, new ReadWriteMessage(new PooledBuffer(data,size), bitPos: 0, lBits: size * 8, copyBuf: false));
 
             if (socket?.Type is OwnerOrClient.Owner)
             {

--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/Primitives/Peers/LidgrenClientPeer.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/Primitives/Peers/LidgrenClientPeer.cs
@@ -240,7 +240,7 @@ namespace Barotrauma.Networking
             }
 #endif
 
-            byte[] bufAux = msg.PrepareForSending(compressPastThreshold, out bool isCompressed, out _);
+            PooledBuffer bufAux = msg.PrepareForSending(compressPastThreshold, out bool isCompressed, out _);
 
             var headers = new PeerPacketHeaders
             {

--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/Primitives/Peers/P2PClientPeer.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/Primitives/Peers/P2PClientPeer.cs
@@ -166,7 +166,7 @@ namespace Barotrauma.Networking
                 if (!completeMessageOption.TryUnwrap(out var completeMessage)) { return; }
 
                 int completeMessageLengthBits = completeMessage.Length * 8;
-                incomingDataMessages.Add(new ReadWriteMessage(completeMessage.ToArray(), 0, completeMessageLengthBits, copyBuf: false));
+                incomingDataMessages.Add(new ReadWriteMessage(new PooledBuffer(completeMessage), 0, completeMessageLengthBits, copyBuf: false));
             }
             else if (packetHeader.IsHeartbeatMessage() || packetHeader.IsDoSProtectionMessage())
             {
@@ -269,7 +269,7 @@ namespace Barotrauma.Networking
         {
             if (!isActive) { return; }
 
-            byte[] bufAux = msg.PrepareForSending(compressPastThreshold, out bool isCompressed, out _);
+            PooledBuffer bufAux = msg.PrepareForSending(compressPastThreshold, out bool isCompressed, out _);
             if (bufAux.Length > MessageFragment.MaxSize)
             {
                 var fragments = fragmenter.FragmentMessage(msg.Buffer.AsSpan()[..msg.LengthBytes]);

--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/Primitives/Peers/P2POwnerPeer.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/Primitives/Peers/P2POwnerPeer.cs
@@ -39,7 +39,7 @@ namespace Barotrauma.Networking
             public Option<DisconnectInfo> PendingDisconnect;
             public AuthenticationStatus AuthStatus;
 
-            public readonly record struct UnauthedMessage(byte[] Bytes, int LengthBytes);
+            public readonly record struct UnauthedMessage(PooledBuffer Bytes, int LengthBytes);
 
             public readonly List<UnauthedMessage> UnauthedMessages;
 

--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/Primitives/Peers/P2POwnerPeer.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/Primitives/Peers/P2POwnerPeer.cs
@@ -319,9 +319,9 @@ namespace Barotrauma.Networking
             }
         }
 
-        private static byte[] GetRemainingBytes(IReadMessage msg)
+        private static Span<byte> GetRemainingBytes(IReadMessage msg)
         {
-            return msg.Buffer[msg.BytePosition..msg.LengthBytes];
+            return msg.Buffer.AsSpanRange(msg.BytePosition,msg.LengthBytes);
         }
         
         private void HandleMessageForRemotePeer(PeerPacketHeaders peerPacketHeaders, P2PEndpoint recipientEndpoint, IReadMessage inc)
@@ -360,7 +360,7 @@ namespace Barotrauma.Networking
                     LobbyID = 0,
                     Message = new PeerPacketMessage
                     {
-                        Buffer = GetRemainingBytes(inc)
+                        Buffer = new PooledBuffer(GetRemainingBytes(inc))
                     }
                 };
 
@@ -368,7 +368,7 @@ namespace Barotrauma.Networking
             }
             else
             {
-                byte[] userMessage = GetRemainingBytes(inc);
+                PooledBuffer userMessage = new PooledBuffer(GetRemainingBytes(inc));
                 outMsg.WriteBytes(userMessage, 0, userMessage.Length);
             }
 
@@ -507,7 +507,7 @@ namespace Barotrauma.Networking
             if (!isActive) { return; }
 
             IWriteMessage msgToSend = new WriteOnlyMessage();
-            byte[] msgData = msg.PrepareForSending(compressPastThreshold, out bool isCompressed, out _);
+            PooledBuffer msgData = msg.PrepareForSending(compressPastThreshold, out bool isCompressed, out _);
             msgToSend.WriteNetSerializableStruct(new P2POwnerToServerHeader
             {
                 EndpointStr = selfPrimaryEndpoint.StringRepresentation,
@@ -533,9 +533,7 @@ namespace Barotrauma.Networking
 
         private static void ForwardToServerProcess(IWriteMessage msg)
         {
-            byte[] bufToSend = new byte[msg.LengthBytes];
-            msg.Buffer[..msg.LengthBytes].CopyTo(bufToSend.AsSpan());
-            ChildServerRelay.Write(bufToSend);
+            ChildServerRelay.Write(msg.Buffer);
         }
 
         private void ForwardToRemotePeer(DeliveryMethod deliveryMethod, P2PEndpoint recipient, IWriteMessage outMsg)

--- a/Barotrauma/BarotraumaServer/ServerSource/Networking/GameServer.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Networking/GameServer.cs
@@ -786,12 +786,12 @@ namespace Barotrauma.Networking
 
 
         private double lastPingTime;
-        private byte[] lastPingData;
+        private PooledBuffer lastPingData;
         private void UpdatePing()
         {
             if (Timing.TotalTime > lastPingTime + 1.0)
             {
-                lastPingData ??= new byte[64];
+                lastPingData ??= new PooledBuffer(64);
                 for (int i = 0; i < lastPingData.Length; i++)
                 {
                     lastPingData[i] = (byte)Rand.Range(33, 126);

--- a/Barotrauma/BarotraumaServer/ServerSource/Networking/NetEntityEvent/ServerEntityEventManager.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Networking/NetEntityEvent/ServerEntityEventManager.cs
@@ -526,7 +526,7 @@ namespace Barotrauma.Networking
                     UInt16 characterStateID = msg.ReadUInt16();
 
                     ReadWriteMessage buffer = new ReadWriteMessage();
-                    byte[] temp = msg.ReadBytes(msgLength - 2);
+                    PooledBuffer temp = msg.ReadBytes(msgLength - 2);
                     buffer.WriteBytes(temp, 0, msgLength - 2);
                     buffer.BitPosition = 0;
                     BufferEvent(

--- a/Barotrauma/BarotraumaServer/ServerSource/Networking/Primitives/Peers/Server/LidgrenServerPeer.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Networking/Primitives/Peers/Server/LidgrenServerPeer.cs
@@ -408,7 +408,7 @@ namespace Barotrauma.Networking
                 return;
             }
 
-            byte[] bufAux = msg.PrepareForSending(compressPastThreshold, out bool isCompressed, out _);
+            PooledBuffer bufAux = msg.PrepareForSending(compressPastThreshold, out bool isCompressed, out _);
 
 #if DEBUG
             ToolBox.ThrowIfNull(netPeerConfiguration);

--- a/Barotrauma/BarotraumaServer/ServerSource/Networking/Primitives/Peers/Server/P2PServerPeer.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Networking/Primitives/Peers/Server/P2PServerPeer.cs
@@ -73,7 +73,7 @@ namespace Barotrauma.Networking
 
             try
             {
-                foreach (byte[] incBuf in ChildServerRelay.Read())
+                foreach (PooledBuffer incBuf in ChildServerRelay.Read())
                 {
                     P2PEndpoint? senderEndpoint = null;
                     try
@@ -205,7 +205,7 @@ namespace Barotrauma.Networking
                         var completeMessageOption = connectedClient.Defragmenter.ProcessIncomingFragment(fragment);
                         if (!completeMessageOption.TryUnwrap(out var completeMessage)) { return; }
 
-                        IReadMessage msg = new ReadOnlyMessage(completeMessage.ToArray(), false, 0, completeMessage.Length, connectedClient.Connection);
+                        IReadMessage msg = new ReadOnlyMessage(new PooledBuffer(completeMessage), false, 0, completeMessage.Length, connectedClient.Connection);
                         callbacks.OnMessageReceived.Invoke(connectedClient.Connection, msg);
                     }
                     else
@@ -316,7 +316,7 @@ namespace Barotrauma.Networking
                 DebugConsole.ThrowError($"Tried to send message to unauthenticated connection: {p2pConn.AccountInfo.AccountId}");
                 return;
             }
-            byte[] bufAux = msg.PrepareForSending(compressPastThreshold, out bool isCompressed, out _);
+            PooledBuffer bufAux = msg.PrepareForSending(compressPastThreshold, out bool isCompressed, out _);
 
             if (bufAux.Length > MessageFragment.MaxSize && conn != OwnerConnection)
             {
@@ -404,9 +404,8 @@ namespace Barotrauma.Networking
 
         private static void ForwardToOwnerProcess(IWriteMessage msg)
         {
-            byte[] bufToSend = (byte[])msg.Buffer.Clone();
-            Array.Resize(ref bufToSend, msg.LengthBytes);
-            ChildServerRelay.Write(bufToSend);
+            msg.Buffer.Resize(msg.LengthBytes);
+            ChildServerRelay.Write(msg.Buffer);
         }
 
         protected override void ProcessAuthTicket(ClientAuthTicketAndVersionPacket packet, PendingClient pendingClient)

--- a/Barotrauma/BarotraumaShared/SharedSource/Networking/ChildServerRelay.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Networking/ChildServerRelay.cs
@@ -45,10 +45,10 @@ namespace Barotrauma.Networking
         private static int readIncOffset;
         private static int readIncTotal;
 
-        private static ConcurrentQueue<byte[]> msgsToWrite;
+        private static ConcurrentQueue<PooledBuffer> msgsToWrite;
         private static ConcurrentQueue<string> errorsToWrite;
 
-        private static ConcurrentQueue<byte[]> msgsToRead;
+        private static ConcurrentQueue<PooledBuffer> msgsToRead;
 
         private static Thread readThread;
         private static Thread writeThread;
@@ -64,10 +64,10 @@ namespace Barotrauma.Networking
 
             readTempBytes = new byte[ReadBufferSize];
 
-            msgsToWrite = new ConcurrentQueue<byte[]>();
+            msgsToWrite = new ConcurrentQueue<PooledBuffer>();
             errorsToWrite = new ConcurrentQueue<string>();
             
-            msgsToRead = new ConcurrentQueue<byte[]>();
+            msgsToRead = new ConcurrentQueue<PooledBuffer>();
 
             readCancellationToken = new CancellationTokenSource();
 
@@ -211,7 +211,7 @@ namespace Barotrauma.Networking
                                 | (msgLengthSpan[3] << 24);
                 WriteStatus writeStatus = (WriteStatus)msgLengthSpan[4];
 
-                byte[] msg = msgLength > 0 ? new byte[msgLength] : Array.Empty<byte>();
+                PooledBuffer msg = msgLength > 0 ? new PooledBuffer(msgLength) : new PooledBuffer(0);
                 if (msg.Length > 0 && !readBytes(msg.AsSpan())) { status = StatusEnum.ShutDown; break; }
 
                 switch (writeStatus)
@@ -314,7 +314,7 @@ namespace Barotrauma.Networking
             }
         }
 
-        public static void Write(byte[] msg)
+        public static void Write(PooledBuffer msg)
         {
             if (HasShutDown) { return; }
 
@@ -331,7 +331,7 @@ namespace Barotrauma.Networking
         private static readonly Stopwatch stopwatch = new Stopwatch();
         private const int MaxMilliseconds = 8;
 
-        public static IEnumerable<byte[]> Read()
+        public static IEnumerable<PooledBuffer> Read()
         {
             stopwatch.Restart();
 
@@ -357,7 +357,7 @@ namespace Barotrauma.Networking
             stopwatch.Stop();
         }
 
-        private static bool ReadSingleMessage(out byte[] msg)
+        private static bool ReadSingleMessage(out PooledBuffer msg)
         {
             if (HasShutDown) { msg = null; return false; }
 

--- a/Barotrauma/BarotraumaShared/SharedSource/Networking/INetSerializableStruct.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Networking/INetSerializableStruct.cs
@@ -188,7 +188,11 @@ namespace Barotrauma
             { type => IsOfGenericType(type, typeof(ImmutableArray<>)), CreateImmutableArrayBehavior },
 
             // Option
-            { type => IsOfGenericType(type, typeof(Option<>)), CreateOptionBehavior }
+            { type => IsOfGenericType(type, typeof(Option<>)), CreateOptionBehavior },
+
+            //PooledBuffer
+            { type => type == typeof(PooledBuffer), CreatePooledBufferBehavior }
+
         }.ToImmutableDictionary();
 
         /// <param name="behaviorGenericParam">The type that the behavior handles</param>
@@ -227,6 +231,13 @@ namespace Barotrauma
                 arrayType.GetElementType()!,
                 ReadArray<object>,
                 WriteArray<object>);
+
+        private static IReadWriteBehavior CreatePooledBufferBehavior(Type arrayType) =>
+            CreateBehavior(
+                typeof(PooledBuffer),
+                typeof(PooledBuffer), // funcGenericParam matches
+                ReadPooledBuffer<byte>,     // Matches ReadDelegate<PooledBuffer>
+                WritePooledBuffer<byte>);
 
         private static IReadWriteBehavior CreateINetSerializableStructBehavior(Type structType) =>
             CreateBehavior(
@@ -519,7 +530,36 @@ namespace Barotrauma
             WriteSingle(x, attribute, msg, bitField);
             WriteSingle(y, attribute, msg, bitField);
         }
+        private static PooledBuffer ReadPooledBuffer<T>(IReadMessage inc, NetworkSerialize attribute, ReadOnlyBitField bitField) where T : notnull
+        {
+            int length = bitField.ReadInteger(0, attribute.ArrayMaxSize);
+            PooledBuffer buffer = new PooledBuffer(length);
+            
+            if (!TryFindBehavior(out ReadWriteBehavior<byte> behavior))
+            {
+                throw new InvalidOperationException($"Could not find suitable behavior for type {typeof(byte)} in {nameof(ReadArray)}");
+            }
 
+            for (int i = 0; i < length; i++)
+            {
+                buffer[i] = behavior.ReadActionDirect(inc, attribute, bitField);
+            }
+            return buffer;
+        }
+        private static void WritePooledBuffer<T>(PooledBuffer buffer, NetworkSerialize attribute, IWriteMessage msg, WriteOnlyBitField bitField) where T : notnull
+        {
+            bitField.WriteInteger(buffer.Length, 0, attribute.ArrayMaxSize);
+
+            if (!TryFindBehavior(out ReadWriteBehavior<byte> behavior))
+            {
+                throw new InvalidOperationException($"Could not find suitable behavior for type {typeof(byte)} in {nameof(WriteArray)}");
+            }
+
+            foreach (byte o in buffer)
+            {
+                behavior.WriteActionDirect(o, attribute, msg, bitField);
+            }
+        }
         private static readonly Range<Int64> ValidTickRange
             = new Range<Int64>(
                 start: DateTime.MinValue.Ticks,

--- a/Barotrauma/BarotraumaShared/SharedSource/Networking/Primitives/Message/IReadMessage.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Networking/Primitives/Message/IReadMessage.cs
@@ -29,7 +29,7 @@ namespace Barotrauma.Networking
 
         int BitPosition { get; set; }
         int BytePosition { get; }
-        byte[] Buffer { get; }
+        PooledBuffer Buffer { get; }
         int LengthBits { get; set; }
         int LengthBytes { get; }
 

--- a/Barotrauma/BarotraumaShared/SharedSource/Networking/Primitives/Message/IReadMessage.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Networking/Primitives/Message/IReadMessage.cs
@@ -25,7 +25,7 @@ namespace Barotrauma.Networking
         Microsoft.Xna.Framework.Color ReadColorR8G8B8A8();
         int ReadRangedInteger(int min, int max);
         Single ReadRangedSingle(Single min, Single max, int bitCount);
-        byte[] ReadBytes(int numberOfBytes);
+        PooledBuffer ReadBytes(int numberOfBytes);
 
         int BitPosition { get; set; }
         int BytePosition { get; }

--- a/Barotrauma/BarotraumaShared/SharedSource/Networking/Primitives/Message/IWriteMessage.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Networking/Primitives/Message/IWriteMessage.cs
@@ -22,7 +22,7 @@ namespace Barotrauma.Networking
         void WriteIdentifier(Identifier val);
         void WriteRangedInteger(int val, int min, int max);
         void WriteRangedSingle(Single val, Single min, Single max, int bitCount);
-        void WriteBytes(byte[] val, int startIndex, int length);
+        void WriteBytes(PooledBuffer val, int startIndex, int length);
 
         PooledBuffer PrepareForSending(bool compressPastThreshold, out bool isCompressed, out int outLength);
 

--- a/Barotrauma/BarotraumaShared/SharedSource/Networking/Primitives/Message/IWriteMessage.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Networking/Primitives/Message/IWriteMessage.cs
@@ -24,11 +24,11 @@ namespace Barotrauma.Networking
         void WriteRangedSingle(Single val, Single min, Single max, int bitCount);
         void WriteBytes(byte[] val, int startIndex, int length);
 
-        byte[] PrepareForSending(bool compressPastThreshold, out bool isCompressed, out int outLength);
+        PooledBuffer PrepareForSending(bool compressPastThreshold, out bool isCompressed, out int outLength);
 
         int BitPosition { get; set; }
         int BytePosition { get; }
-        byte[] Buffer { get; }
+        PooledBuffer Buffer { get; }
         int LengthBits { get; set; }
         int LengthBytes { get; }
     }

--- a/Barotrauma/BarotraumaShared/SharedSource/Networking/Primitives/Message/Message.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Networking/Primitives/Message/Message.cs
@@ -46,7 +46,7 @@ namespace Barotrauma.Networking
             bitLength = Math.Max(bitLength, bitPos);
         }
         
-        internal static void WriteBoolean(ref byte[] buf, ref int bitPos, ref int bitLength, bool val)
+        internal static void WriteBoolean(ref PooledBuffer buf, ref int bitPos, ref int bitLength, bool val)
         {
 #if DEBUG
             int resetPos = bitPos;
@@ -71,7 +71,7 @@ namespace Barotrauma.Networking
 #endif
         }
 
-        internal static void WritePadBits(ref byte[] buf, ref int bitPos, ref int bitLength)
+        internal static void WritePadBits(ref PooledBuffer buf, ref int bitPos, ref int bitLength)
         {
             int bitOffset = bitPos % 8;
             bitPos += ((8 - bitOffset) % 8);
@@ -79,7 +79,7 @@ namespace Barotrauma.Networking
             EnsureBufferSize(ref buf, bitPos);
         }
 
-        internal static void WriteByte(ref byte[] buf, ref int bitPos, ref int bitLength, byte val)
+        internal static void WriteByte(ref PooledBuffer buf, ref int bitPos, ref int bitLength, byte val)
         {
             EnsureBufferSize(ref buf, bitPos + 8);
             NetBitWriter.WriteByte(val, 8, buf, bitPos);
@@ -87,7 +87,7 @@ namespace Barotrauma.Networking
             UpdateBitLength(ref bitLength, bitPos);
         }
 
-        internal static void WriteUInt16(ref byte[] buf, ref int bitPos, ref int bitLength, UInt16 val)
+        internal static void WriteUInt16(ref PooledBuffer buf, ref int bitPos, ref int bitLength, UInt16 val)
         {
             EnsureBufferSize(ref buf, bitPos + 16);
             NetBitWriter.WriteUInt16(val, 16, buf, bitPos);
@@ -95,7 +95,7 @@ namespace Barotrauma.Networking
             UpdateBitLength(ref bitLength, bitPos);
         }
 
-        internal static void WriteInt16(ref byte[] buf, ref int bitPos, ref int bitLength, Int16 val)
+        internal static void WriteInt16(ref PooledBuffer buf, ref int bitPos, ref int bitLength, Int16 val)
         {
             EnsureBufferSize(ref buf, bitPos + 16);
             NetBitWriter.WriteUInt16((UInt16)val, 16, buf, bitPos);
@@ -103,7 +103,7 @@ namespace Barotrauma.Networking
             UpdateBitLength(ref bitLength, bitPos);
         }
 
-        internal static void WriteUInt32(ref byte[] buf, ref int bitPos, ref int bitLength, UInt32 val)
+        internal static void WriteUInt32(ref PooledBuffer buf, ref int bitPos, ref int bitLength, UInt32 val)
         {
             EnsureBufferSize(ref buf, bitPos + 32);
             NetBitWriter.WriteUInt32(val, 32, buf, bitPos);
@@ -111,7 +111,7 @@ namespace Barotrauma.Networking
             UpdateBitLength(ref bitLength, bitPos);
         }
 
-        internal static void WriteInt32(ref byte[] buf, ref int bitPos, ref int bitLength, Int32 val)
+        internal static void WriteInt32(ref PooledBuffer buf, ref int bitPos, ref int bitLength, Int32 val)
         {
             EnsureBufferSize(ref buf, bitPos + 32);
             NetBitWriter.WriteUInt32((UInt32)val, 32, buf, bitPos);
@@ -119,7 +119,7 @@ namespace Barotrauma.Networking
             UpdateBitLength(ref bitLength, bitPos);
         }
 
-        internal static void WriteUInt64(ref byte[] buf, ref int bitPos, ref int bitLength, UInt64 val)
+        internal static void WriteUInt64(ref PooledBuffer buf, ref int bitPos, ref int bitLength, UInt64 val)
         {
             EnsureBufferSize(ref buf, bitPos + 64);
             NetBitWriter.WriteUInt64(val, 64, buf, bitPos);
@@ -127,7 +127,7 @@ namespace Barotrauma.Networking
             UpdateBitLength(ref bitLength, bitPos);
         }
 
-        internal static void WriteInt64(ref byte[] buf, ref int bitPos, ref int bitLength, Int64 val)
+        internal static void WriteInt64(ref PooledBuffer buf, ref int bitPos, ref int bitLength, Int64 val)
         {
             EnsureBufferSize(ref buf, bitPos + 64);
             NetBitWriter.WriteUInt64((UInt64)val, 64, buf, bitPos);
@@ -135,7 +135,7 @@ namespace Barotrauma.Networking
             UpdateBitLength(ref bitLength, bitPos);
         }
 
-        internal static void WriteSingle(ref byte[] buf, ref int bitPos, ref int bitLength, Single val)
+        internal static void WriteSingle(ref PooledBuffer buf, ref int bitPos, ref int bitLength, Single val)
         {
             // Use union to avoid BitConverter.GetBytes() which allocates memory on the heap
             SingleUIntUnion su;
@@ -149,7 +149,7 @@ namespace Barotrauma.Networking
             UpdateBitLength(ref bitLength, bitPos);
         }
 
-        internal static void WriteDouble(ref byte[] buf, ref int bitPos, ref int bitLength, Double val)
+        internal static void WriteDouble(ref PooledBuffer buf, ref int bitPos, ref int bitLength, Double val)
         {
             EnsureBufferSize(ref buf, bitPos + 64);
 
@@ -157,7 +157,7 @@ namespace Barotrauma.Networking
             WriteBytes(ref buf, ref bitPos, ref bitLength, bytes, 0, 8);
         }
 
-        internal static void WriteColorR8G8B8(ref byte[] buf, ref int bitPos, ref int bitLength, Color val)
+        internal static void WriteColorR8G8B8(ref PooledBuffer buf, ref int bitPos, ref int bitLength, Color val)
         {
             EnsureBufferSize(ref buf, bitPos + 24);
 
@@ -166,7 +166,7 @@ namespace Barotrauma.Networking
             WriteByte(ref buf, ref bitPos, ref bitLength, val.B);
         }
 
-        internal static void WriteColorR8G8B8A8(ref byte[] buf, ref int bitPos, ref int bitLength, Color val)
+        internal static void WriteColorR8G8B8A8(ref PooledBuffer buf, ref int bitPos, ref int bitLength, Color val)
         {
             EnsureBufferSize(ref buf, bitPos + 32);
 
@@ -176,7 +176,7 @@ namespace Barotrauma.Networking
             WriteByte(ref buf, ref bitPos, ref bitLength, val.A);
         }
 
-        internal static void WriteString(ref byte[] buf, ref int bitPos, ref int bitLength, string val)
+        internal static void WriteString(ref PooledBuffer buf, ref int bitPos, ref int bitLength, string val)
         {
             if (string.IsNullOrEmpty(val))
             {
@@ -189,7 +189,7 @@ namespace Barotrauma.Networking
             WriteBytes(ref buf, ref bitPos, ref bitLength, bytes, 0, bytes.Length);
         }
 
-        internal static void WriteVariableUInt32(ref byte[] buf, ref int bitPos, ref int bitLength, uint value)
+        internal static void WriteVariableUInt32(ref PooledBuffer buf, ref int bitPos, ref int bitLength, uint value)
         {
             uint remainingValue = value;
             while (remainingValue >= 0x80)
@@ -201,7 +201,7 @@ namespace Barotrauma.Networking
             WriteByte(ref buf, ref bitPos, ref bitLength, (byte)remainingValue);
         }
 
-        internal static void WriteRangedInteger(ref byte[] buf, ref int bitPos, ref int bitLength, int val, int min, int max)
+        internal static void WriteRangedInteger(ref PooledBuffer buf, ref int bitPos, ref int bitLength, int val, int min, int max)
         {
             uint range = (uint)(max - min);
             int numberOfBits = NetUtility.BitsToHoldUInt(range);
@@ -214,7 +214,7 @@ namespace Barotrauma.Networking
             UpdateBitLength(ref bitLength, bitPos);
         }
 
-        internal static void WriteRangedSingle(ref byte[] buf, ref int bitPos, ref int bitLength, Single val, Single min, Single max, int numberOfBits)
+        internal static void WriteRangedSingle(ref PooledBuffer buf, ref int bitPos, ref int bitLength, Single val, Single min, Single max, int numberOfBits)
         {
             float range = max - min;
             float unit = ((val - min) / range);
@@ -227,7 +227,7 @@ namespace Barotrauma.Networking
             UpdateBitLength(ref bitLength, bitPos);
         }
 
-        internal static void WriteBytes(ref byte[] buf, ref int bitPos, ref int bitLength, byte[] val, int pos, int length)
+        internal static void WriteBytes(ref PooledBuffer buf, ref int bitPos, ref int bitLength, byte[] val, int pos, int length)
         {
             EnsureBufferSize(ref buf, bitPos + length * 8);
             NetBitWriter.WriteBytes(val, pos, length, buf, bitPos);
@@ -235,25 +235,25 @@ namespace Barotrauma.Networking
             UpdateBitLength(ref bitLength, bitPos);
         }
 
-        internal static void EnsureBufferSize(ref byte[] buf, int numberOfBits)
+        internal static void EnsureBufferSize(ref PooledBuffer buf, int numberOfBits)
         {
             int byteLen = (numberOfBits + 7) / 8;
             if (buf == null)
             {
-                buf = new byte[byteLen + MsgConstants.BufferOverAllocateAmount];
+                buf = new PooledBuffer(byteLen + MsgConstants.BufferOverAllocateAmount);
                 return;
             }
 
             if (buf.Length < byteLen)
             {
-                Array.Resize(ref buf, byteLen + MsgConstants.BufferOverAllocateAmount);
+               buf.Resize(byteLen + MsgConstants.BufferOverAllocateAmount);
             }
         }
     }
 
     internal static class MsgReader
     {
-        internal static bool ReadBoolean(byte[] buf, ref int bitPos)
+        internal static bool ReadBoolean(PooledBuffer buf, ref int bitPos)
         {
             byte retval = NetBitWriter.ReadByte(buf, 1, bitPos);
             bitPos++;
@@ -266,44 +266,44 @@ namespace Barotrauma.Networking
             bitPos += (8 - bitOffset) % 8;
         }
 
-        internal static byte ReadByte(byte[] buf, ref int bitPos)
+        internal static byte ReadByte(PooledBuffer buf, ref int bitPos)
         {
             byte retval = NetBitWriter.ReadByte(buf, 8, bitPos);
             bitPos += 8;
             return retval;
         }
 
-        internal static byte PeekByte(byte[] buf, ref int bitPos)
+        internal static byte PeekByte(PooledBuffer buf, ref int bitPos)
         {
             byte retval = NetBitWriter.ReadByte(buf, 8, bitPos);
             return retval;
         }
 
-        internal static UInt16 ReadUInt16(byte[] buf, ref int bitPos)
+        internal static UInt16 ReadUInt16(PooledBuffer buf, ref int bitPos)
         {
             uint retval = NetBitWriter.ReadUInt16(buf, 16, bitPos);
             bitPos += 16;
             return (ushort)retval;
         }
 
-        internal static Int16 ReadInt16(byte[] buf, ref int bitPos)
+        internal static Int16 ReadInt16(PooledBuffer buf, ref int bitPos)
         {
             return (Int16)ReadUInt16(buf, ref bitPos);
         }
 
-        internal static UInt32 ReadUInt32(byte[] buf, ref int bitPos)
+        internal static UInt32 ReadUInt32(PooledBuffer buf, ref int bitPos)
         {
             uint retval = NetBitWriter.ReadUInt32(buf, 32, bitPos);
             bitPos += 32;
             return retval;
         }
 
-        internal static Int32 ReadInt32(byte[] buf, ref int bitPos)
+        internal static Int32 ReadInt32(PooledBuffer buf, ref int bitPos)
         {
             return (Int32)ReadUInt32(buf, ref bitPos);
         }
 
-        internal static UInt64 ReadUInt64(byte[] buf, ref int bitPos)
+        internal static UInt64 ReadUInt64(PooledBuffer buf, ref int bitPos)
         {
             ulong low = NetBitWriter.ReadUInt32(buf, 32, bitPos);
             bitPos += 32;
@@ -313,12 +313,12 @@ namespace Barotrauma.Networking
             return retval;
         }
 
-        internal static Int64 ReadInt64(byte[] buf, ref int bitPos)
+        internal static Int64 ReadInt64(PooledBuffer buf, ref int bitPos)
         {
             return (Int64)ReadUInt64(buf, ref bitPos);
         }
 
-        internal static Single ReadSingle(byte[] buf, ref int bitPos)
+        internal static Single ReadSingle(PooledBuffer buf, ref int bitPos)
         {
             if ((bitPos & 7) == 0) // read directly
             {
@@ -331,7 +331,7 @@ namespace Barotrauma.Networking
             return BitConverter.ToSingle(bytes, 0);
         }
 
-        internal static Double ReadDouble(byte[] buf, ref int bitPos)
+        internal static Double ReadDouble(PooledBuffer buf, ref int bitPos)
         {
             if ((bitPos & 7) == 0) // read directly
             {
@@ -345,7 +345,7 @@ namespace Barotrauma.Networking
             return BitConverter.ToDouble(bytes, 0);
         }
 
-        internal static Color ReadColorR8G8B8(byte[] buf, ref int bitPos)
+        internal static Color ReadColorR8G8B8(PooledBuffer buf, ref int bitPos)
         {
             byte r = ReadByte(buf, ref bitPos);
             byte g = ReadByte(buf, ref bitPos);
@@ -353,7 +353,7 @@ namespace Barotrauma.Networking
             return new Color(r, g, b, (byte)255);
         }
 
-        internal static Color ReadColorR8G8B8A8(byte[] buf, ref int bitPos)
+        internal static Color ReadColorR8G8B8A8(PooledBuffer buf, ref int bitPos)
         {
             byte r = ReadByte(buf, ref bitPos);
             byte g = ReadByte(buf, ref bitPos);
@@ -362,7 +362,7 @@ namespace Barotrauma.Networking
             return new Color(r, g, b, a);
         }
 
-        internal static UInt32 ReadVariableUInt32(byte[] buf, ref int bitPos)
+        internal static UInt32 ReadVariableUInt32(PooledBuffer buf, ref int bitPos)
         {
             int bitLength = buf.Length * 8;
 
@@ -380,7 +380,7 @@ namespace Barotrauma.Networking
             return (uint)result;
         }
 
-        internal static String ReadString(byte[] buf, ref int bitPos)
+        internal static String ReadString(PooledBuffer buf, ref int bitPos)
         {
             int bitLength = buf.Length * 8;
             int byteLen = (int)ReadVariableUInt32(buf, ref bitPos);
@@ -405,7 +405,7 @@ namespace Barotrauma.Networking
             return Encoding.UTF8.GetString(bytes, 0, bytes.Length);
         }
 
-        internal static int ReadRangedInteger(byte[] buf, ref int bitPos, int min, int max)
+        internal static int ReadRangedInteger(PooledBuffer buf, ref int bitPos, int min, int max)
         {
             uint range = (uint)(max - min);
             int numBits = NetUtility.BitsToHoldUInt(range);
@@ -416,7 +416,7 @@ namespace Barotrauma.Networking
             return (int)(min + rvalue);
         }
 
-        internal static Single ReadRangedSingle(byte[] buf, ref int bitPos, Single min, Single max, int bitCount)
+        internal static Single ReadRangedSingle(PooledBuffer buf, ref int bitPos, Single min, Single max, int bitCount)
         {
             int maxInt = (1 << bitCount) - 1;
             int intVal = ReadRangedInteger(buf, ref bitPos, 0, maxInt);
@@ -424,7 +424,7 @@ namespace Barotrauma.Networking
             return min + range * intVal / maxInt;
         }
 
-        internal static byte[] ReadBytes(byte[] buf, ref int bitPos, int numberOfBytes)
+        internal static byte[] ReadBytes(PooledBuffer buf, ref int bitPos, int numberOfBytes)
         {
             byte[] retval = new byte[numberOfBytes];
             NetBitWriter.ReadBytes(buf, numberOfBytes, bitPos, retval, 0);
@@ -435,7 +435,7 @@ namespace Barotrauma.Networking
 
     internal sealed class WriteOnlyMessage : IWriteMessage
     {
-        private byte[] buf = new byte[MsgConstants.InitialBufferSize];
+        private PooledBuffer buf = new PooledBuffer(MsgConstants.InitialBufferSize);
         private int seekPos;
         private int lengthBits;
 
@@ -447,7 +447,7 @@ namespace Barotrauma.Networking
 
         public int BytePosition => seekPos / 8;
 
-        public byte[] Buffer => buf;
+        public PooledBuffer Buffer => buf;
 
         public int LengthBits
         {
@@ -561,13 +561,13 @@ namespace Barotrauma.Networking
             MsgWriter.WriteBytes(ref buf, ref seekPos, ref lengthBits, val, startPos, length);
         }
 
-        public byte[] PrepareForSending(bool compressPastThreshold, out bool isCompressed, out int length)
+        public PooledBuffer PrepareForSending(bool compressPastThreshold, out bool isCompressed, out int length)
         {
-            byte[] outBuf;
+            PooledBuffer outBuf;
             if (LengthBytes <= MsgConstants.CompressionThreshold || !compressPastThreshold)
             {
                 isCompressed = false;
-                outBuf = new byte[LengthBytes];
+                outBuf = new PooledBuffer(LengthBytes);
                 Array.Copy(buf, outBuf, LengthBytes);
                 length = LengthBytes;
             }
@@ -586,14 +586,14 @@ namespace Barotrauma.Networking
                 if (compressedBuf.Length >= LengthBytes)
                 {
                     isCompressed = false;
-                    outBuf = new byte[LengthBytes];
+                    outBuf = new PooledBuffer(LengthBytes);
                     Array.Copy(buf, outBuf, LengthBytes);
                     length = LengthBytes;
                 }
                 else
                 {
                     isCompressed = true;
-                    outBuf = compressedBuf;
+                    outBuf = new PooledBuffer(compressedBuf);
                     length = outBuf.Length;
                     DebugConsole.Log($"Compressed message: {LengthBytes} to {length}");
                 }
@@ -616,7 +616,7 @@ namespace Barotrauma.Networking
 
         public int BytePosition => seekPos / 8;
 
-        public byte[] Buffer { get; }
+        public PooledBuffer Buffer { get; }
 
         public int LengthBits
         {
@@ -636,12 +636,12 @@ namespace Barotrauma.Networking
 
         public NetworkConnection Sender { get; }
 
-        public ReadOnlyMessage(byte[] inBuf, bool isCompressed, int startPos, int byteLength, NetworkConnection sender)
+        public ReadOnlyMessage(PooledBuffer inBuf, bool isCompressed, int startPos, int byteLength, NetworkConnection sender)
         {
             Sender = sender;
             if (isCompressed)
             {
-                byte[] decompressedData;
+                PooledBuffer decompressedData;
                 using (MemoryStream input = new MemoryStream(inBuf, startPos, byteLength))
                 {
                     using (MemoryStream output = new MemoryStream())
@@ -651,11 +651,10 @@ namespace Barotrauma.Networking
                             dstream.CopyTo(output);
                         }
 
-                        decompressedData = output.ToArray();
+                        Buffer = new PooledBuffer(output.ToArray());
                     }
                 }
-
-                Buffer = new byte[decompressedData.Length];
+                /*
                 try
                 {
                     Array.Copy(decompressedData, 0, Buffer, 0, decompressedData.Length);
@@ -665,13 +664,13 @@ namespace Barotrauma.Networking
                     throw new ArgumentException(
                         $"Failed to copy the incoming compressed buffer. Source buffer length: {decompressedData.Length}, start position: {0}, length: {decompressedData.Length}, destination buffer length: {Buffer.Length}.", e);
                 }
-
-                lengthBits = decompressedData.Length * 8;
+                */
+                lengthBits = Buffer.Length * 8;
                 DebugConsole.Log("Decompressing message: " + byteLength + " to " + LengthBytes);
             }
             else
             {
-                Buffer = new byte[inBuf.Length];
+                Buffer = new PooledBuffer(inBuf.Length);
                 try
                 {
                     Array.Copy(inBuf, startPos, Buffer, 0, byteLength);
@@ -787,20 +786,20 @@ namespace Barotrauma.Networking
 
     internal sealed class ReadWriteMessage : IWriteMessage, IReadMessage
     {
-        private byte[] buf;
+        private PooledBuffer buf;
         private int seekPos;
         private int lengthBits;
 
         public ReadWriteMessage()
         {
-            buf = new byte[MsgConstants.InitialBufferSize];
+            buf = new PooledBuffer(MsgConstants.InitialBufferSize);
             seekPos = 0;
             lengthBits = 0;
         }
 
-        public ReadWriteMessage(byte[] b, int bitPos, int lBits, bool copyBuf)
+        public ReadWriteMessage(PooledBuffer b, int bitPos, int lBits, bool copyBuf)
         {
-            buf = copyBuf ? (byte[])b.Clone() : b;
+            buf = copyBuf ? b.Clone() : b;
             seekPos = bitPos;
             lengthBits = lBits;
         }
@@ -813,7 +812,7 @@ namespace Barotrauma.Networking
 
         public int BytePosition => seekPos / 8;
 
-        public byte[] Buffer => buf;
+        public PooledBuffer Buffer => buf;
 
         public int LengthBits
         {
@@ -1025,7 +1024,7 @@ namespace Barotrauma.Networking
             return MsgReader.ReadBytes(buf, ref seekPos, numberOfBytes);
         }
 
-        public byte[] PrepareForSending(bool compressPastThreshold, out bool isCompressed, out int outLength)
+        public PooledBuffer PrepareForSending(bool compressPastThreshold, out bool isCompressed, out int outLength)
         {
             throw new InvalidOperationException("ReadWriteMessages are not to be sent");
         }

--- a/Barotrauma/BarotraumaShared/SharedSource/Networking/Primitives/Message/Message.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Networking/Primitives/Message/Message.cs
@@ -401,8 +401,8 @@ namespace Barotrauma.Networking
                 return retval;
             }
 
-            byte[] bytes = ReadBytes(buf, ref bitPos, byteLen);
-            return Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+            PooledBuffer bytes = ReadBytes(buf, ref bitPos, byteLen);
+            return Encoding.UTF8.GetString(bytes, 0, byteLen);
         }
 
         internal static int ReadRangedInteger(PooledBuffer buf, ref int bitPos, int min, int max)
@@ -424,9 +424,9 @@ namespace Barotrauma.Networking
             return min + range * intVal / maxInt;
         }
 
-        internal static byte[] ReadBytes(PooledBuffer buf, ref int bitPos, int numberOfBytes)
+        internal static PooledBuffer ReadBytes(PooledBuffer buf, ref int bitPos, int numberOfBytes)
         {
-            byte[] retval = new byte[numberOfBytes];
+            PooledBuffer retval = new PooledBuffer(numberOfBytes);
             NetBitWriter.ReadBytes(buf, numberOfBytes, bitPos, retval, 0);
             bitPos += 8 * numberOfBytes;
             return retval;
@@ -556,7 +556,7 @@ namespace Barotrauma.Networking
             MsgWriter.WriteRangedSingle(ref buf, ref seekPos, ref lengthBits, val, min, max, bitCount);
         }
 
-        public void WriteBytes(byte[] val, int startPos, int length)
+        public void WriteBytes(PooledBuffer val, int startPos, int length)
         {
             MsgWriter.WriteBytes(ref buf, ref seekPos, ref lengthBits, val, startPos, length);
         }
@@ -654,17 +654,6 @@ namespace Barotrauma.Networking
                         Buffer = new PooledBuffer(output.ToArray());
                     }
                 }
-                /*
-                try
-                {
-                    Array.Copy(decompressedData, 0, Buffer, 0, decompressedData.Length);
-                }
-                catch (ArgumentException e)
-                {
-                    throw new ArgumentException(
-                        $"Failed to copy the incoming compressed buffer. Source buffer length: {decompressedData.Length}, start position: {0}, length: {decompressedData.Length}, destination buffer length: {Buffer.Length}.", e);
-                }
-                */
                 lengthBits = Buffer.Length * 8;
                 DebugConsole.Log("Decompressing message: " + byteLength + " to " + LengthBytes);
             }
@@ -778,7 +767,7 @@ namespace Barotrauma.Networking
             return MsgReader.ReadRangedSingle(Buffer, ref seekPos, min, max, bitCount);
         }
 
-        public byte[] ReadBytes(int numberOfBytes)
+        public PooledBuffer ReadBytes(int numberOfBytes)
         {
             return MsgReader.ReadBytes(Buffer, ref seekPos, numberOfBytes);
         }
@@ -922,7 +911,7 @@ namespace Barotrauma.Networking
             MsgWriter.WriteRangedSingle(ref buf, ref seekPos, ref lengthBits, val, min, max, bitCount);
         }
 
-        public void WriteBytes(byte[] val, int startPos, int length)
+        public void WriteBytes(PooledBuffer val, int startPos, int length)
         {
             MsgWriter.WriteBytes(ref buf, ref seekPos, ref lengthBits, val, startPos, length);
         }
@@ -1019,7 +1008,7 @@ namespace Barotrauma.Networking
             return MsgReader.ReadRangedSingle(buf, ref seekPos, min, max, bitCount);
         }
 
-        public byte[] ReadBytes(int numberOfBytes)
+        public PooledBuffer ReadBytes(int numberOfBytes)
         {
             return MsgReader.ReadBytes(buf, ref seekPos, numberOfBytes);
         }

--- a/Barotrauma/BarotraumaShared/SharedSource/Networking/Primitives/NetworkExtensions.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Networking/Primitives/NetworkExtensions.cs
@@ -42,7 +42,7 @@ namespace Barotrauma.Networking
 
         public static IReadMessage ToReadMessage(this NetIncomingMessage msg)
         {
-            return new ReadWriteMessage(msg.Data, 0, msg.LengthBits, copyBuf: false);
+            return new ReadWriteMessage(new PooledBuffer(msg.Data), 0, msg.LengthBits, copyBuf: false);
         }
     }
 

--- a/Barotrauma/BarotraumaShared/SharedSource/Networking/Primitives/NetworkPeerStructs.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Networking/Primitives/NetworkPeerStructs.cs
@@ -74,7 +74,7 @@ namespace Barotrauma.Networking
     [NetworkSerialize(ArrayMaxSize = ushort.MaxValue)]
     internal struct PeerPacketMessage : INetSerializableStruct
     {
-        public byte[] Buffer;
+        public PooledBuffer Buffer;
         public readonly int Length => Buffer.Length;
 
         public readonly IReadMessage GetReadMessageUncompressed() => new ReadWriteMessage(Buffer, 0, Length * 8, copyBuf: false);

--- a/Barotrauma/BarotraumaShared/SharedSource/Networking/Voip/VoipQueue.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Networking/Voip/VoipQueue.cs
@@ -6,7 +6,7 @@ namespace Barotrauma.Networking
     {
         public const int BUFFER_COUNT = 8;
         protected int[] bufferLengths;
-        protected byte[][] buffers;
+        protected PooledBuffer[] buffers;
         protected int newestBufferInd;
         protected bool firstRead;
 
@@ -70,10 +70,10 @@ namespace Barotrauma.Networking
             BufferToQueue = new byte[VoipConfig.MAX_COMPRESSED_SIZE];
             newestBufferInd = BUFFER_COUNT - 1;
             bufferLengths = new int[BUFFER_COUNT];
-            buffers = new byte[BUFFER_COUNT][];
+            buffers = new PooledBuffer[BUFFER_COUNT];
             for (int i = 0; i < BUFFER_COUNT; i++)
             {
-                buffers[i] = new byte[VoipConfig.MAX_COMPRESSED_SIZE];
+                buffers[i] = new PooledBuffer(VoipConfig.MAX_COMPRESSED_SIZE);
             }
             QueueID = id;
             CanSend = canSend;

--- a/Barotrauma/BarotraumaShared/SharedSource/Utils/MemPool.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Utils/MemPool.cs
@@ -1,0 +1,271 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Immutable;
+using System.Runtime.InteropServices;
+
+namespace Barotrauma
+{
+    /// <summary>
+    /// A generic wrapper around System.Buffers.ArrayPool to provide a consistent 
+    /// interface for renting and returning arrays, reducing GC pressure.
+    /// </summary>
+    public static class ArrayPoolBase<T>
+    {
+        // Using the shared pool which is thread-safe and optimized for general use.
+        private static readonly ArrayPool<T> Pool = ArrayPool<T>.Shared;
+
+        /// <summary>
+        /// Rents a buffer of at least the specified size. 
+        /// Note: The buffer is not guaranteed to be empty.
+        /// </summary>
+        public static T[] Rent(int size)
+        {
+            return Pool.Rent(size);
+        }
+
+        /// <summary>
+        /// Rents a buffer and ensures it is cleared before use.
+        /// Useful if the logic depends on default-initialized values.
+        /// </summary>
+        public static T[] RentZeroed(int size)
+        {
+            T[] buffer = Pool.Rent(size);
+            Array.Clear(buffer, 0, size);
+            return buffer;
+        }
+
+        /// <summary>
+        /// Returns the buffer to the pool for future reuse.
+        /// Clears the array to prevent memory leaks (sensitive data) 
+        /// and avoid accidental cross-contamination.
+        /// </summary>
+        public static void Return(T[] buffer)
+        {
+            Pool.Return(buffer, clearArray: true);
+        }
+
+        /// <summary>
+        /// Rents a buffer and executes an action. 
+        /// The buffer is automatically returned to the pool after the action completes.
+        /// This is the safest way to prevent memory leaks.
+        /// </summary>
+        public static void RentImmediate(int size, Action<T[]> action)
+        {
+            T[] buffer = Pool.Rent(size);
+            try
+            {
+                action(buffer);
+            }
+            finally
+            {
+                // Ensure the buffer is returned even if the action throws an exception.
+                Pool.Return(buffer, clearArray: true);
+            }
+        }
+
+        /// <summary>
+        /// Rents a buffer and executes a function that returns a result.
+        /// The buffer is returned to the pool immediately after the function finishes.
+        /// </summary>
+        public static TResult RentImmediate<TResult>(int size, Func<T[], TResult> func)
+        {
+            T[] buffer = Pool.Rent(size);
+            try
+            {
+                return func(buffer);
+            }
+            finally
+            {
+                Pool.Return(buffer, clearArray: true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Type-specific alias for managing float arrays efficiently.
+    /// </summary>
+    public static class FloatArrayPool
+    {
+        /// <summary>
+        /// Rents a buffer of at least the specified size. 
+        /// Note: The buffer is not guaranteed to be empty.
+        /// </summary>
+        public static float[] Rent(int size) => ArrayPoolBase<float>.Rent(size);
+        /// <summary>
+        /// Rents a buffer and ensures it is cleared before use.
+        /// Useful if the logic depends on default-initialized values.
+        /// </summary>
+        public static float[] RentZeroed(int size) => ArrayPoolBase<float>.RentZeroed(size);
+        /// <summary>
+        /// Returns the buffer to the pool for future reuse.
+        /// Clears the array to prevent memory leaks (sensitive data) 
+        /// and avoid accidental cross-contamination.
+        /// </summary>
+        public static void Return(float[] buffer) => ArrayPoolBase<float>.Return(buffer);
+        /// <summary>
+        /// Rents a buffer and executes an action. 
+        /// The buffer is automatically returned to the pool after the action completes.
+        /// This is the safest way to prevent memory leaks.
+        /// </summary>
+        public static void RentImmediate(int size, Action<float[]> action) => ArrayPoolBase<float>.RentImmediate(size, action);
+        /// <summary>
+        /// Rents a buffer and executes an action. 
+        /// The buffer is automatically returned to the pool after the action completes.
+        /// This is the safest way to prevent memory leaks.
+        /// </summary>
+        public static TResult RentImmediate<TResult>(int size, Func<float[], TResult> func) => ArrayPoolBase<float>.RentImmediate(size, func);
+    }
+
+    /// <summary>
+    /// Type-specific alias for managing byte arrays efficiently.
+    /// Frequently used for network packets and file streams.
+    /// </summary>
+    public static class ByteArrayPool
+    {
+        /// <summary>
+        /// Rents a buffer of at least the specified size. 
+        /// Note: The buffer is not guaranteed to be empty.
+        /// </summary>
+        public static byte[] Rent(int size) => ArrayPoolBase<byte>.Rent(size);
+        /// <summary>
+        /// Rents a buffer and ensures it is cleared before use.
+        /// Useful if the logic depends on default-initialized values.
+        /// </summary>
+        public static byte[] RentZeroed(int size) => ArrayPoolBase<byte>.RentZeroed(size);
+        /// <summary>
+        /// Returns the buffer to the pool for future reuse.
+        /// Clears the array to prevent memory leaks (sensitive data) 
+        /// and avoid accidental cross-contamination.
+        /// </summary>
+        public static void Return(byte[] buffer) => ArrayPoolBase<byte>.Return(buffer);
+        /// <summary>
+        /// Rents a buffer and executes an action. 
+        /// The buffer is automatically returned to the pool after the action completes.
+        /// This is the safest way to prevent memory leaks.
+        /// </summary>
+        public static void RentImmediate(int size, Action<byte[]> action) => ArrayPoolBase<byte>.RentImmediate(size, action);
+        /// <summary>
+        /// Rents a buffer and executes an action. 
+        /// The buffer is automatically returned to the pool after the action completes.
+        /// This is the safest way to prevent memory leaks.
+        /// </summary>
+        public static TResult RentImmediate<TResult>(int size, Func<byte[], TResult> func) => ArrayPoolBase<byte>.RentImmediate(size, func);
+    }
+    public class PooledBuffer : IDisposable
+    {
+        public byte[] Array { get; private set; }
+        public int Length { get; private set; }
+        private bool _disposed;
+
+        public PooledBuffer(int size)
+        {
+            Array = ByteArrayPool.Rent(size);
+            Length = size;
+            _disposed = false;
+        }
+        public PooledBuffer(byte[] data)
+        {
+            Array = ByteArrayPool.Rent(data.Length);
+            Length = data.Length;
+            _disposed = false;
+
+            data.AsSpan().CopyTo(Array);
+        }
+        public PooledBuffer(ImmutableArray<byte> data)
+        {
+            Array = ByteArrayPool.Rent(data.Length);
+            Length = data.Length;
+            _disposed = false;
+            data.AsSpan().CopyTo(Array);
+        }
+        public PooledBuffer(Span<byte> data)
+        {
+            Array = ByteArrayPool.Rent(data.Length);
+            Length = data.Length;
+            _disposed = false;
+            data.CopyTo(Array);
+        }
+        public PooledBuffer(IntPtr data, int size, int startIndex = 0) : this(size)
+        {
+            if (data != IntPtr.Zero && size > 0)
+            {
+                Marshal.Copy(data, Array, startIndex, size);
+            }
+        }
+        /// <summary>
+        /// Creates a deep copy of this buffer in a new PooledBuffer instance.
+        /// </summary>
+        public PooledBuffer Clone()
+        {
+            var clone = new PooledBuffer(Length);
+
+            AsSpan().CopyTo(clone.AsSpan());
+
+            return clone;
+        }
+        public Span<byte> AsSpan() => Array.AsSpan(0, Length);
+        public Span<byte> AsSpan(int start) => Array.AsSpan(start, Length - start);
+        public Span<byte> AsSpan(int start, int count)
+        {
+            if (start < 0 || count < 0 || (start + count) > Length)
+            {
+                throw new ArgumentOutOfRangeException("The specified start or length is out of bounds for this buffer.");
+            }
+            return Array.AsSpan(start, count);
+        }
+        public Span<byte> AsSpanRange(int start, int end)
+        {
+            int count = end - start;
+            return AsSpan(start, count);
+        }
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this); // Tell GC we already cleaned up, no need to run finalizer
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (Array != null)
+                {
+                    ByteArrayPool.Return(Array);
+                    Array = null;
+                }
+                _disposed = true;
+            }
+        }
+
+        // The Finalizer (Destructor)
+        ~PooledBuffer()
+        {
+            Dispose(false);
+        }
+        public void Resize(int newSize){
+            if (newSize <= Array.Length)
+            {
+                // If the new size fits in the existing buffer, 
+                // we just update our internal length tracker as ArrayPool uses multiples of 2.
+                Length = newSize;
+                return;
+            }
+
+        
+            byte[] newArray = ByteArrayPool.Rent(newSize);
+            Array.AsSpan(0, Length).CopyTo(newArray);
+
+            ByteArrayPool.Return(Array);
+
+            Array = newArray;
+            Length = newSize;
+        }
+        public byte this[int index]
+        {
+            get => Array[index];
+            set => Array[index] = value;
+        }
+
+        public static implicit operator byte[](PooledBuffer buffer) => buffer.Array;
+    }
+}

--- a/Barotrauma/BarotraumaShared/SharedSource/Utils/MemPool.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Utils/MemPool.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Buffers;
+using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Runtime.InteropServices;
 
@@ -151,7 +153,7 @@ namespace Barotrauma
         /// </summary>
         public static TResult RentImmediate<TResult>(int size, Func<byte[], TResult> func) => ArrayPoolBase<byte>.RentImmediate(size, func);
     }
-    public class PooledBuffer : IDisposable
+    public class PooledBuffer : IDisposable, IEnumerable<byte>
     {
         public byte[] Array { get; private set; }
         public int Length { get; private set; }
@@ -236,8 +238,16 @@ namespace Barotrauma
                 _disposed = true;
             }
         }
+        public IEnumerator<byte> GetEnumerator()
+        {
+            // Use the Span to iterate only over the valid 'Length' of the buffer
+            for (int i = 0; i < Array.Length; i++)
+            {
+                yield return Array[i];
+            }
+        }
 
-        // The Finalizer (Destructor)
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         ~PooledBuffer()
         {
             Dispose(false);

--- a/Barotrauma/BarotraumaShared/SharedSource/Utils/MemPool.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Utils/MemPool.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Buffers;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace Barotrauma
 {
@@ -13,9 +15,29 @@ namespace Barotrauma
     /// </summary>
     public static class ArrayPoolBase<T>
     {
+        
         // Using the shared pool which is thread-safe and optimized for general use.
         private static readonly ArrayPool<T> Pool = ArrayPool<T>.Shared;
 
+        private static readonly BlockingCollection<T[]> BufferClearQueue = new();
+
+        private static readonly Thread BufferClearThread = new Thread(() =>
+        {
+            foreach (T[] buffer in BufferClearQueue.GetConsumingEnumerable())
+            {
+                Array.Clear(buffer, 0, buffer.Length);
+                Pool.Return(buffer);
+            }
+        })
+        {
+            IsBackground = true,
+            Name = $"ArrayPoolClearThread<{typeof(T).Name}>"
+        };
+
+        static ArrayPoolBase()
+        {
+            BufferClearThread.Start();
+        }
         /// <summary>
         /// Rents a buffer of at least the specified size. 
         /// Note: The buffer is not guaranteed to be empty.
@@ -26,24 +48,18 @@ namespace Barotrauma
         }
 
         /// <summary>
-        /// Rents a buffer and ensures it is cleared before use.
-        /// Useful if the logic depends on default-initialized values.
-        /// </summary>
-        public static T[] RentZeroed(int size)
-        {
-            T[] buffer = Pool.Rent(size);
-            Array.Clear(buffer, 0, size);
-            return buffer;
-        }
-
-        /// <summary>
         /// Returns the buffer to the pool for future reuse.
         /// Clears the array to prevent memory leaks (sensitive data) 
         /// and avoid accidental cross-contamination.
         /// </summary>
         public static void Return(T[] buffer)
         {
-            Pool.Return(buffer, clearArray: true);
+            if (buffer == null)
+            {
+                return;
+            }
+
+            BufferClearQueue.Add(buffer);
         }
 
         /// <summary>
@@ -93,11 +109,7 @@ namespace Barotrauma
         /// Note: The buffer is not guaranteed to be empty.
         /// </summary>
         public static float[] Rent(int size) => ArrayPoolBase<float>.Rent(size);
-        /// <summary>
-        /// Rents a buffer and ensures it is cleared before use.
-        /// Useful if the logic depends on default-initialized values.
-        /// </summary>
-        public static float[] RentZeroed(int size) => ArrayPoolBase<float>.RentZeroed(size);
+       
         /// <summary>
         /// Returns the buffer to the pool for future reuse.
         /// Clears the array to prevent memory leaks (sensitive data) 
@@ -129,11 +141,7 @@ namespace Barotrauma
         /// Note: The buffer is not guaranteed to be empty.
         /// </summary>
         public static byte[] Rent(int size) => ArrayPoolBase<byte>.Rent(size);
-        /// <summary>
-        /// Rents a buffer and ensures it is cleared before use.
-        /// Useful if the logic depends on default-initialized values.
-        /// </summary>
-        public static byte[] RentZeroed(int size) => ArrayPoolBase<byte>.RentZeroed(size);
+
         /// <summary>
         /// Returns the buffer to the pool for future reuse.
         /// Clears the array to prevent memory leaks (sensitive data) 

--- a/Barotrauma/BarotraumaShared/SharedSource/Utils/SegmentTable.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Utils/SegmentTable.cs
@@ -210,7 +210,7 @@ readonly ref struct SegmentTableReader<T> where T : struct
 
         public float ReadRangedSingle(float min, float max, int bitCount) => Check(underlyingMsg.ReadRangedSingle(min, max, bitCount));
 
-        public byte[] ReadBytes(int numberOfBytes) => Check(underlyingMsg.ReadBytes(numberOfBytes));
+        public PooledBuffer ReadBytes(int numberOfBytes) => Check(underlyingMsg.ReadBytes(numberOfBytes));
 
         public int BitPosition
         {

--- a/Barotrauma/BarotraumaShared/SharedSource/Utils/SegmentTable.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Utils/SegmentTable.cs
@@ -220,7 +220,7 @@ readonly ref struct SegmentTableReader<T> where T : struct
 
         public int BytePosition => BitPosition / 8;
 
-        public byte[] Buffer => underlyingMsg.Buffer;
+        public PooledBuffer Buffer => underlyingMsg.Buffer;
 
         public int LengthBits
         {


### PR DESCRIPTION
# ArrayPool:
https://learn.microsoft.com/en-us/dotnet/api/system.buffers.arraypool-1?view=net-8.0
by using array pool we can reduce the load on the .NET GC by using ArrayPool wich reuses the buffer instead of Reallocation.
this prevents lag spikes from occuring due to GC overload.

and it is fully thread safe

To faccilitate Easier Use a wrapper class was made called PooledBuffer.