### PR TITLE
Allow controlling bots in multiplayer

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Barotrauma",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "${workspaceFolder}/Barotrauma/bin/DebugWindows/net8.0/Barotrauma.exe",
+            "cwd": "${workspaceFolder}/Barotrauma/bin/DebugWindows/net8.0",
+            "preLaunchTask": "Build Windows Debug",
+            "console": "integratedTerminal",
+            "stopAtEntry": false
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,159 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build Windows Debug",
+            "dependsOn": [
+                "Build Windows Server Debug",
+                "Build Windows Client Debug"
+            ],
+            "dependsOrder": "sequence",
+            "group": {
+                "kind": "build"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Build Windows Release",
+            "dependsOn": [
+                "Build Windows Server Release",
+                "Build Windows Client Release"
+            ],
+            "dependsOrder": "sequence",
+            "group": {
+                "kind": "build"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Rebuild Windows Debug",
+            "dependsOn": [
+                "Clean Windows Server Debug",
+                "Clean Windows Client Debug",
+                "Build Windows Debug"
+            ],
+            "dependsOrder": "sequence",
+            "group": {
+                "kind": "build"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Rebuild Windows Release",
+            "dependsOn": [
+                "Clean Windows Server Release",
+                "Clean Windows Client Release",
+                "Build Windows Release"
+            ],
+            "dependsOrder": "sequence",
+            "group": {
+                "kind": "build"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Clean Windows Server Debug",
+            "type": "process",
+            "command": "dotnet",
+            "args": [
+                "clean",
+                "${workspaceFolder}/Barotrauma/BarotraumaServer/WindowsServer.csproj",
+                "--configuration",
+                "Debug",
+                "--property:Platform=x64"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Clean Windows Client Debug",
+            "type": "process",
+            "command": "dotnet",
+            "args": [
+                "clean",
+                "${workspaceFolder}/Barotrauma/BarotraumaClient/WindowsClient.csproj",
+                "--configuration",
+                "Debug",
+                "--property:Platform=x64"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Clean Windows Server Release",
+            "type": "process",
+            "command": "dotnet",
+            "args": [
+                "clean",
+                "${workspaceFolder}/Barotrauma/BarotraumaServer/WindowsServer.csproj",
+                "--configuration",
+                "Release",
+                "--property:Platform=x64"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Clean Windows Client Release",
+            "type": "process",
+            "command": "dotnet",
+            "args": [
+                "clean",
+                "${workspaceFolder}/Barotrauma/BarotraumaClient/WindowsClient.csproj",
+                "--configuration",
+                "Release",
+                "--property:Platform=x64"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Build Windows Server Debug",
+            "type": "process",
+            "command": "dotnet",
+            "args": [
+                "build",
+                "${workspaceFolder}/Barotrauma/BarotraumaServer/WindowsServer.csproj",
+                "--configuration",
+                "Debug",
+                "--property:Platform=x64"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Build Windows Client Debug",
+            "type": "process",
+            "command": "dotnet",
+            "args": [
+                "build",
+                "${workspaceFolder}/Barotrauma/BarotraumaClient/WindowsClient.csproj",
+                "--configuration",
+                "Debug",
+                "--property:Platform=x64"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Build Windows Server Release",
+            "type": "process",
+            "command": "dotnet",
+            "args": [
+                "build",
+                "${workspaceFolder}/Barotrauma/BarotraumaServer/WindowsServer.csproj",
+                "--configuration",
+                "Release",
+                "--property:Platform=x64"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Build Windows Client Release",
+            "type": "process",
+            "command": "dotnet",
+            "args": [
+                "build",
+                "${workspaceFolder}/Barotrauma/BarotraumaClient/WindowsClient.csproj",
+                "--configuration",
+                "Release",
+                "--property:Platform=x64"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/Barotrauma/BarotraumaClient/ClientSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Characters/Character.cs
@@ -584,19 +584,26 @@ namespace Barotrauma
         {
             HintManager.OnCharacterKilled(this);
 
-            if (GameMain.NetworkMember != null && controlled == this)
+            if (GameMain.NetworkMember != null && (controlled == this || GameMain.Client?.Character == this))
             {
-                LocalizedString chatMessage = CauseOfDeath.Type == CauseOfDeathType.Affliction ?
-                    CauseOfDeath.Affliction.SelfCauseOfDeathDescription :
-                    TextManager.Get("Self_CauseOfDeathDescription." + CauseOfDeath.Type.ToString(), "Self_CauseOfDeathDescription.Damage");
+                bool showDeathPrompt = !GameMain.IsMultiplayer || GameMain.Client?.IsControllingBot != true;
+                if (showDeathPrompt)
+                {
+                    LocalizedString chatMessage = CauseOfDeath.Type == CauseOfDeathType.Affliction ?
+                        CauseOfDeath.Affliction.SelfCauseOfDeathDescription :
+                        TextManager.Get("Self_CauseOfDeathDescription." + CauseOfDeath.Type.ToString(), "Self_CauseOfDeathDescription.Damage");
 
-                if (GameMain.Client != null) { chatMessage += " " + TextManager.Get("DeathChatNotification"); }
+                    if (GameMain.Client != null) { chatMessage += " " + TextManager.Get("DeathChatNotification"); }
 
-                RespawnManager.ShowDeathPromptIfNeeded();
+                    RespawnManager.ShowDeathPromptIfNeeded();
 
-                GameMain.NetworkMember.AddChatMessage(chatMessage.Value, ChatMessageType.Dead);
+                    GameMain.NetworkMember.AddChatMessage(chatMessage.Value, ChatMessageType.Dead);
+                }
                 GameMain.LightManager.LosEnabled = false;
-                controlled = null;
+                if (!GameMain.IsMultiplayer || GameMain.Client?.IsControllingBot != true)
+                {
+                    controlled = null;
+                }
                 if (Screen.Selected?.Cam is Camera cam)
                 {
                     cam.TargetPos = Vector2.Zero;

--- a/Barotrauma/BarotraumaClient/ClientSource/Characters/CharacterNetworking.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Characters/CharacterNetworking.cs
@@ -383,6 +383,17 @@ namespace Barotrauma
                         IsRemotePlayer = false;
                         GameMain.Client.HasSpawned = true;
                         GameMain.Client.Character = this;
+                        if (IsDead)
+                        {
+                            // If the player was controlling a bot, stop controlling it upon death.
+                            GameMain.Client.IsControllingBot = false;
+                            RespawnManager.ShowDeathPromptIfNeeded();
+                            if (Screen.Selected?.Cam is Camera camera)
+                            {
+                                camera.Position = DrawPosition;
+                                camera.TargetPos = DrawPosition;
+                            }
+                        }
                         GameMain.LightManager.LosEnabled = true;
 #if DEBUG
                         GameMain.LightManager.LosEnabled = !GameMain.DevMode;

--- a/Barotrauma/BarotraumaClient/ClientSource/GameSession/CrewManager.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GameSession/CrewManager.cs
@@ -1872,14 +1872,16 @@ namespace Barotrauma
         {
             if (crewList == null) { return; }
 
+            bool allowOwnerIcons = GameMain.Client?.ServerSettings.AllowControllingBots == true;
+
             foreach (GUIComponent characterComponent in crewList.Content.Children)
             {
                 if (characterComponent.UserData is not Character character) { continue; }
                 GUIImage ownerIcon = characterComponent.FindChild(c => Equals(c.UserData, "ownericon"), recursive: true) as GUIImage;
                 if (ownerIcon == null) { continue; }
 
-                string ownerName = GameMain.Client?.Character == character ||
-                    GameMain.Client?.Character?.Info == character.Info
+                string ownerName = !allowOwnerIcons ? null :
+                    GameMain.Client?.Character == character || GameMain.Client?.Character?.Info == character.Info
                     ? GameMain.Client.Name
                     : GameMain.NetworkMember?.ConnectedClients?.FirstOrDefault(c => c.Character == character || c.Character?.Info == character.Info)?.Name;
                 ownerIcon.Visible = ownerName != null;

--- a/Barotrauma/BarotraumaClient/ClientSource/GameSession/CrewManager.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GameSession/CrewManager.cs
@@ -478,6 +478,21 @@ namespace Barotrauma
                 UserData = "extraicons"
             };
 
+            // Extra icons (owner, sound)
+            new GUIImage(
+                new RectTransform(new Vector2(0.5f), extraIconFrame.RectTransform, Anchor.CenterRight, scaleBasis: ScaleBasis.Smallest),
+                style: "OwnerIcon")
+            {
+                CanBeFocused = true,
+                UserData = "ownericon",
+                Visible = false,
+                Color = Color.White * 0.6f,
+                HoverColor = Color.White,
+                SelectedColor = Color.White,
+                PressedColor = Color.White,
+                DisabledColor = Color.White
+            };
+
             var soundIconParent = new GUIFrame(new RectTransform(new Vector2(0.8f), extraIconFrame.RectTransform, Anchor.CenterLeft, scaleBasis: ScaleBasis.Smallest), style: null)
             {
                 CanBeFocused = false,
@@ -596,6 +611,16 @@ namespace Barotrauma
 
             if (GameMain.IsMultiplayer)
             {
+                // Allow controlling bots if permitted by the server settings
+                if (character == Character.Controlled) { return true; }
+                if (GameMain.Client?.ServerSettings.AllowControllingBots == true &&
+                    GameMain.GameSession?.DeathPrompt == null &&
+                    !character.IsDead)
+                {
+                    GameMain.Client.IsControllingBot = character.IsBot;
+                    GameMain.Client.SendCharacterControlRequest(character);
+                    return true;
+                }
                 if (Character.Controlled == null)
                 {
                     Camera cam = Screen.Selected.Cam;
@@ -1486,6 +1511,15 @@ namespace Barotrauma
 
         partial void UpdateProjectSpecific(float deltaTime)
         {
+            // If controlling a bot is allowed by the server settings, update the control icons accordingly.
+            UpdateCharacterControlIcons();
+
+            // Deselect the crew list if the death prompt is active.
+            if (GameMain.GameSession?.DeathPrompt != null)
+            {
+                crewList.Deselect();
+            }
+
             // Quick selection
             if (GameMain.IsSingleplayer && GUI.KeyboardDispatcher.Subscriber == null)
             {
@@ -1831,6 +1865,27 @@ namespace Barotrauma
                     foundMatch = orderInfo.MatchesOrder(orderIdentifier, orderOption);
                     glowComponent.Visible = foundMatch;
                 }
+            }
+        }
+
+        private void UpdateCharacterControlIcons()
+        {
+            if (crewList == null) { return; }
+
+            foreach (GUIComponent characterComponent in crewList.Content.Children)
+            {
+                if (characterComponent.UserData is not Character character) { continue; }
+                GUIImage ownerIcon = characterComponent.FindChild(c => Equals(c.UserData, "ownericon"), recursive: true) as GUIImage;
+                if (ownerIcon == null) { continue; }
+
+                string ownerName = GameMain.Client?.Character == character ||
+                    GameMain.Client?.Character?.Info == character.Info
+                    ? GameMain.Client.Name
+                    : GameMain.NetworkMember?.ConnectedClients?.FirstOrDefault(c => c.Character == character || c.Character?.Info == character.Info)?.Name;
+                ownerIcon.Visible = ownerName != null;
+                ownerIcon.ToolTip = ownerName != null
+                    ? TextManager.GetWithVariable("CrewCharacterControlledBy", "[name]", ownerName).Fallback($"Controlled by {ownerName}")
+                    : string.Empty;
             }
         }
 

--- a/Barotrauma/BarotraumaClient/ClientSource/GameSession/GameSession.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/GameSession/GameSession.cs
@@ -287,6 +287,14 @@ namespace Barotrauma
         {
             if (topLeftButtonGroup == null) { return; }
 
+            // If the player is controlling a bot, hide the death choice elements.
+            if (GameMain.Client?.IsControllingBot == true && Character.Controlled != null)
+            {
+                deathChoiceInfoFrame.Visible = false;
+                deathChoiceButtonContainer.Visible = false;
+                return;
+            }
+
             bool permadeathMode = GameMain.NetworkMember?.ServerSettings is { RespawnMode: RespawnMode.Permadeath };
             bool ironmanMode = GameMain.NetworkMember?.ServerSettings is { IronmanModeActive: true };
 

--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/GameClient.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/GameClient.cs
@@ -547,7 +547,12 @@ namespace Barotrauma.Networking
 
             if (GameStarted && Screen.Selected == GameMain.GameScreen)
             {
-                EndVoteTickBox.Visible = ServerSettings.AllowEndVoting && HasSpawned;
+                // Update the visibility of the end vote tick box based on server settings and player state.
+                EndVoteTickBox.Visible = ServerSettings.AllowEndVoting && HasSpawned && !IsControllingBot;
+                if (!EndVoteTickBox.Visible)
+                {
+                    EndVoteTickBox.Selected = false;
+                }
 
                 RespawnManager?.Update(deltaTime);
 
@@ -2633,6 +2638,16 @@ namespace Barotrauma.Networking
             msg.WriteUInt16(bot.ID);
             ClientPeer?.Send(msg, DeliveryMethod.Reliable);
         }
+
+        public void SendCharacterControlRequest(Character character)
+        {
+            if (character == null) { return; }
+
+            IWriteMessage msg = new WriteOnlyMessage();
+            msg.WriteByte((byte)ClientPacketHeader.REQUEST_CHARACTER_CONTROL);
+            msg.WriteUInt16(character.ID);
+            ClientPeer?.Send(msg, DeliveryMethod.Reliable);
+        }
         
         public void ToggleReserveBench(CharacterInfo bot, bool pendingHire = false)
         {
@@ -3323,6 +3338,8 @@ namespace Barotrauma.Networking
             set { myCharacter = value; }
         }
 
+        public bool IsControllingBot { get; set; }
+
         protected GUIFrame inGameHUD;
         protected ChatBox chatBox;
 
@@ -3346,7 +3363,7 @@ namespace Barotrauma.Networking
                 else
                 {
                     var campaign = GameMain.GameSession?.Campaign;
-                    ShowLogButton.Visible = hasPermissionToUseLogButton && (campaign == null || !campaign.ShowCampaignUI);
+                    ShowLogButton.Visible = hasPermissionToUseLogButton && !IsControllingBot && (campaign == null || !campaign.ShowCampaignUI);
                 }
             }
         }

--- a/Barotrauma/BarotraumaClient/ClientSource/Networking/RespawnManager.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Networking/RespawnManager.cs
@@ -92,7 +92,7 @@ namespace Barotrauma.Networking
                 }
                 teamSpecificState.CurrentState = newState;
 
-                if (respawnPromptPending && !clientHasChosenNewBotViaShuttle)
+                if (respawnPromptPending && !clientHasChosenNewBotViaShuttle && GameMain.Client?.IsControllingBot != true)
                 {
                     GameMain.Client.HasSpawned = true;
                     DeathPrompt.Create(delay: 1.0f);

--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/NetLobbyScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/NetLobbyScreen.cs
@@ -1072,7 +1072,6 @@ namespace Barotrauma
                 }
             };
             AssignComponentToServerSetting(allowControllingBotsTickbox, nameof(ServerSettings.AllowControllingBots));
-            permadeathDisabledRespawnSettings.Add(allowControllingBotsTickbox);
             clientDisabledElements.Add(allowControllingBotsTickbox);
             botSettingsElements.Add(allowControllingBotsTickbox);
 
@@ -1270,7 +1269,7 @@ namespace Barotrauma
                 respawnModeSelection.AddElement(respawnMode, TextManager.Get($"respawnmode.{respawnMode}"), TextManager.Get($"respawnmode.{respawnMode}.tooltip"));
             }
             
-            respawnModeSelection.ElementSelectionCondition += (value) => value != RespawnMode.Permadeath || (SelectedMode == GameModePreset.MultiPlayerCampaign && GameMain.Client?.ServerSettings.AllowControllingBots != true);
+            respawnModeSelection.ElementSelectionCondition += (value) => value != RespawnMode.Permadeath || SelectedMode == GameModePreset.MultiPlayerCampaign;
             respawnModeSelection.OnValueChanged += (_) => GameMain.Client?.ServerSettings.ClientAdminWrite(ServerSettings.NetFlags.Properties);
             AssignComponentToServerSetting(respawnModeSelection, nameof(ServerSettings.RespawnMode));
 

--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/NetLobbyScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/NetLobbyScreen.cs
@@ -101,6 +101,7 @@ namespace Barotrauma
         private GUISelectionCarousel<RespawnMode> respawnModeSelection;
         private GUITextBlock respawnModeLabel;
         private GUIComponent respawnIntervalElement;
+        private GUITickBox allowControllingBotsTickbox;
         
         private readonly List<GUIComponent> midRoundRespawnSettings = new List<GUIComponent>();
         private readonly List<GUIComponent> permadeathEnabledRespawnSettings = new List<GUIComponent>();
@@ -1060,6 +1061,21 @@ namespace Barotrauma
             clientDisabledElements.AddRange(botSpawnModeSettingHolder.GetAllChildren());
             botSettingsElements.Add(botSpawnModeSelection);
 
+            allowControllingBotsTickbox = new GUITickBox(new RectTransform(Vector2.One, gameModeSettingsContent.RectTransform), TextManager.Get("AllowControllingBots").Fallback("Allow controlling bots"))
+            {
+                ToolTip = TextManager.Get("AllowControllingBots.Tooltip").Fallback("Allow players to switch control to available bot crew members during a multiplayer campaign."),
+                Selected = GameMain.Client != null && GameMain.Client.ServerSettings.AllowControllingBots,
+                OnSelected = (GUITickBox box) =>
+                {
+                    GameMain.Client?.ServerSettings.ClientAdminWrite(ServerSettings.NetFlags.Properties);
+                    return true;
+                }
+            };
+            AssignComponentToServerSetting(allowControllingBotsTickbox, nameof(ServerSettings.AllowControllingBots));
+            permadeathDisabledRespawnSettings.Add(allowControllingBotsTickbox);
+            clientDisabledElements.Add(allowControllingBotsTickbox);
+            botSettingsElements.Add(allowControllingBotsTickbox);
+
             botCountSelection.OnValueChanged += (_) =>
             {
                 botSpawnModeSelection.Enabled = GameMain.Client.ServerSettings.BotCount > 0;
@@ -1254,7 +1270,7 @@ namespace Barotrauma
                 respawnModeSelection.AddElement(respawnMode, TextManager.Get($"respawnmode.{respawnMode}"), TextManager.Get($"respawnmode.{respawnMode}.tooltip"));
             }
             
-            respawnModeSelection.ElementSelectionCondition += (value) => value != RespawnMode.Permadeath || SelectedMode == GameModePreset.MultiPlayerCampaign;
+            respawnModeSelection.ElementSelectionCondition += (value) => value != RespawnMode.Permadeath || (SelectedMode == GameModePreset.MultiPlayerCampaign && GameMain.Client?.ServerSettings.AllowControllingBots != true);
             respawnModeSelection.OnValueChanged += (_) => GameMain.Client?.ServerSettings.ClientAdminWrite(ServerSettings.NetFlags.Properties);
             AssignComponentToServerSetting(respawnModeSelection, nameof(ServerSettings.RespawnMode));
 
@@ -2424,6 +2440,8 @@ namespace Barotrauma
             }
 
             RefreshStartButtonVisibility();
+
+            allowControllingBotsTickbox.Visible = SelectedMode == GameModePreset.MultiPlayerCampaign;
 
             botSettingsElements.ForEach(b => b.Enabled = !campaignStarted && manageSettings);
 

--- a/Barotrauma/BarotraumaClient/ClientSource/Screens/NetLobbyScreen.cs
+++ b/Barotrauma/BarotraumaClient/ClientSource/Screens/NetLobbyScreen.cs
@@ -1063,7 +1063,7 @@ namespace Barotrauma
 
             allowControllingBotsTickbox = new GUITickBox(new RectTransform(Vector2.One, gameModeSettingsContent.RectTransform), TextManager.Get("AllowControllingBots").Fallback("Allow controlling bots"))
             {
-                ToolTip = TextManager.Get("AllowControllingBots.Tooltip").Fallback("Allow players to switch control to available bot crew members during a multiplayer campaign."),
+                ToolTip = TextManager.Get("AllowControllingBots.Tooltip").Fallback("Allow players to switch control to available bot crew members."),
                 Selected = GameMain.Client != null && GameMain.Client.ServerSettings.AllowControllingBots,
                 OnSelected = (GUITickBox box) =>
                 {
@@ -2441,7 +2441,7 @@ namespace Barotrauma
 
             RefreshStartButtonVisibility();
 
-            allowControllingBotsTickbox.Visible = SelectedMode == GameModePreset.MultiPlayerCampaign;
+            allowControllingBotsTickbox.Visible = SelectedMode != GameModePreset.PvP;
 
             botSettingsElements.ForEach(b => b.Enabled = !campaignStarted && manageSettings);
 

--- a/Barotrauma/BarotraumaServer/ServerSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Characters/Character.cs
@@ -49,6 +49,21 @@ namespace Barotrauma
                 }
             }
 
+            // Ensure the owner client is correctly associated with this character in the multiplayer campaign.
+            if (GameMain.Server is { } server &&
+                GameMain.GameSession?.Campaign is MultiPlayerCampaign)
+            {
+                var ownerClient = server.ConnectedClients.FirstOrDefault(c => c.Character == this);
+                if (ownerClient == null)
+                {
+                    ownerClient = server.ConnectedClients.FirstOrDefault(c => c.Character != this && server.GetMainCharacter(c) == this);
+                    if (ownerClient != null)
+                    {
+                        server.SetClientCharacter(ownerClient, this);
+                    }
+                }
+            }
+
             if (HasAbilityFlag(AbilityFlags.RetainExperienceForNewCharacter))
             {
                 var ownerClient = GameMain.Server.ConnectedClients.Find(c => c.Character == this);

--- a/Barotrauma/BarotraumaServer/ServerSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Characters/Character.cs
@@ -32,7 +32,8 @@ namespace Barotrauma
                 GameMain.GameSession?.Campaign is MultiPlayerCampaign mpCampaign &&
                 causeOfDeath != CauseOfDeathType.Disconnected)
             {
-                Client ownerClient = GameMain.Server.ConnectedClients.FirstOrDefault(c => c.Character == this);
+                //the dying character may be the client's real/main character even if they're currently controlling a borrowed bot
+                Client ownerClient = GameMain.Server.ConnectedClients.FirstOrDefault(c => c.Character == this || GameMain.Server.GetMainCharacter(c) == this);
                 if (ownerClient != null)
                 {
                     ownerClient.SpectateOnly = true;

--- a/Barotrauma/BarotraumaServer/ServerSource/GameSession/GameModes/MultiPlayerCampaign.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/GameSession/GameModes/MultiPlayerCampaign.cs
@@ -261,17 +261,43 @@ namespace Barotrauma
                 {
                     c.Character = null;
                 }
-                //use the info of the character the client is currently controlling
-                // or the previously saved info if not (e.g. if the client has been spectating or died)
+
+                // Save the main character separately when the client is controlling a bot
+                var mainCharacter = GameMain.Server.GetMainCharacter(c);
+                Character activeCharacter = c.Character;
+                CharacterInfo activeCharacterInfo = c.CharacterInfo;
+                if (mainCharacter != null)
+                {
+                    c.Character = mainCharacter;
+                    c.CharacterInfo = mainCharacter.Info;
+                }
+
+                // Use the main character's info, or the previously saved info if not (e.g. if the client has been spectating or died)
                 var characterInfo = c.Character?.Info;
                 var matchingCharacterData = characterData.Find(d => d.MatchesClient(c));
                 if (matchingCharacterData != null)
                 {
                     //hasn't spawned this round -> don't touch the data
-                    if (!matchingCharacterData.HasSpawned) { continue; }
+                    if (!matchingCharacterData.HasSpawned)
+                    {
+                        if (mainCharacter != null)
+                        {
+                            c.Character = activeCharacter;
+                            c.CharacterInfo = activeCharacterInfo;
+                        }
+                        continue;
+                    }
                     characterInfo ??= matchingCharacterData.CharacterInfo;
                 }
-                if (characterInfo == null || characterInfo.Discarded) { continue; }
+                if (characterInfo == null || characterInfo.Discarded)
+                {
+                    if (mainCharacter != null)
+                    {
+                        c.Character = activeCharacter;
+                        c.CharacterInfo = activeCharacterInfo;
+                    }
+                    continue;
+                }
                 //reduce skills if the character has died
                 bool diedToDisconnect = characterInfo.CauseOfDeath is { Type: CauseOfDeathType.Disconnected };
                 bool diedForReal = characterInfo.CauseOfDeath != null && !diedToDisconnect;
@@ -296,6 +322,12 @@ namespace Barotrauma
                 if (c.Character != null || diedForReal)
                 {
                     SetClientCharacterData(c);
+                }
+
+                if (mainCharacter != null)
+                {
+                    c.Character = activeCharacter;
+                    c.CharacterInfo = activeCharacterInfo;
                 }
             }
 
@@ -345,7 +377,7 @@ namespace Barotrauma
                     Map.CurrentLocation.RegisterTakenItems(c.Inventory.AllItems.Where(it => it.SpawnedInCurrentOutpost && it.OriginalModuleIndex > 0));
                 }
 
-                if (c.Info != null && c.IsBot)
+                if (c.Info != null && (c.IsBot || c.AIController is HumanAIController))
                 {
                     if (c.IsDead && c.CauseOfDeath?.Type != CauseOfDeathType.Disconnected) { CrewManager.RemoveCharacterInfo(c.Info); }
                     c.Info.HealthData = new XElement("health");

--- a/Barotrauma/BarotraumaServer/ServerSource/Networking/GameServer.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Networking/GameServer.cs
@@ -1665,7 +1665,7 @@ namespace Barotrauma.Networking
             var validationResult = ValidateCharacterControlRequest(
                 ServerSettings.AllowControllingBots,
                 GameStarted,
-                GameMain.GameSession?.GameMode is MultiPlayerCampaign,
+                GameMain.GameSession?.GameMode is not PvPMode,
                 sender.InGame,
                 sender.SpectateOnly,
                     target is { Removed: false, IsDead: false, IsOnPlayerTeam: true, Info: not null } &&
@@ -1731,7 +1731,7 @@ namespace Barotrauma.Networking
         internal static CharacterControlRequestResult ValidateCharacterControlRequest(
             bool featureEnabled,
             bool gameStarted,
-            bool isMultiplayerCampaign,
+            bool isGameModeAllowed,
             bool senderInGame,
             bool senderIsSpectating,
             bool targetIsValid,
@@ -1739,7 +1739,7 @@ namespace Barotrauma.Networking
         {
             if (!featureEnabled) { return CharacterControlRequestResult.FeatureDisabled; }
             if (!gameStarted) { return CharacterControlRequestResult.RoundNotRunning; }
-            if (!isMultiplayerCampaign) { return CharacterControlRequestResult.InvalidGameMode; }
+            if (!isGameModeAllowed) { return CharacterControlRequestResult.InvalidGameMode; }
             if (!senderInGame) { return CharacterControlRequestResult.SenderNotInGame; }
             if (senderIsSpectating) { return CharacterControlRequestResult.SenderIsSpectating; }
             if (!targetIsValid) { return CharacterControlRequestResult.InvalidTarget; }

--- a/Barotrauma/BarotraumaServer/ServerSource/Networking/GameServer.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Networking/GameServer.cs
@@ -17,6 +17,25 @@ namespace Barotrauma.Networking
 {
     sealed class GameServer : NetworkMember
     {
+        internal enum CharacterControlRequestResult
+        {
+            Accepted,
+            FeatureDisabled,
+            RoundNotRunning,
+            InvalidGameMode,
+            SenderNotInGame,
+            SenderIsSpectating,
+            InvalidTarget,
+            TargetAlreadyControlled
+        }
+
+        private sealed class CrewControlState
+        {
+            public CharacterInfo MainCharacterInfo;
+            public CharacterInfo ControlledCharacterInfo;
+            public int ControlledCharacterIdentifier;
+        }
+
         public override bool IsServer => true;
         public override bool IsClient => false;
 
@@ -35,6 +54,8 @@ namespace Barotrauma.Networking
         public bool SubmarineSwitchLoad = false;
 
         private readonly List<Client> connectedClients = new List<Client>();
+        private readonly Dictionary<Client, CrewControlState> crewControlStates = new Dictionary<Client, CrewControlState>();
+        private MultiPlayerCampaign crewControlCampaign;
 
         /// <summary>
         /// For keeping track of disconnected clients in case they reconnect shortly after.
@@ -1011,6 +1032,9 @@ namespace Barotrauma.Networking
                 case ClientPacketHeader.READY_TO_SPAWN:
                     ReadReadyToSpawnMessage(inc, connectedClient);
                     break;
+                case ClientPacketHeader.REQUEST_CHARACTER_CONTROL:
+                    ReadCharacterControlRequest(inc, connectedClient);
+                    break;
                 case ClientPacketHeader.TAKEOVERBOT:
                     ReadTakeOverBotMessage(inc, connectedClient);
                     break;
@@ -1631,6 +1655,96 @@ namespace Barotrauma.Networking
                     DebugConsole.ThrowError($"Client {sender.Name} failed to take over a bot (taking control of bots is disallowed).");
                 }
             }
+        }
+
+        private void ReadCharacterControlRequest(IReadMessage inc, Client sender)
+        {
+            ushort characterId = inc.ReadUInt16();
+            var target = Character.CharacterList.FirstOrDefault(c => c.ID == characterId);
+            var isReservedForSender = target != null && crewControlStates.TryGetValue(sender, out CrewControlState controlState) && target.Info == controlState.MainCharacterInfo;
+            var validationResult = ValidateCharacterControlRequest(
+                ServerSettings.AllowControllingBots,
+                GameStarted,
+                GameMain.GameSession?.GameMode is MultiPlayerCampaign,
+                sender.InGame,
+                sender.SpectateOnly,
+                    target is { Removed: false, IsDead: false, IsOnPlayerTeam: true, Info: not null } &&
+                    (sender.Character is { IsDead: false } || IsControllingBot(sender)) &&
+                    IsCharacterControlTargetValid(target.IsBot, isReservedForSender),
+                ConnectedClients.Any(c => c != sender && c.Character == target));
+
+            if (validationResult != CharacterControlRequestResult.Accepted)
+            {
+                if (validationResult == CharacterControlRequestResult.TargetAlreadyControlled)
+                {
+                    SendConsoleMessage("That character is already controlled by another player.", sender, Color.Red);
+                }
+                else if (validationResult == CharacterControlRequestResult.InvalidTarget)
+                {
+                    SendConsoleMessage("Could not take control of that character.", sender, Color.Red);
+                }
+                return;
+            }
+
+            if (sender.Character != null && sender.Character != target)
+            {
+                if (!crewControlStates.TryGetValue(sender, out controlState))
+                {
+                    controlState = new CrewControlState { MainCharacterInfo = sender.Character.Info };
+                    crewControlStates.Add(sender, controlState);
+                }
+                controlState.ControlledCharacterInfo = target.Info;
+                controlState.ControlledCharacterIdentifier = target.Info.GetIdentifier();
+            }
+            SetClientCharacter(sender, target);
+        }
+
+        internal static bool IsCharacterControlTargetValid(bool targetIsBot, bool targetIsReservedForSender)
+            => targetIsBot || targetIsReservedForSender;
+
+        internal static bool IsControlledCharacterMatch(bool sameCharacterInfo, int? characterIdentifier, int controlledCharacterIdentifier)
+            => sameCharacterInfo || characterIdentifier == controlledCharacterIdentifier;
+
+        internal static bool IsCrewControlStateActive(CharacterInfo mainCharacterInfo, CharacterInfo controlledCharacterInfo)
+            => mainCharacterInfo != null &&
+               !mainCharacterInfo.Discarded &&
+               !mainCharacterInfo.PermanentlyDead &&
+               controlledCharacterInfo != null &&
+               controlledCharacterInfo != mainCharacterInfo &&
+               !controlledCharacterInfo.Discarded &&
+               !controlledCharacterInfo.PermanentlyDead;
+
+        internal Character GetMainCharacter(Client client)
+        {
+            if (!crewControlStates.TryGetValue(client, out CrewControlState controlState)) { return null; }
+            if (!IsCrewControlStateActive(controlState.MainCharacterInfo, controlState.ControlledCharacterInfo)) { return null; }
+            return Character.CharacterList.FirstOrDefault(c => c.Info == controlState.MainCharacterInfo);
+        }
+
+        internal bool IsControllingBot(Client client)
+        {
+            if (!crewControlStates.TryGetValue(client, out CrewControlState controlState)) { return false; }
+            return IsCrewControlStateActive(controlState.MainCharacterInfo, controlState.ControlledCharacterInfo) &&
+                   client.Character?.Info == controlState.ControlledCharacterInfo;
+        }
+
+        internal static CharacterControlRequestResult ValidateCharacterControlRequest(
+            bool featureEnabled,
+            bool gameStarted,
+            bool isMultiplayerCampaign,
+            bool senderInGame,
+            bool senderIsSpectating,
+            bool targetIsValid,
+            bool targetIsControlled)
+        {
+            if (!featureEnabled) { return CharacterControlRequestResult.FeatureDisabled; }
+            if (!gameStarted) { return CharacterControlRequestResult.RoundNotRunning; }
+            if (!isMultiplayerCampaign) { return CharacterControlRequestResult.InvalidGameMode; }
+            if (!senderInGame) { return CharacterControlRequestResult.SenderNotInGame; }
+            if (senderIsSpectating) { return CharacterControlRequestResult.SenderIsSpectating; }
+            if (!targetIsValid) { return CharacterControlRequestResult.InvalidTarget; }
+            if (targetIsControlled) { return CharacterControlRequestResult.TargetAlreadyControlled; }
+            return CharacterControlRequestResult.Accepted;
         }
 
         private static void SpawnAndTakeOverBot(CampaignMode campaign, CharacterInfo botInfo, Client client)
@@ -2830,6 +2944,12 @@ namespace Barotrauma.Networking
             MultiPlayerCampaign campaign = selectedMode == GameMain.GameSession?.GameMode.Preset ?
                 GameMain.GameSession?.GameMode as MultiPlayerCampaign : null;
 
+            if (campaign != crewControlCampaign)
+            {
+                crewControlStates.Clear();
+                crewControlCampaign = campaign;
+            }
+
             if (campaign != null && campaign.Map == null)
             {
                 initiatedStartGame = false;
@@ -2903,6 +3023,18 @@ namespace Barotrauma.Networking
                 GameMain.GameSession.StartRound(campaign.NextLevel, startOutpost: campaign.GetPredefinedStartOutpost(), mirrorLevel: campaign.MirrorLevel);
                 SubmarineSwitchLoad = false;
                 campaign.AssignClientCharacterInfos(connectedClients);
+                foreach (var (client, controlState) in crewControlStates.ToList())
+                {
+                    if (!IsCrewControlStateActive(controlState.MainCharacterInfo, controlState.ControlledCharacterInfo))
+                    {
+                        crewControlStates.Remove(client);
+                        continue;
+                    }
+                    if (!client.SpectateOnly)
+                    {
+                        client.CharacterInfo = controlState.MainCharacterInfo;
+                    }
+                }
                 Log("Game mode: " + selectedMode.Name.Value, ServerLog.MessageType.ServerMessage);
                 Log("Submarine: " + GameMain.GameSession.SubmarineInfo.Name, ServerLog.MessageType.ServerMessage);
                 Log("Level seed: " + campaign.NextLevel.Seed, ServerLog.MessageType.ServerMessage);
@@ -2951,6 +3083,20 @@ namespace Barotrauma.Networking
             AutoItemPlacer.SpawnItems(campaign?.Settings.StartItemSet);
 
             CrewManager crewManager = GameMain.GameSession.CrewManager;
+
+            foreach (var controlState in crewControlStates.Values.ToList())
+            {
+                CharacterInfo controlledCharacterInfo = controlState.ControlledCharacterInfo;
+                if (!IsCrewControlStateActive(controlState.MainCharacterInfo, controlledCharacterInfo))
+                {
+                    continue;
+                }
+                if (!crewManager.GetCharacterInfos(includeReserveBench: true).Contains(controlledCharacterInfo))
+                {
+                    controlledCharacterInfo.TeamID = CharacterTeamType.Team1;
+                    crewManager.AddCharacterInfo(controlledCharacterInfo);
+                }
+            }
 
             bool hadBots = true;
 
@@ -3063,7 +3209,9 @@ namespace Barotrauma.Networking
                     //give the job items based on that spawnpoint
                     WayPoint jobItemSpawnPoint = mainSubWaypoints != null ? mainSubWaypoints[i] : spawnWaypoints[i];
 
-                    Character spawnedCharacter = Character.Create(teamClients[i].CharacterInfo, spawnWaypoints[i].WorldPosition, teamClients[i].CharacterInfo.Name, isRemotePlayer: true, hasAi: false);
+                    // When bot control is allowed, player characters need an AIController too so they behave like bots whenever no client is controlling them
+                    Character spawnedCharacter = Character.Create(teamClients[i].CharacterInfo, spawnWaypoints[i].WorldPosition, teamClients[i].CharacterInfo.Name, isRemotePlayer: true, hasAi: ServerSettings.AllowControllingBots);
+
                     //spawnedCharacter.AnimController.Frozen = true;
                     spawnedCharacter.TeamID = teamID;
                     teamClients[i].Character = spawnedCharacter;
@@ -3151,6 +3299,23 @@ namespace Barotrauma.Networking
                     //created new bots -> save them
                     SaveUtil.SaveGame(GameMain.GameSession.DataPath);
                 }
+            }
+
+            foreach (var (client, controlState) in crewControlStates.ToList())
+            {
+                if (!IsCrewControlStateActive(controlState.MainCharacterInfo, controlState.ControlledCharacterInfo))
+                {
+                    crewControlStates.Remove(client);
+                    continue;
+                }
+                if (client.SpectateOnly) { continue; }
+                Character character = Character.CharacterList.FirstOrDefault(c =>
+                    !c.IsDead &&
+                    IsControlledCharacterMatch(
+                        c.Info == controlState.ControlledCharacterInfo,
+                        c.Info?.GetIdentifier(),
+                        controlState.ControlledCharacterIdentifier));
+                if (character != null) { SetClientCharacter(client, character); }
             }
 
             campaign?.LoadPets();
@@ -3694,6 +3859,8 @@ namespace Barotrauma.Networking
         public void DisconnectClient(Client client, PeerDisconnectPacket peerDisconnectPacket)
         {
             if (client == null) return;
+
+            crewControlStates.Remove(client);
 
             if (client.Character != null)
             {
@@ -4314,14 +4481,21 @@ namespace Barotrauma.Networking
             //the client's previous character is no longer a remote player
             if (client.Character != null)
             {
-                client.Character.SetOwnerClient(null);
+                Character previousCharacter = client.Character;
+                previousCharacter.SetOwnerClient(null);
+                CreateEntityEvent(previousCharacter, new Character.ControlEventData(null));
+
+                // The objective may be unchanged (e.g. already idle), so force a resync to update the order/objective icon
+                if (previousCharacter.AIController is HumanAIController previousController)
+                {
+                    previousController.ObjectiveManager.SendCurrentObjectiveState();
+                }
             }
 
             if (newCharacter == null)
             {
                 if (client.Character != null) //removing control of the current character
                 {
-                    CreateEntityEvent(client.Character, new Character.ControlEventData(null));
                     client.Character = null;
                 }
             }

--- a/Barotrauma/BarotraumaServer/ServerSource/Networking/RespawnManager.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/Networking/RespawnManager.cs
@@ -20,7 +20,7 @@ namespace Barotrauma.Networking
             {
                 if (!c.InGame) { continue; }
                 if (c.SpectateOnly && (GameMain.Server.ServerSettings.AllowSpectating || GameMain.Server.OwnerConnection == c.Connection)) { continue; }
-                if (c.Character != null && !c.Character.IsDead) { continue; }
+                if (c.Character != null && (!c.Character.IsDead || GameMain.Server.IsControllingBot(c))) { continue; }
                 if (c.TeamID != CharacterTeamType.None && c.TeamID != teamId)
                 {
                     continue;
@@ -62,7 +62,7 @@ namespace Barotrauma.Networking
 
             if (!c.InGame) { return false; }
             if (c.SpectateOnly && (GameMain.Server.ServerSettings.AllowSpectating || GameMain.Server.OwnerConnection == c.Connection)) { return false; }
-            if (c.Character != null && !c.Character.IsDead) { return false; }
+            if (c.Character != null && (!c.Character.IsDead || GameMain.Server.IsControllingBot(c))) { return false; }
 
             CharacterCampaignData matchingData = campaign.GetClientCharacterData(c);
             if (matchingData != null && matchingData.HasSpawned)
@@ -478,7 +478,9 @@ namespace Barotrauma.Networking
                     anyCharacterSpawnedInShuttle = true;                        
                 }
 
-                var character = Character.Create(characterInfo, (forceSpawnInMainSub ? mainSubSpawnPoints[i] : selectedSpawnPoints[i]).WorldPosition, characterInfo.Name, isRemotePlayer: !bot, hasAi: bot);
+                // When bot control is allowed, player characters need an AIController too so they behave like bots whenever no client is controlling them
+                bool needsAi = bot || GameMain.Server.ServerSettings.AllowControllingBots;
+                var character = Character.Create(characterInfo, (forceSpawnInMainSub ? mainSubSpawnPoints[i] : selectedSpawnPoints[i]).WorldPosition, characterInfo.Name, isRemotePlayer: !bot, hasAi: needsAi);
                 characterCampaignData?.ApplyWalletData(character);
                 character.LoadTalents();
                 if (characterInfo.LastRewardDistribution.TryUnwrap(out int salary))

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/Objectives/AIObjectiveManager.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/AI/Objectives/AIObjectiveManager.cs
@@ -255,12 +255,23 @@ namespace Barotrauma
                 CurrentObjective.OnSelected();
                 GetObjective<AIObjectiveIdle>().CalculatePriority(Math.Max(CurrentObjective.Priority - 10, 0));   
             }
+            SendCurrentObjectiveState();
+            return CurrentObjective;
+        }
+
+        /// <summary>
+        /// Lets the clients know what the character's current order/objective is, so they can display the correct icon in the crew UI.
+        /// Normally only sent when the current objective changes, but this can be used to force clients to re-sync
+        /// (e.g. when a bot stops being controlled by a player and resumes its previous, unchanged objective).
+        /// </summary>
+        public void SendCurrentObjectiveState()
+        {
             if (GameMain.NetworkMember is { IsServer: true })
             {
+                bool currentObjectiveIsOrder = CurrentObjective != null && CurrentObjective == CurrentOrder;
                 GameMain.NetworkMember.CreateEntityEvent(character,
                     new Character.ObjectiveManagerStateEventData(currentObjectiveIsOrder ? ObjectiveType.Order : ObjectiveType.Objective));
             }
-            return CurrentObjective;
         }
 
         /// <summary>

--- a/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Characters/Character.cs
@@ -5191,9 +5191,10 @@ namespace Barotrauma
 #if CLIENT
             // Keep permadeath status in sync (to show it correctly in the UI, the server takes care of the actual logic)
             // NOTE: The opposite is done in Revive
+            // Check against the info rather than the currently controlled Character, since the player may be controlling a borrowed bot
             if (GameMain.NetworkMember is { ServerSettings.RespawnMode: RespawnMode.Permadeath } &&
-                GameMain.Client.Character == this &&
-                GameMain.Client.CharacterInfo is CharacterInfo characterInfo)
+                GameMain.Client.CharacterInfo is CharacterInfo characterInfo &&
+                characterInfo == info)
             {
                 characterInfo.PermanentlyDead = true;
             }

--- a/Barotrauma/BarotraumaShared/SharedSource/Networking/NetworkMember.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Networking/NetworkMember.cs
@@ -45,7 +45,8 @@ namespace Barotrauma.Networking
         TAKEOVERBOT,
         TOGGLE_RESERVE_BENCH,
 
-        REQUEST_BACKUP_INDICES // client wants a list of available backups for a save file
+        REQUEST_BACKUP_INDICES, // client wants a list of available backups for a save file
+        REQUEST_CHARACTER_CONTROL // client wants to take control of a character
     }
 
     enum ClientNetSegment

--- a/Barotrauma/BarotraumaShared/SharedSource/Networking/ServerSettings.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Networking/ServerSettings.cs
@@ -516,6 +516,21 @@ namespace Barotrauma.Networking
             get;
             private set;
         }
+
+        private bool allowControllingBots;
+
+        [Serialize(false, IsPropertySaveable.Yes)]
+        public bool AllowControllingBots
+        {
+            get { return allowControllingBots; }
+            private set
+            {
+                if (GameMain.NetworkMember is { GameStarted: true, IsServer: true }) { return; }
+                if (value && (respawnMode == RespawnMode.Permadeath || IronmanMode)) { return; }
+                allowControllingBots = value;
+                ServerDetailsChanged = true;
+            }
+        }
         
         [Serialize(false, IsPropertySaveable.Yes)]
         /// <summary>
@@ -756,6 +771,7 @@ namespace Barotrauma.Networking
                 if (respawnMode == value) { return; }
                 //can't change this when a round is running (but clients can, if the server says so, e.g. when a client joins and needs to know what it's set to despite a round being running)
                 if (GameMain.NetworkMember is { GameStarted: true, IsServer: true }) { return; }
+                if (value == RespawnMode.Permadeath && AllowControllingBots) { return; }
                 respawnMode = value;
                 ServerDetailsChanged = true;
             }

--- a/Barotrauma/BarotraumaShared/SharedSource/Networking/ServerSettings.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Networking/ServerSettings.cs
@@ -526,7 +526,6 @@ namespace Barotrauma.Networking
             private set
             {
                 if (GameMain.NetworkMember is { GameStarted: true, IsServer: true }) { return; }
-                if (value && (respawnMode == RespawnMode.Permadeath || IronmanMode)) { return; }
                 allowControllingBots = value;
                 ServerDetailsChanged = true;
             }
@@ -771,7 +770,6 @@ namespace Barotrauma.Networking
                 if (respawnMode == value) { return; }
                 //can't change this when a round is running (but clients can, if the server says so, e.g. when a client joins and needs to know what it's set to despite a round being running)
                 if (GameMain.NetworkMember is { GameStarted: true, IsServer: true }) { return; }
-                if (value == RespawnMode.Permadeath && AllowControllingBots) { return; }
                 respawnMode = value;
                 ServerDetailsChanged = true;
             }

--- a/Barotrauma/BarotraumaTest/CharacterControlRequestTests.cs
+++ b/Barotrauma/BarotraumaTest/CharacterControlRequestTests.cs
@@ -1,0 +1,107 @@
+extern alias Server;
+
+using FluentAssertions;
+using Xunit;
+using GameServer = Server::Barotrauma.Networking.GameServer;
+
+namespace TestProject;
+
+public class CharacterControlRequestTests
+{
+    [Theory]
+    [InlineData(false, true, true, true, false, true, false, 1)]
+    [InlineData(true, false, true, true, false, true, false, 2)]
+    [InlineData(true, true, false, true, false, true, false, 3)]
+    [InlineData(true, true, true, false, false, true, false, 4)]
+    [InlineData(true, true, true, true, true, true, false, 5)]
+    [InlineData(true, true, true, true, false, false, false, 6)]
+    [InlineData(true, true, true, true, false, true, true, 7)]
+    public void InvalidCharacterControlRequestsAreRejected(
+        bool featureEnabled,
+        bool gameStarted,
+        bool isMultiplayerCampaign,
+        bool senderInGame,
+        bool senderIsSpectating,
+        bool targetIsValid,
+        bool targetIsControlled,
+        int expectedResult)
+    {
+        GameServer.ValidateCharacterControlRequest(
+                featureEnabled,
+                gameStarted,
+                isMultiplayerCampaign,
+                senderInGame,
+                senderIsSpectating,
+                targetIsValid,
+                targetIsControlled)
+            .Should().Be((GameServer.CharacterControlRequestResult)expectedResult);
+    }
+
+    [Fact]
+    public void ValidCharacterControlRequestIsAccepted()
+    {
+        GameServer.ValidateCharacterControlRequest(
+                featureEnabled: true,
+                gameStarted: true,
+                isMultiplayerCampaign: true,
+                senderInGame: true,
+                senderIsSpectating: false,
+                targetIsValid: true,
+                targetIsControlled: false)
+            .Should().Be(GameServer.CharacterControlRequestResult.Accepted);
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void CharacterControlTargetMustBeBotOrReservedForSender(bool targetIsBot, bool targetIsReservedForSender)
+    {
+        GameServer.IsCharacterControlTargetValid(targetIsBot, targetIsReservedForSender).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CharacterControlTargetCannotBeAnotherPlayersFormerCharacter()
+    {
+        GameServer.IsCharacterControlTargetValid(targetIsBot: false, targetIsReservedForSender: false).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(true, null, 12, true)]
+    [InlineData(false, 12, 12, true)]
+    [InlineData(false, 7, 12, false)]
+    [InlineData(false, null, 12, false)]
+    public void ControlledCharacterRestorationUsesIdentityOrStableIdentifier(
+        bool sameCharacterInfo,
+        int? characterIdentifier,
+        int controlledCharacterIdentifier,
+        bool expectedMatch)
+    {
+        GameServer.IsControlledCharacterMatch(sameCharacterInfo, characterIdentifier, controlledCharacterIdentifier)
+            .Should().Be(expectedMatch);
+    }
+
+    [Theory]
+    [InlineData(false, false, false, false)]
+    [InlineData(true, false, false, true)]
+    [InlineData(false, true, false, false)]
+    [InlineData(false, false, true, false)]
+    [InlineData(true, true, false, false)]
+    public void CrewControlStateMustIgnoreDeadOrDiscardedCharacters(
+        bool mainAlive,
+        bool mainDiscarded,
+        bool controlledDead,
+        bool expectedActive)
+    {
+        var main = mainAlive ? new Server::Barotrauma.CharacterInfo(Server::Barotrauma.CharacterPrefab.HumanSpeciesName) : null;
+        if (main != null)
+        {
+            main.Discarded = mainDiscarded;
+            main.PermanentlyDead = !mainAlive;
+        }
+
+        var controlled = new Server::Barotrauma.CharacterInfo(Server::Barotrauma.CharacterPrefab.HumanSpeciesName);
+        controlled.PermanentlyDead = controlledDead;
+
+        GameServer.IsCrewControlStateActive(main, controlled).Should().Be(expectedActive);
+    }
+}

--- a/Barotrauma/BarotraumaTest/CharacterControlRequestTests.cs
+++ b/Barotrauma/BarotraumaTest/CharacterControlRequestTests.cs
@@ -19,7 +19,7 @@ public class CharacterControlRequestTests
     public void InvalidCharacterControlRequestsAreRejected(
         bool featureEnabled,
         bool gameStarted,
-        bool isMultiplayerCampaign,
+        bool isGameModeAllowed,
         bool senderInGame,
         bool senderIsSpectating,
         bool targetIsValid,
@@ -29,7 +29,7 @@ public class CharacterControlRequestTests
         GameServer.ValidateCharacterControlRequest(
                 featureEnabled,
                 gameStarted,
-                isMultiplayerCampaign,
+                isGameModeAllowed,
                 senderInGame,
                 senderIsSpectating,
                 targetIsValid,
@@ -43,7 +43,7 @@ public class CharacterControlRequestTests
         GameServer.ValidateCharacterControlRequest(
                 featureEnabled: true,
                 gameStarted: true,
-                isMultiplayerCampaign: true,
+                isGameModeAllowed: true,
                 senderInGame: true,
                 senderIsSpectating: false,
                 targetIsValid: true,


### PR DESCRIPTION
Adds support for controlling bots in multiplayer campaigns, bringing the feature to parity with single-player.

**Server Configuration:**

- **Optional Feature:** Disabled by default when hosting/starting a server. Must be explicitly enabled in server settings (`AllowControllingBots`).
- Available in Sandbox, Mission, and Campaign game modes (including PermaDeath and Ironman). Not available in PvP.

**Key Features & Behavior:**

- **Bot Control:** Players can take control of bots directly during multiplayer matches if enabled by server settings.
- **Main Character Persistence:** The player's main character remains the sole character tied to respawning.
- **Death Handling:**
  - If the main character dies while controlling a bot, control automatically switches back to the main character to display the death popup.
  - Death popups are suppressed when a controlled bot dies.
- **UI Indicators:** Added an "owner" icon to the crew list to clearly show which bots are actively being controlled and by whom.